### PR TITLE
Merge branch 'LTS-C++17'

### DIFF
--- a/benchmarks/fkBenchmarksCommon.h
+++ b/benchmarks/fkBenchmarksCommon.h
@@ -49,9 +49,9 @@ inline bool compareAndCheck(const fk::Ptr2D<T>& firstResult, const fk::Ptr2D<T>&
         std::cout << "Dimensions do not match: " << firstResult.dims().width << "x" << firstResult.dims().height << " vs " << secondResult.dims().width << "x" << secondResult.dims().height << std::endl;
         return false;
     }
-    for (uint y = 0; y < firstResult.dims().height; ++y) {
-        for (uint x = 0; x < firstResult.dims().width; ++x) {
-            if (!fk::Equal<T>::exec(fk::make_tuple(firstResult.at(fk::Point(x, y)), secondResult.at(fk::Point(x, y))))) {
+    for (int y = 0; y < static_cast<int>(firstResult.dims().height); ++y) {
+        for (int x = 0; x < static_cast<int>(firstResult.dims().width); ++x) {
+            if (!fk::Equal<T>::exec(fk::make_tuple(firstResult.at(fk::Point{ x, y, 0 }), secondResult.at(fk::Point{ x, y, 0 })))) {
                 std::cout << "Mismatch at (" << x << ", " << y << ") " << std::endl;
                 return false;
             }

--- a/benchmarks/fusion/benchmark_horizontal_fusion.h
+++ b/benchmarks/fusion/benchmark_horizontal_fusion.h
@@ -56,9 +56,9 @@ bool benchmark_Horizontal_Fusion(const size_t& NUM_ELEMS_X, const size_t& NUM_EL
 
         std::array<fk::Ptr2D<InputType>, BATCH> crops;
         for (int crop_i = 0; crop_i < BATCH; crop_i++) {
-            crops[crop_i] = d_input.crop(fk::Point(crop_i, crop_i), fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
-                                                                                         static_cast<uint>(cropSize.height), 
-                                                                                         static_cast<uint>(d_input.dims().pitch)});
+            crops[crop_i] = d_input.crop(fk::Point{ crop_i, crop_i, 0 }, fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
+                                                                                                  static_cast<uint>(cropSize.height), 
+                                                                                                  static_cast<uint>(d_input.dims().pitch)});
             d_output_cv[crop_i].Alloc(cropSize);
         }
 
@@ -143,9 +143,9 @@ bool benchmark_Horizontal_Fusion_NO_CPU_OVERHEAD(const size_t& NUM_ELEMS_X, cons
 
         std::array<fk::Ptr2D<InputType>, BATCH> crops;
         for (int crop_i = 0; crop_i < BATCH; crop_i++) {
-            crops[crop_i] = d_input.crop(fk::Point(crop_i, crop_i), fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
-                                                                                         static_cast<uint>(cropSize.height), 
-                                                                                         static_cast<uint>(d_input.dims().pitch)});
+            crops[crop_i] = d_input.crop(fk::Point{ crop_i, crop_i, 0 }, fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
+                                                                                                  static_cast<uint>(cropSize.height), 
+                                                                                                  static_cast<uint>(d_input.dims().pitch)});
             d_output_cv[crop_i].Alloc(cropSize);
         }
 
@@ -235,9 +235,9 @@ bool benchmark_Horizontal_Fusion_NO_CPU_OVERHEAD_CUDAGraphs(const size_t& NUM_EL
 
         std::array<fk::Ptr2D<InputType>, BATCH> crops;
         for (int crop_i = 0; crop_i < BATCH; crop_i++) {
-            crops[crop_i] = d_input.crop(fk::Point(crop_i, crop_i), fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
-                                                                                         static_cast<uint>(cropSize.height), 
-                                                                                         static_cast<uint>(d_input.dims().pitch)});
+            crops[crop_i] = d_input.crop(fk::Point{ crop_i, crop_i, 0 }, fk::PtrDims<fk::ND::_2D>{static_cast<uint>(cropSize.width),
+                                                                                                  static_cast<uint>(cropSize.height), 
+                                                                                                  static_cast<uint>(d_input.dims().pitch)});
             d_output_cv[crop_i].Alloc(cropSize);
         }
 

--- a/include/fused_kernel/algorithms/basic_ops/algebraic.h
+++ b/include/fused_kernel/algorithms/basic_ops/algebraic.h
@@ -38,7 +38,7 @@ namespace fk {
         using Parent = BinaryOperation<float3, M3x3Float, float3, MxVFloat3<BinaryType>>;
         DECLARE_BINARY_PARENT
 
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             const float3 xOut = input * params.x;
             const float3 yOut = input * params.y;
             const float3 zOut = input * params.z;
@@ -54,7 +54,7 @@ namespace fk {
         FK_STATIC_STRUCT(MxVFloat3, SelfType)
         using Parent = UnaryOperation<Tuple<float3, M3x3Float>, float3, MxVFloat3<UnaryType>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             const float3 xOut = get<0>(input) * get<1>(input).x;
             const float3 yOut = get<0>(input) * get<1>(input).y;
             const float3 zOut = get<0>(input) * get<1>(input).z;

--- a/include/fused_kernel/algorithms/basic_ops/arithmetic.h
+++ b/include/fused_kernel/algorithms/basic_ops/arithmetic.h
@@ -30,7 +30,7 @@ namespace fk {
         FK_STATIC_STRUCT(Add, SelfType)
         using Parent = BinaryOperation<I, P, O, Add<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input + params;
         }
     };
@@ -43,7 +43,7 @@ namespace fk {
         FK_STATIC_STRUCT(Add, SelfType)
         using Parent = UnaryOperation<Tuple<I1, I2>, O, Add<I1, I2, O, UnaryType>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return get<0>(input) + get<1>(input);
         }
     };
@@ -56,7 +56,7 @@ namespace fk {
         FK_STATIC_STRUCT(Sub, SelfType)
         using Parent = BinaryOperation<I, P, O, Sub<I, P, O>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input - params;
         }
     };
@@ -69,7 +69,7 @@ namespace fk {
         FK_STATIC_STRUCT(Mul, SelfType)
         using Parent = BinaryOperation<I, P, O, Mul<I, P, O>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input * params;
         }
     };
@@ -82,7 +82,7 @@ namespace fk {
         FK_STATIC_STRUCT(Div, SelfType)
         using Parent = BinaryOperation<I, P, O, Div<I, P, O>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input / params;
         }
     };

--- a/include/fused_kernel/algorithms/basic_ops/cast.h
+++ b/include/fused_kernel/algorithms/basic_ops/cast.h
@@ -27,7 +27,7 @@ namespace fk {
         FK_STATIC_STRUCT(Cast, SelfType)
         using Parent = UnaryOperation<I, O, Cast<I, O>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::cast<OutputType>::f(input);
         }
     };

--- a/include/fused_kernel/algorithms/basic_ops/logical.h
+++ b/include/fused_kernel/algorithms/basic_ops/logical.h
@@ -29,7 +29,7 @@ namespace fk {
         FK_STATIC_STRUCT(IsEven, SelfType)
         using Parent = UnaryOperation<I, bool, IsEven<I>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE auto exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE auto exec(const InputType input) {
             return cxp::is_even::f(input);
         }
     };
@@ -42,7 +42,7 @@ namespace fk {
         FK_STATIC_STRUCT(Max, SelfType)
         using Parent = BinaryOperation<I, P, O, Max<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return cxp::max::f(input, params);
         }
     };
@@ -55,7 +55,7 @@ namespace fk {
         FK_STATIC_STRUCT(Max, SelfType)
         using Parent = UnaryOperation<Tuple<I, P>, O, Max<I, P, O, UnaryType>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::max::f(get<0>(input), get<1>(input));
         }
     };
@@ -68,7 +68,7 @@ namespace fk {
         FK_STATIC_STRUCT(Min, SelfType)
         using Parent = BinaryOperation<I, P, O, Min<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return cxp::min::f(input, params);
         }
     };
@@ -81,7 +81,7 @@ namespace fk {
         FK_STATIC_STRUCT(Min, SelfType)
         using Parent = UnaryOperation<Tuple<I, P>, O, Min<I, P, O, UnaryType>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::min::f(get<0>(input), get<1>(input));
         }
     };
@@ -95,21 +95,21 @@ namespace fk {
         using Parent = UnaryOperation<Tuple<I1, I2>, bool, Equal<I1, I2>>;
         DECLARE_UNARY_PARENT
         template <int N = cn<I1>>
-        FK_HOST_DEVICE_FUSE std::enable_if_t<N==1, OutputType> exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE std::enable_if_t<N==1, OutputType> exec(const InputType input) {
             return get<0>(input) == get<1>(input);
         }
         template <int N = cn<I1>>
-        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 2, OutputType> exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 2, OutputType> exec(const InputType input) {
             const auto result = get<0>(input) == get<1>(input);
             return result.x && result.y;
         }
         template <int N = cn<I1>>
-        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 3, OutputType> exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 3, OutputType> exec(const InputType input) {
             const auto result = get<0>(input) == get<1>(input);
             return result.x && result.y && result.z;
         }
         template <int N = cn<I1>>
-        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 4, OutputType> exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE std::enable_if_t<N == 4, OutputType> exec(const InputType input) {
             const auto result = get<0>(input) == get<1>(input);
             return result.x && result.y && result.z && result.w;
         }

--- a/include/fused_kernel/algorithms/basic_ops/memory_operations.h
+++ b/include/fused_kernel/algorithms/basic_ops/memory_operations.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,15 +20,7 @@
 #include <fused_kernel/core/execution_model/thread_fusion.h>
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/core/data/array.h>
-
-#if !defined(NVRTC_COMPILER)
 #include <vector>
-#else
-namespace std {
-    template <typename T>
-    class vector;
-}
-#endif
 
 namespace fk {
     template <ND D, typename T>
@@ -40,16 +32,16 @@ namespace fk {
         FK_STATIC_STRUCT(PerThreadRead, SelfType)
         DECLARE_READ_PARENT
         template <uint ELEMS_PER_THREAD=1>
-        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType>
-        exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const ParamsType& params) 
+            -> ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> {
             return *PtrAccessor<D>::template cr_point<T, ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType>>(thread, params);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             if constexpr (D == ND::_1D) {
                 return 1;
             } else {
@@ -57,7 +49,7 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             if constexpr (D == ND::_1D || D == ND::_2D) {
                 return 1;
             } else {
@@ -65,12 +57,27 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
+        }
+    };
+
+    struct ReadOp {
+        template <typename PtrType>
+        FK_HOST_FUSE decltype(auto) build(PtrType&& ptr) {
+            constexpr ND D = std::decay_t<PtrType>::nd;
+            using PtrDataType = typename std::decay_t<PtrType>::Type;
+            return PerThreadRead<D, PtrDataType>::build(std::forward<PtrType>(ptr));
+        }
+        template <typename PtrType, size_t N>
+        FK_HOST_FUSE decltype(auto) build(const std::array<PtrType, N>& ptrs) {
+            constexpr ND D = PtrType::nd;
+            using PtrDataType = typename PtrType::Type;
+            return PerThreadRead<D, PtrDataType>::build(ptrs);
         }
     };
 
@@ -83,19 +90,34 @@ namespace fk {
         FK_STATIC_STRUCT(PerThreadWrite, SelfType)
         DECLARE_WRITE_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread,
-                                      const ThreadFusionType<T, ELEMS_PER_THREAD, T>& input,
+        FK_HOST_DEVICE_FUSE void exec(const Point thread,
+                                      const ThreadFusionType<T, ELEMS_PER_THREAD, T> input,
                                       const ParamsType& params) {
             *PtrAccessor<D>::template point<T, ThreadFusionType<T, ELEMS_PER_THREAD, T>>(thread, params) = input;
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
         FK_HOST_FUSE InstantiableType build(const Ptr<D, T>& ptr) {
-            return InstantiableType{ {ptr.ptr()} };
+            return { {ptr.ptr()} };
+        }
+    };
+
+    struct WriteOp {
+        template <typename PtrType>
+        FK_HOST_FUSE decltype(auto) build(PtrType&& ptr) {
+            constexpr ND D = std::decay_t<PtrType>::nd;
+            using PtrDataType = typename std::decay_t<PtrType>::Type;
+            return PerThreadWrite<D, PtrDataType>::build(std::forward<PtrType>(ptr));
+        }
+        template <typename PtrType, size_t N>
+        FK_HOST_FUSE decltype(auto) build(const std::array<PtrType, N>& ptrs) {
+            constexpr ND D = PtrType::nd;
+            using PtrDataType = typename PtrType::Type;
+            return PerThreadWrite<D, PtrDataType>::build(ptrs);
         }
     };
 
@@ -109,27 +131,28 @@ namespace fk {
         DECLARE_READ_PARENT
 
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const ParamsType& params) 
+            -> ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> {
             return *PtrAccessor<ND::_3D>::template cr_point<T, ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType>>(thread, params);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.planes;
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -142,15 +165,15 @@ namespace fk {
         FK_STATIC_STRUCT(TensorWrite, SelfType)
         DECLARE_WRITE_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> input, const ParamsType& params) {
             *PtrAccessor<ND::_3D>::template point<T, ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>>(thread, params) = input;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
     };
@@ -163,7 +186,7 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(TensorSplit, SelfType)
         DECLARE_WRITE_PARENT
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const T& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const InputType input, const ParamsType& params) {
             static_assert(cn<InputType> >= 2,
                           "Wrong type for split tensor write. It must be one of <type>2, <type>3 or <type>4.");
 
@@ -180,10 +203,10 @@ namespace fk {
                 *(work_plane + (planePixels * 3)) = input.w;
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
     };
@@ -196,7 +219,7 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(TensorTSplit, SelfType)
         DECLARE_WRITE_PARENT
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const InputType input, const ParamsType& params) {
             static_assert(cn<InputType> >= 2,
                           "Wrong type for split tensor write. It must be one of <type>2, <type>3 or <type>4.");
 
@@ -209,10 +232,10 @@ namespace fk {
                 *PtrAccessor<ND::T3D>::point(thread, params, 3) = input.w;
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
     };
@@ -225,7 +248,7 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(TensorPack, SelfType)
         DECLARE_READ_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params) {
             static_assert(cn<OutputType> >= 2,
                           "Wrong type for split tensor read. It must be one of <type>2, <type>3 or <type>4.");
 
@@ -245,24 +268,24 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.planes;
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -274,7 +297,7 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(TensorTPack, SelfType)
         DECLARE_READ_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params) {
             static_assert(cn<OutputType> >= 2,
                           "Wrong type for split tensor read. It must be one of <type>2, <type>3 or <type>4.");
 
@@ -293,20 +316,20 @@ namespace fk {
                 return make_<OutputType>(x, y, z, w);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.width;
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.height;
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.planes;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.dims.pitch;
         }
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -342,7 +365,7 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(SplitWrite, SelfType)
         DECLARE_WRITE_PARENT
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const InputType input, const ParamsType& params) {
             static_assert(cn<InputType> >= 2,
                           "Wrong type for split write. It must be one of <type>2, <type>3 or <type>4.");
             *PtrAccessor<D>::point(thread, params.x) = input.x;
@@ -350,30 +373,30 @@ namespace fk {
             if constexpr (cn<InputType> >= 3) *PtrAccessor<D>::point(thread, params.z) = input.z;
             if constexpr (cn<InputType> == 4) *PtrAccessor<D>::point(thread, params.w) = input.w;
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.x.dims.width;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return opData.params.x.dims.pitch;
         }
 
-        FK_HOST_FUSE auto build(const std::vector<Ptr2D<VBase<T>>>& output) {
+        FK_HOST_FUSE InstantiableType build(const std::vector<Ptr2D<VBase<T>>>& output) {
             static_assert(cn<T> >= 2, "Split operations can only be used with types of 2, 3 or 4 channels.");
             if constexpr (cn<T> == 2) {
-                return InstantiableType{ {{output.at(0).ptr(), output.at(1).ptr()}} };
+                return { {{output.at(0).ptr(), output.at(1).ptr()}} };
             } else if constexpr (cn<T> == 3) {
-                return InstantiableType{ {{output.at(0).ptr(), output.at(1).ptr(), output.at(2).ptr()}} };
+                return { {{output.at(0).ptr(), output.at(1).ptr(), output.at(2).ptr()}} };
             } else {
-                return InstantiableType{ {{output.at(0).ptr(), output.at(1).ptr(), output.at(2).ptr(), output.at(3).ptr()}} };
+                return { {{output.at(0).ptr(), output.at(1).ptr(), output.at(2).ptr(), output.at(3).ptr()}} };
             }
         }
     };
 
     /* The following code has the following copy right
 
-       Copyright 2024-2025 Oscar Amoros Huguet
-       Copyright 2023 Mediaproduccion S.L.U. (Oscar Amoros Huget)
-       Copyright 2023 Mediaproduccion S.L.U. (Guillermo Oyarzun Altamirano)
+       Copyright 2024-2026 Oscar Amoros Huguet
+       Copyright 2023 Grup Mediapro S.L.U. (Oscar Amoros Huguet)
+       Copyright 2023 Grup Mediapro S.L.U. (Guillermo Oyarzun Altamirano)
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -397,7 +420,7 @@ namespace fk {
 
     namespace circular_batch_internal {
         template <CircularDirection direction, int BATCH>
-        FK_HOST_DEVICE_CNST Point computeCircularThreadIdx(const Point& currentIdx, const int& fst) {
+        FK_HOST_DEVICE_CNST Point computeCircularThreadIdx(const Point currentIdx, const int fst) {
             if constexpr (direction == CircularDirection::Ascendent) {
                 const int z = currentIdx.z + fst;
                 return { currentIdx.x, currentIdx.y, z >= BATCH ? z - BATCH : z };
@@ -421,7 +444,7 @@ namespace fk {
         FK_STATIC_STRUCT(CircularBatchRead, SelfType)
         DECLARE_READ_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> exec(const Point thread, const ParamsType& params) {
             const Point newThreadIdx = circular_batch_internal::computeCircularThreadIdx<direction, BATCH>(thread, params.first);
             if constexpr (THREAD_FUSION) {
                 return Operation::template exec<ELEMS_PER_THREAD>(newThreadIdx, params.opData[newThreadIdx.z]);
@@ -429,24 +452,24 @@ namespace fk {
                 return Operation::exec(newThreadIdx, params.opData[newThreadIdx.z]);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData[thread.z]);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData[thread.z]);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData[thread.z]);
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -463,7 +486,7 @@ namespace fk {
         FK_STATIC_STRUCT(CircularBatchWrite, SelfType)
         DECLARE_WRITE_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> input, const ParamsType& params) {
             const Point newThreadIdx = circular_batch_internal::computeCircularThreadIdx<direction, BATCH>(thread, params.first);
             if constexpr (THREAD_FUSION) {
                 Operation::template exec<ELEMS_PER_THREAD>(newThreadIdx, input, params.opData[newThreadIdx.z]);
@@ -471,10 +494,10 @@ namespace fk {
                 Operation::exec(newThreadIdx, input, params.opData[newThreadIdx.z]);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opBatch) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opBatch) {
             return Operation::num_elems_x(thread, opBatch.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opBatch) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opBatch) {
             return Operation::pitch(thread, opBatch.params.opData[thread.z]);
         }
     };
@@ -492,7 +515,7 @@ namespace fk {
         FK_STATIC_STRUCT(CircularTensorRead, SelfType)
         DECLARE_READ_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE const ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType> exec(const Point thread, const ParamsType& params) {
             const Point newThreadIdx = circular_batch_internal::computeCircularThreadIdx<direction, BATCH>(thread, params.first);
             if constexpr (THREAD_FUSION) {
                 return Operation::template exec<ELEMS_PER_THREAD>(newThreadIdx, params.opData);
@@ -500,24 +523,24 @@ namespace fk {
                 return Operation::exec(newThreadIdx, params.opData);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
 
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData);
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -534,8 +557,8 @@ namespace fk {
         FK_STATIC_STRUCT(CircularTensorWrite, SelfType)
         DECLARE_WRITE_PARENT
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread,
-                                      const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>& input,
+        FK_HOST_DEVICE_FUSE void exec(const Point thread,
+                                      const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> input,
                                       const ParamsType& params) {
             const Point newThreadIdx = circular_batch_internal::computeCircularThreadIdx<direction, BATCH>(thread, params.first);
             if constexpr (THREAD_FUSION) {
@@ -544,10 +567,10 @@ namespace fk {
                 Operation::exec(newThreadIdx, input, params.opData);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData);
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData);
         }
     };

--- a/include/fused_kernel/algorithms/basic_ops/set.h
+++ b/include/fused_kernel/algorithms/basic_ops/set.h
@@ -1,4 +1,4 @@
-/* Copyright 2024-2025 Oscar Amoros Huguet
+/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,24 +34,24 @@ namespace fk {
         FK_STATIC_STRUCT(ReadSet, SelfType)
         using Parent = ReadOperation<T, ReadSetParams<T>, T, TF::DISABLED, ReadSet<T>>;
         DECLARE_READ_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params) {
             return params.value;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.size.x;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.size.y;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return opData.params.size.z;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
 
         FK_HOST_FUSE auto build(const T& value, const ActiveThreads& activeThreads) {

--- a/include/fused_kernel/algorithms/basic_ops/static_loop.h
+++ b/include/fused_kernel/algorithms/basic_ops/static_loop.h
@@ -29,7 +29,7 @@ namespace fk {
 
         private:
         template <int ITERATION>
-        FK_DEVICE_FUSE OutputType helper_exec(const InputType& input, const ParamsType& params) {
+        FK_DEVICE_FUSE OutputType helper_exec(const InputType input, const ParamsType& params) {
             if constexpr (ITERATION + 1 < ITERATIONS) {
                 return helper_exec<ITERATION + 1>(Operation::exec(input, params), params);
             } else {
@@ -38,7 +38,7 @@ namespace fk {
         }
 
         public:
-        FK_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return helper_exec<0>(Operation::exec(input, params), params);
         }
     };

--- a/include/fused_kernel/algorithms/basic_ops/vector_ops.h
+++ b/include/fused_kernel/algorithms/basic_ops/vector_ops.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ namespace fk {
         FK_STATIC_STRUCT(Discard, SelfType)
         using Parent = UnaryOperation<I, O, Discard<I, O>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(cn<I> > cn<O>, "Output type should at least have one channel less");
             static_assert(std::is_same_v<VBase<I>, VBase<O>>,
                 "Base types should be the same");
@@ -48,10 +48,10 @@ namespace fk {
         FK_STATIC_STRUCT(VectorReorder, SelfType)
         using Parent = UnaryOperation<T, T, VectorReorder<T, Idx...>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(validCUDAVec<T>, "Non valid CUDA vetor type: UnaryVectorReorder");
             static_assert(cn<T> >= 2, "Minimum number of channels is 2: UnaryVectorReorder");
-            return {static_get<Idx>::f(input)...};
+            return {static_get<Idx>(input)...};
         }
     };
 
@@ -61,9 +61,9 @@ namespace fk {
         using SelfType = VectorReorderRT<T>;
     public:
         FK_STATIC_STRUCT(VectorReorderRT, SelfType)
-        using Parent = BinaryOperation<T, VectorType_t<int, cn<T>>, T, VectorReorderRT<T>>;
+        using Parent = BinaryOperation<T, int_<cn<T>>, T, VectorReorderRT<T>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             static_assert(validCUDAVec<T>, "Non valid CUDA vetor type");
             static_assert(cn<T> >= 2, "Minimum number of channels is 2");
             if constexpr (cn<T> == 2) {
@@ -86,7 +86,7 @@ namespace fk {
         FK_STATIC_STRUCT(VectorReduce, SelfType)
         using Parent = UnaryOperation<T, typename Operation::OutputType, VectorReduce<T, Operation>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) { 
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) { 
             return cxp::vector_reduce<Operation>::f(input);
         }
     };
@@ -99,7 +99,7 @@ namespace fk {
         FK_STATIC_STRUCT(AddLast, SelfType)
         using Parent = BinaryOperation<I, typename VectorTraits<I>::base, O, AddLast<I, O>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             static_assert(cn<I> == cn<O> -1, "Output type should have one channel more");
             static_assert(std::is_same_v<typename VectorTraits<I>::base, typename VectorTraits<O>::base>,
                 "Base types should be the same");
@@ -125,7 +125,7 @@ namespace fk {
         FK_STATIC_STRUCT(VectorAnd, SelfType)
         using Parent = UnaryOperation<T, bool, VectorAnd<T>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::vector_and::f(input);
         }
     };

--- a/include/fused_kernel/algorithms/image_processing/border_reader.h
+++ b/include/fused_kernel/algorithms/image_processing/border_reader.h
@@ -56,15 +56,15 @@ namespace fk {
         using Parent = IncompleteReadBackOperation<NullType, NullType, NullType, NullType, SelfType>;
         DECLARE_INCOMPLETEREADBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
@@ -93,15 +93,15 @@ namespace fk {
         using Parent = IncompleteReadBackOperation<NullType, BorderReaderParameters<BorderType::CONSTANT, T>, NullType, NullType, SelfType>;
         DECLARE_INCOMPLETEREADBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
@@ -127,20 +127,20 @@ namespace fk {
         using Parent = IncompleteReadBackOperation<NullType, BorderReaderParameters<BT>, NullType, NullType, SelfType>;
         DECLARE_INCOMPLETEREADBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_FUSE auto build() {
-            return BorderReader<BT>{};
+            return InstantiableType{};
         }
 
         template <typename BIOp>
@@ -165,21 +165,21 @@ public: \
     using Parent = ReadBackOperation<typename BackIOp_::Operation::OutputType, BorderReaderParameters<BT>, \
         BackIOp_, typename BackIOp_::Operation::OutputType, SelfType>; \
     DECLARE_READBACK_PARENT \
-FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) { \
+FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) { \
     return BackIOp::Operation::num_elems_x(thread, opData.backIOp); \
 } \
-FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) { \
+FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) { \
     return BackIOp::Operation::num_elems_y(thread, opData.backIOp); \
 } \
-FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) { \
+FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) { \
     return BackIOp::Operation::num_elems_z(thread, opData.backIOp); \
 }
 
 #define BORDER_READER_EXEC \
-FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) { \
+FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) { \
     const int last_col = BackIOp::Operation::num_elems_x(thread, backIOp) - 1; \
     const int last_row = BackIOp::Operation::num_elems_y(thread, backIOp) - 1; \
-    const Point new_thread(idx_col(thread.x, last_col), idx_row(thread.y, last_row), thread.z); \
+    const Point new_thread{idx_col(thread.x, last_col), idx_row(thread.y, last_row), thread.z}; \
     return BackIOp::Operation::exec(new_thread, backIOp); \
 }
 
@@ -197,17 +197,17 @@ FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& param
                         BackIOp_, ReadAndOutputType, SelfType>;
         DECLARE_READBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_x(thread, opData.backIOp);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_y(thread, opData.backIOp);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_z(thread, opData.backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             const int width = BackIOp::Operation::num_elems_x(thread, backIOp);
             const int height = BackIOp::Operation::num_elems_y(thread, backIOp);
             if (thread.x >= 0 && thread.x < width && thread.y >= 0 && thread.y < height) {
@@ -274,10 +274,10 @@ FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& param
     struct BorderReader<BorderType::WRAP, BorderReaderParameters<BorderType::WRAP>, BackIOp_,
                         std::enable_if_t<isAnyCompleteReadType<BackIOp_>, void>> {
         BORDER_READER_DETAILS(BorderType::WRAP)
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             const int width = BackIOp::Operation::num_elems_x(thread, backIOp);
             const int height = BackIOp::Operation::num_elems_y(thread, backIOp);
-            const Point new_thread(idx_col(thread.x, width), idx_row(thread.y, height), thread.z);
+            const Point new_thread{idx_col(thread.x, width), idx_row(thread.y, height), thread.z};
             return BackIOp::Operation::exec(new_thread, backIOp);
         }
     private:

--- a/include/fused_kernel/algorithms/image_processing/color_conversion.h
+++ b/include/fused_kernel/algorithms/image_processing/color_conversion.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace fk {
         FK_STATIC_STRUCT(StaticAddAlpha, SelfType)
         using Parent = UnaryOperation<I, VOneMore<I>, StaticAddAlpha<I, alpha>>;
         DECLARE_UNARY_PARENT
-        FK_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_DEVICE_FUSE OutputType exec(const InputType input) {
             return AddLast<InputType, OutputType>::exec(input, { alpha });
         }
     };
@@ -52,7 +52,7 @@ namespace fk {
         FK_STATIC_STRUCT(RGB2Gray, SelfType)
         using Parent = UnaryOperation<I, O, RGB2Gray<I, O, GrayFormula::CCIR_601>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             // 0.299*R + 0.587*G + 0.114*B
             if constexpr (std::is_unsigned_v<OutputType>) {
 #ifdef __CUDA_ARCH__
@@ -71,7 +71,7 @@ namespace fk {
             }
         }
     private:
-        FK_HOST_DEVICE_FUSE float compute_luminance(const InputType& input) {
+        FK_HOST_DEVICE_FUSE float compute_luminance(const InputType input) {
             return (input.x * 0.299f) + (input.y * 0.587f) + (input.z * 0.114f);
         }
     };
@@ -82,7 +82,7 @@ namespace fk {
     using PackedPixelType = VectorType_t<ColorDepthPixelBaseType<static_cast<ColorDepth>(PixelFormatTraits<PF>::depth)>, PixelFormatTraits<PF>::cn>;
 
     template <PixelFormat PF, bool ALPHA>
-    using YUVOutputPixelType = VectorType_t<ColorDepthPixelBaseType<static_cast<ColorDepth>(PixelFormatTraits<PF>::depth)>, ALPHA ? 4 : PixelFormatTraits<PF>::cn>;
+    using YUVOutputPixelType = VectorType_t<ColorDepthPixelBaseType<PixelFormatTraits<PF>::depth>, ALPHA ? 4 : PixelFormatTraits<PF>::cn>;
 
     struct SubCoefficients {
         const float luma;
@@ -110,7 +110,7 @@ namespace fk {
         FK_STATIC_STRUCT(AddOpaqueAlpha, SelfType)
         using Parent = UnaryOperation<I, VOneMore<I>, AddOpaqueAlpha<I, CD>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             constexpr auto alpha = maxDepthValue<CD>;
             return AddLast<InputType, OutputType>::exec(input, { alpha });
         }
@@ -124,7 +124,7 @@ namespace fk {
         FK_STATIC_STRUCT(SaturateDepth, SelfType)
         using Parent = UnaryOperation<T, T, SaturateDepth<T, CD>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return Saturate<float>::exec(input, { { 0.f, static_cast<float>(maxDepthValue<CD>) } });
         }
     };
@@ -190,9 +190,9 @@ namespace fk {
         using SelfType = DenormalizePixel<O, CD>;
     public:
         FK_STATIC_STRUCT(DenormalizePixel, SelfType)
-        using Parent = UnaryOperation<VectorType_t<float, cn<O>>, O, DenormalizePixel<O, CD>>;
+        using Parent = UnaryOperation<float_<cn<O>>, O, DenormalizePixel<O, CD>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             constexpr auto maxDepth = maxDepthValue<CD>;
             return cxp::cast<OutputType>::f(input * maxDepth);
         }
@@ -204,9 +204,9 @@ namespace fk {
         using SelfType = NormalizePixel<I, CD>;
     public:
         FK_STATIC_STRUCT(NormalizePixel, SelfType)
-        using Parent = UnaryOperation<I, VectorType_t<float, cn<I>>, NormalizePixel<I, CD>>;
+        using Parent = UnaryOperation<I, float_<cn<I>>, NormalizePixel<I, CD>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return input / static_cast<float>(maxDepthValue<CD>);
         }
     };
@@ -219,7 +219,7 @@ namespace fk {
         FK_STATIC_STRUCT(SaturateDenormalizePixel, SelfType)
         using Parent = UnaryOperation<I, O, SaturateDenormalizePixel<I, O, CD>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(std::is_same_v<VBase<I>, float>, "SaturateDenormalizePixel only works with float base types.");
             const InputType saturatedFloat = SaturateFloat<InputType>::exec(input);
             return DenormalizePixel<OutputType, CD>::exec(saturatedFloat);
@@ -235,7 +235,7 @@ namespace fk {
         using Parent = UnaryOperation<T, T, NormalizeColorRangeDepth<T, CD>>;
         DECLARE_UNARY_PARENT
         using Base = typename VectorTraits<T>::base;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(std::is_floating_point_v<VBase<T>>, "NormalizeColorRangeDepth only works for floating point values");
             // The nvcc compiler will only be able to use the global constexpr floatShiftFactor<CD> variable if it is stored in 
             // a local variable.
@@ -262,7 +262,7 @@ namespace fk {
         // Y     -> input.x
         // Cb(U) -> input.y
         // Cr(V) -> input.z
-        FK_HOST_DEVICE_FUSE float3 computeRGB(const InputType& pixel) {
+        FK_HOST_DEVICE_FUSE float3 computeRGB(const InputType pixel) {
             constexpr M3x3Float coefficients = ccMatrix<CR, CP, ColorConversionDir::YCbCr2RGB>;
             constexpr float CSub = subCoefficients<CD>.chroma;
             if constexpr (CP == ColorPrimitives::bt601) {
@@ -273,7 +273,7 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE OutputType computePixel(const InputType& pixel) {
+        FK_HOST_DEVICE_FUSE OutputType computePixel(const InputType pixel) {
             const float3 pixelRGBFloat = computeRGB(pixel);
             if constexpr (std::is_same_v<VBase<OutputType>, float>) {
                 if constexpr (ALPHA) {
@@ -293,7 +293,7 @@ namespace fk {
         }
 
         public:
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             // Pixel data shifted to the right to it's color depth numerical range
             constexpr auto shiftFactorLocal = shiftFactor<CD>;
             const InputType shiftedPixel = input >> shiftFactorLocal;
@@ -326,7 +326,7 @@ namespace fk {
                                      TF::DISABLED,
                                      ReadYUV<PF>>;
         DECLARE_READ_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params) {
             const auto rawPtr = params.data;
             if constexpr (PF == PixelFormat::NV12 || PF == PixelFormat::P010 ||
                           PF == PixelFormat::P016 || PF == PixelFormat::P210 ||
@@ -338,12 +338,12 @@ namespace fk {
                 const PtrDims<ND::_2D> dims = rawPtr.dims;
                 using VectorType2 = VectorType_t<PixelBaseType, 2>;
                 const RawPtr<ND::_2D, VectorType2> chromaPlane{
-                    reinterpret_cast<VectorType2*>(reinterpret_cast<uchar*>(rawPtr.data) + dims.pitch * dims.height),
-                    { dims.width >> 1, dims.height >> 1, dims.pitch }
+                    reinterpret_cast<VectorType2*>(reinterpret_cast<uchar*>(rawPtr.data) + (dims.pitch * params.height)),
+                    {dims.width >> 1, params.height >> 1, dims.pitch}
                 };
                 const ColorSpace CS = static_cast<ColorSpace>(PixelFormatTraits<PF>::space);
-                const VectorType2 UV =
-                    *PtrAccessor<ND::_2D>::cr_point({ thread.x >> 1, CS == ColorSpace::YUV420 ? thread.y >> 1 : thread.y, thread.z }, chromaPlane);
+                const Point chromaPoint{thread.x >> 1, CS == ColorSpace::YUV420 ? thread.y >> 1 : thread.y, thread.z};
+                const VectorType2 UV = *PtrAccessor<ND::_2D>::cr_point(chromaPoint, chromaPlane);
 
                 return { Y, UV.x, UV.y };
             } else if constexpr (PF == PixelFormat::NV21) {
@@ -353,10 +353,12 @@ namespace fk {
                 // Packed chroma
                 const PtrDims<ND::_2D> dims = rawPtr.dims;
                 const RawPtr<ND::_2D, uchar2> chromaPlane{
-                    reinterpret_cast<uchar2*>(reinterpret_cast<uchar*>(rawPtr.data) + dims.pitch * dims.height),
-                                              { dims.width >> 1, dims.height >> 1, dims.pitch }
+                    reinterpret_cast<uchar2*>(reinterpret_cast<uchar*>(rawPtr.data) + (dims.pitch * params.height)),
+                                              { dims.width >> 1, params.height >> 1, dims.pitch }
                 };
-                const uchar2 VU = *PtrAccessor<ND::_2D>::cr_point({ thread.x >> 1, thread.y >> 1, thread.z }, chromaPlane);
+
+                const Point chromaPoint{thread.x >> 1, thread.y >> 1, thread.z};
+                const uchar2 VU = *PtrAccessor<ND::_2D>::cr_point(chromaPoint, chromaPlane);
 
                 return { Y, VU.y, VU.x };
             } else if constexpr (PF == PixelFormat::Y216 || PF == PixelFormat::Y210 || PF == PixelFormat::UYVY) {
@@ -380,20 +382,20 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
 
         FK_HOST_FUSE InstantiableType build(const Image<PF>& data) {
@@ -414,7 +416,7 @@ namespace fk {
                                       TF::DISABLED,
                                       WriteYUV<PF>>;
         DECLARE_WRITE_PARENT
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread, const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const InputType input, const ParamsType& params) {
             const auto rawPtr = params.data;
             if constexpr (PF == PixelFormat::NV12 || PF == PixelFormat::P010 ||
                           PF == PixelFormat::P016 || PF == PixelFormat::P210 ||
@@ -426,8 +428,8 @@ namespace fk {
                 using VectorType2 = VectorType_t<PixelBaseType, 2>;
                 const PtrDims<ND::_2D> dims = rawPtr.dims;
                 const RawPtr<ND::_2D, VectorType2> chromaPlane{
-                    reinterpret_cast<VectorType2*>(reinterpret_cast<uchar*>(rawPtr.data) + dims.pitch * dims.height),
-                    { dims.width >> 1, dims.height >> 1, dims.pitch }
+                    reinterpret_cast<VectorType2*>(reinterpret_cast<uchar*>(rawPtr.data) + (dims.pitch * params.height)),
+                    { dims.width >> 1, params.height >> 1, dims.pitch }
                 };
                 constexpr ColorSpace CS = PixelFormatTraits<PF>::space;
                 if constexpr (CS == ColorSpace::YUV420) {
@@ -448,16 +450,14 @@ namespace fk {
                 // Packed chroma
                 const PtrDims<ND::_2D> dims = rawPtr.dims;
                 const RawPtr<ND::_2D, uchar2> chromaPlane{
-                    reinterpret_cast<uchar2*>(reinterpret_cast<uchar*>(rawPtr.data) + dims.pitch * dims.height),
-                                              { dims.width >> 1, dims.height >> 1, dims.pitch }
+                    reinterpret_cast<uchar2*>(reinterpret_cast<uchar*>(rawPtr.data) + (dims.pitch * params.height)),
+                    { dims.width >> 1, params.height >> 1, dims.pitch }
                 };
                 *PtrAccessor<ND::_2D>::point({ thread.x >> 1, thread.y >> 1, thread.z }, chromaPlane) = make_<uchar2>(input.z, input.y);
             } else if constexpr (PF == PixelFormat::Y216 || PF == PixelFormat::Y210 || PF == PixelFormat::UYVY) {
                 const PtrDims<ND::_2D> dims = rawPtr.dims;
                 using VectorType2 = VectorType_t<PixelBaseType, 2>;
                 const RawPtr<ND::_2D, VectorType2> imageV2{ reinterpret_cast<VectorType2*>(rawPtr.data), {dims.width >> 1, dims.height, dims.pitch} };
-                //*PtrAccessor<ND::_2D>::point({ (thread.x >> 1) * 2, thread.y, thread.z }, imageV2);
-                //*PtrAccessor<ND::_2D>::point({ (thread.x >> 1) * 4, thread.y, thread.z }, rawPtr);
 
                 const bool isEvenThread = cxp::is_even::f(thread.x);
                 // input = { Y, U, V }
@@ -494,20 +494,20 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
 
         FK_HOST_FUSE InstantiableType build(const Image<PF>& data) {

--- a/include/fused_kernel/algorithms/image_processing/crop.h
+++ b/include/fused_kernel/algorithms/image_processing/crop.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -33,25 +33,25 @@ namespace fk {
                                          typename BackIOp_::Operation::OutputType,
                                          Crop<BackIOp_>>;
         DECLARE_READBACK_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
-            const Point newThread(thread.x + params.x, thread.y + params.y);
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
+            const Point newThread{thread.x + static_cast<int>(params.x), thread.y + static_cast<int>(params.y)};
             return BackIOp::Operation::exec(newThread, backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
 
         FK_HOST_FUSE InstantiableType build(const BackIOp& backIOp, const Rect& rect) {
@@ -68,15 +68,15 @@ namespace fk {
         using Parent = IncompleteReadBackOperation<NullType, Rect, NullType, NullType, Crop<NullType>>;
         DECLARE_INCOMPLETEREADBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 

--- a/include/fused_kernel/algorithms/image_processing/deinterlace.h
+++ b/include/fused_kernel/algorithms/image_processing/deinterlace.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
    Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 #define FK_DEINTERLACE
 
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/data/size.h>
 #include <fused_kernel/core/constexpr_libs/constexpr_cmath.h>
 
@@ -47,11 +47,11 @@ namespace fk {
         using Parent = ReadBackOperation<typename BackIOp_::Operation::OutputType,
                                          DeinterlaceParameters<DType>,
                                          BackIOp_,
-                                         VectorType_t<float, cn<typename BackIOp_::Operation::OutputType>>,
+                                         float_<cn<typename BackIOp_::Operation::OutputType>>,
                                          Deinterlace<DType, BackIOp_>>;
         DECLARE_READBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             if constexpr (DType == DeinterlaceType::BLEND) {
                 return execBlend(thread, params, backIOp);
             } else { // INTER_LINEAR
@@ -59,58 +59,58 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_x(thread, opData.backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_y(thread, opData.backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     private:
-        FK_HOST_DEVICE_FUSE OutputType execBlend(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType execBlend(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             // For blend deinterlacing, we average the current line with adjacent lines
             using ReadOperation = typename BackIOp::Operation;
             
             // Read current pixel
-            const auto current = ReadOperation::exec(Point(thread.x, thread.y, thread.z), backIOp);
+            const auto current = ReadOperation::exec(thread, backIOp);
             
             if (thread.y > 0) {
-                const auto above = ReadOperation::exec(Point(thread.x, thread.y - 1, thread.z), backIOp);
+                const auto above = ReadOperation::exec(Point{thread.x, thread.y - 1, thread.z}, backIOp);
                 return (current + above + 1) * 0.5f;
             } else {
                 return current * 1.f;
             }
         }
 
-        FK_HOST_DEVICE_FUSE OutputType execInterLinearGetPixel(const Point& thread, const BackIOp& backIOp, const bool& interpolate) {
+        FK_HOST_DEVICE_FUSE OutputType execInterLinearGetPixel(const Point thread, const BackIOp& backIOp, const bool& interpolate) {
             using ReadOperation = typename BackIOp::Operation;
             if (interpolate) {
                 // We average the above pixel with the below pixel
-                const auto above = ReadOperation::exec(Point(thread.x, thread.y - 1, thread.z), backIOp);
-                const auto below = ReadOperation::exec(Point(thread.x, thread.y + 1, thread.z), backIOp);
+                const auto above = ReadOperation::exec(Point{thread.x, thread.y - 1, thread.z}, backIOp);
+                const auto below = ReadOperation::exec(Point{thread.x, thread.y + 1, thread.z}, backIOp);
                 return (above + below + 1) * 0.5f;
             } else {
                 return ReadOperation::exec(thread, backIOp) * 1.f;
             }
         }
 
-        FK_HOST_DEVICE_FUSE OutputType execInterLinear(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType execInterLinear(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             using ReadOperation = typename BackIOp::Operation;
             
-            // Assuming BackFunction::Operation::num_elems_y(Point(), backIOp) is an even number
+            // Assuming BackFunction::Operation::num_elems_y(Point{0,0,0}, backIOp) is an even number
             // If useEvenLines is true, we interpolate on odd lines, otherwise we interpolate the even lines
             // useEvenLines = true, we interpolate if thread.y is odd and not the last line
             // useEvenLines = false, we interpolate if thread.y is even and not the first line
             const bool interpolate = params.useEvenLines ?
-                                        !cxp::is_even::f(thread.y) && thread.y != ReadOperation::num_elems_y(Point(), backIOp) - 1
+                                        !cxp::is_even::f(thread.y) && thread.y != ReadOperation::num_elems_y(Point{0,0,0}, backIOp) - 1
                                         : cxp::is_even::f(thread.y) && thread.y != 0;
 
             return execInterLinearGetPixel(thread, backIOp, interpolate);
@@ -129,15 +129,15 @@ namespace fk {
         template <typename BackIOp_>
         using NewInstantiableType = ReadBack<Deinterlace<DType, BackIOp_>>;
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 

--- a/include/fused_kernel/algorithms/image_processing/image.h
+++ b/include/fused_kernel/algorithms/image_processing/image.h
@@ -1,4 +1,5 @@
 /* Copyright 2025 Grup Mediapro S.L.U
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -57,10 +58,10 @@ namespace fk {
             return ptr();
         }
 
-        FK_HOST_CNST Image<PF> crop(const Point& p, const uint& newWidth, const uint& newHeight) {
+        FK_HOST_CNST Image<PF> crop(const Point p, const uint& newWidth, const uint& newHeight) {
             const uint newDataWidth = newWidth * PixelFormatTraits<PF>::rf.width_f;
             const uint newDataHeight = newHeight * PixelFormatTraits<PF>::rf.height_f;
-            const Point dataPoint(p.x * PixelFormatTraits<PF>::rf.width_f, p.y * PixelFormatTraits<PF>::rf.height_f);
+            const Point dataPoint{p.x * PixelFormatTraits<PF>::rf.width_f, p.y * PixelFormatTraits<PF>::rf.height_f, 0};
             PtrDims<ND::_2D> newDataDims{ newDataWidth, newDataHeight, data.dims().pitch };
             return Image<PF>(data.crop(dataPoint, newDataDims), newWidth, newHeight);
         }
@@ -86,7 +87,7 @@ namespace fk {
 #endif // defined(__NVCC__) || defined(__HIP__) || defined(NVRTC_ENABLED)
 #endif // defined(NVRTC_COMPILER)
 
-        FK_HOST_CNST VectorType_t<BaseType, PixelFormatTraits<PF>::cn> readAt(const Point& p) const {
+        FK_HOST_CNST VectorType_t<BaseType, PixelFormatTraits<PF>::cn> readAt(const Point p) const {
             return ReadYUV<PF>::exec(p, ptr());
         }
     };

--- a/include/fused_kernel/algorithms/image_processing/interpolation.h
+++ b/include/fused_kernel/algorithms/image_processing/interpolation.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,23 +51,23 @@ namespace fk {
     public:
         FK_STATIC_STRUCT(InterpolateComplete, SelfType)
         using Parent = TernaryOperation<float2, InterpolationParameters<InterpolationType::INTER_LINEAR>,
-                                        BackIOp_, VectorType_t<float, cn<BackIOpOutputType>>,
+                                        BackIOp_, float_<cn<BackIOpOutputType>>,
                                         SelfType>;
         DECLARE_TERNARY_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_x(thread, opData.backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return BackIOp::Operation::num_elems_y(thread, opData.backIOp);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params, const BackIOp& backIOp) {
             const float src_x = input.x;
             const float src_y = input.y;
 
@@ -81,14 +81,14 @@ namespace fk {
             const int x2 = x1 + 1;
             const int y2 = y1 + 1;
 
-            const Size srcSize = NumElems::size(Point(), backIOp);
+            const Size srcSize = NumElems::size(Point{0,0,0}, backIOp);
             const int x2_read = cxp::min::f(x2, srcSize.width - 1);
             const int y2_read = cxp::min::f(y2, srcSize.height - 1);
 
-            const Slice2x2<Point> readPoints{ Point(x1, y1),
-                                              Point(x2_read, y1),
-                                              Point(x1, y2_read),
-                                              Point(x2_read, y2_read) };
+            const Slice2x2<Point> readPoints{ {x1, y1, 0},
+                                              {x2_read, y1, 0},
+                                              {x1, y2_read, 0},
+                                              {x2_read, y2_read, 0} };
 
             // Read the 4 pixels from backIOp Read or ReadBack Operation
             const auto src_reg0x0 = BackIOp::Operation::exec(readPoints._0x0, backIOp);

--- a/include/fused_kernel/algorithms/image_processing/resize.h
+++ b/include/fused_kernel/algorithms/image_processing/resize.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <fused_kernel/algorithms/image_processing/saturate.h>
 #include <fused_kernel/algorithms/basic_ops/cast.h>
 #include <fused_kernel/core/data/array.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/constexpr_libs/constexpr_cmath.h>
 
 namespace fk {
@@ -27,7 +27,7 @@ namespace fk {
         FK_STATIC_STRUCT(ComputeResizePoint, ComputeResizePoint)
         using Parent = BinaryOperation<Point, float2, float2, ComputeResizePoint>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType thread, const ParamsType& params) {
             // This is what makes the interpolation a resize operation
             const float fx = params.x;
             const float fy = params.y;
@@ -70,12 +70,12 @@ namespace fk {
 
     template <AspectRatio AR, typename BackIOp_>
     struct ResizeComplete {
-        static_assert(isTernaryType<BackIOp_>, "BackIOp must be a ternary type for this specialization");
+        static_assert(opIs<TernaryType, BackIOp_>, "BackIOp must be a ternary type for this specialization");
     private:
         using SelfType = ResizeComplete<AR, BackIOp_>;
     public:
         FK_STATIC_STRUCT(ResizeComplete, SelfType)
-        using DefaultType = VectorType_t<float, cn<typename BackIOp_::Operation::OutputType>>;
+        using DefaultType = float_<cn<typename BackIOp_::Operation::OutputType>>;
         using Parent = ReadBackOperation<typename BackIOp_::Operation::OutputType,
                                          ResizeParams<AR, DefaultType>,
                                          BackIOp_,
@@ -83,47 +83,43 @@ namespace fk {
                                          SelfType>;
         DECLARE_READBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             if constexpr (AR == AspectRatio::IGNORE_AR) {
                 return exec_resize(thread, params, backIOp);
             } else {
                 if (thread.x >= params.x1 && thread.x <= params.x2 &&
                     thread.y >= params.y1 && thread.y <= params.y2) {
-                    const Point roiThread(thread.x - params.x1, thread.y - params.y1, thread.z);
-                    return exec_resize(roiThread, params, backIOp);
+                    // z is 0 because we do not use it going forward, and batch is handled before calling this exec
+                    return exec_resize(Point{thread.x - params.x1, thread.y - params.y1, 0}, params, backIOp);
                 } else {
                     return params.defaultValue;
                 }
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
 
     private:
-        FK_HOST_DEVICE_FUSE OutputType exec_resize(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
-            const float fx = params.src_conv_factors.x;
-            const float fy = params.src_conv_factors.y;
-
-            const float src_x = thread.x * fx;
-            const float src_y = thread.y * fy;
-            const float2 rezisePoint = { src_x, src_y };
-
-            // Assuming BackIOp is a TernaryType
-            return BackIOp::Operation::exec(rezisePoint, backIOp);
+        FK_HOST_DEVICE_FUSE auto exec_resize(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
+            static_assert(opIs<TernaryType, BackIOp>, "BackIOp must be a ternary type for this specialization");
+            
+            const float src_x = thread.x * params.src_conv_factors.x;
+            const float src_y = thread.y * params.src_conv_factors.y;
+            return BackIOp::Operation::exec({ src_x, src_y }, backIOp);
         }
     };
 
@@ -142,20 +138,20 @@ namespace fk {
         template <typename BackIOp_>
         using NewInstantiableType = ResizeComplete<AR, Ternary<InterpolateComplete<IType, BackIOp_>>>;
 
-        FK_HOST_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.width;
         }
-        FK_HOST_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.height;
         }
-        FK_HOST_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         template <typename NewBackIOp>
         FK_HOST_FUSE auto build(const NewBackIOp& backIOp, const InstantiableType& iOp) {
             static_assert(isCompleteOperation<NewBackIOp>, "NewBackIOp must be a complete IOp");
-            using NewDefaultType = VectorType_t<float, cn<typename NewBackIOp::Operation::OutputType>>;
+            using NewDefaultType = float_<cn<typename NewBackIOp::Operation::OutputType>>;
             static_assert(std::is_same_v<NewDefaultType, DefaultType>, "Default value type and Op::OutputType must be the same.");
             return build(backIOp, iOp.params.dstSize, iOp.params.defaultValue);
         }
@@ -169,13 +165,13 @@ namespace fk {
         FK_HOST_FUSE auto build(const NewBackIOp& backIOp, const Size& dstSize,
                                 const VectorType_t<float, cn<typename NewBackIOp::Operation::OutputType>>& backgroundValue) {
             static_assert(isCompleteOperation<NewBackIOp>, "NewBackIOp must be a complete IOp");
-            const Size srcSize = NumElems::size(Point(), backIOp);
+            const Size srcSize = NumElems::size(Point{0,0,0}, backIOp);
             const Size targetSize = compute_target_size(srcSize, dstSize);
 
             const double cfx = static_cast<double>(targetSize.width) / srcSize.width;
             const double cfy = static_cast<double>(targetSize.height) / srcSize.height;
 
-            using NewOutputType = VectorType_t<float, cn<typename NewBackIOp::Operation::OutputType>>;
+            using NewOutputType = float_<cn<typename NewBackIOp::Operation::OutputType>>;
 
             if constexpr (AR == AspectRatio::PRESERVE_AR_LEFT) {
                 const int x1 = 0; // Always 0 to make sure the image is adjusted to the left
@@ -253,13 +249,13 @@ namespace fk {
         template <typename NewBackIOp>
         using NewInstantiableType = ResizeComplete<AspectRatio::IGNORE_AR, Ternary<InterpolateComplete<InterpolationType::INTER_LINEAR, NewBackIOp>>>;
 
-        FK_HOST_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.width;
         }
-        FK_HOST_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.height;
         }
-        FK_HOST_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
@@ -270,7 +266,7 @@ namespace fk {
         template <typename NewBackIOp>
         FK_HOST_FUSE auto build(const NewBackIOp& backIOp, const Size& dstSize) {
             static_assert(isCompleteOperation<NewBackIOp>, "NewBackIOp must be a complete IOp");
-            const Size srcSize = NumElems::size(Point(), backIOp);
+            const Size srcSize = NumElems::size(Point{0,0,0}, backIOp);
             const double cfx = static_cast<double>(dstSize.width) / static_cast<double>(srcSize.width);
             const double cfy = static_cast<double>(dstSize.height) / static_cast<double>(srcSize.height);
             const typename NewInstantiableType<NewBackIOp>::ParamsType resizeParams{

--- a/include/fused_kernel/algorithms/image_processing/saturate.h
+++ b/include/fused_kernel/algorithms/image_processing/saturate.h
@@ -30,7 +30,7 @@ namespace fk {
         FK_STATIC_STRUCT(SaturateCast, SelfType)
         using Parent = UnaryOperation<I, O, SaturateCast<I, O>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::saturate_cast<OutputType>::f(input);
         }
     };
@@ -43,7 +43,7 @@ namespace fk {
         FK_STATIC_STRUCT(Saturate, SelfType)
         using Parent = BinaryOperation<T, VectorType_t<VBase<T>, 2>, T, Saturate<T>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             static_assert(!validCUDAVec<T>, "Saturate only works with non cuda vector types");
             return cxp::max::f(cxp::min::f(input, params.y), params.x);
         }
@@ -57,7 +57,7 @@ namespace fk {
         FK_STATIC_STRUCT(SaturateFloat, SelfType)
         using Parent = UnaryOperation<T, T, SaturateFloat<T>>;
         DECLARE_UNARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(std::is_same_v<VBase<T>, float>, "Saturate float only works with float base types.");
             
             return cxp::max::f(make_set<InputType>(0.f), cxp::min::f(input, make_set<InputType>(1.f)));;

--- a/include/fused_kernel/algorithms/image_processing/warping.h
+++ b/include/fused_kernel/algorithms/image_processing/warping.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
    Copyright 2025 Grup Mediapro S.L.U
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ namespace fk {
         FK_STATIC_STRUCT(WarpingCoords, SelfType)
         using Parent = BinaryOperation<Point, WarpingParameters<WT>, float2, WarpingCoords<WT>>;
         DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType thread, const ParamsType& params) {
             const int x = thread.x;
             const int y = thread.y;
             const auto& transMatRaw = params.transformMatrix.data;
@@ -77,10 +77,10 @@ namespace fk {
         using Parent = ReadBackOperation<typename BackIOp_::Operation::ReadDataType,
                                          WarpingParameters<WT>,
                                          BackIOp_,
-                                         VectorType_t<float, cn<typename BackIOp_::Operation::ReadDataType>>,
+                                         float_<cn<typename BackIOp_::Operation::ReadDataType>>,
                                          Warping<WT, BackIOp_>>;
         DECLARE_READBACK_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params, const BackIOp& backIOp) {
             const float2 coord = WarpingCoords<WT>::exec(thread, params);
             const Size sourceSize(BackIOp::Operation::num_elems_x(thread, backIOp),
                                   BackIOp::Operation::num_elems_y(thread, backIOp));
@@ -91,20 +91,20 @@ namespace fk {
             }
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
         }
     };
 
@@ -121,15 +121,15 @@ namespace fk {
                                                    Warping<WT, NullType>>;
         DECLARE_INCOMPLETEREADBACK_PARENT
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.width;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return opData.params.dstSize.height;
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return 1;
         }
 

--- a/include/fused_kernel/core/constexpr_libs/constexpr_vector.h
+++ b/include/fused_kernel/core/constexpr_libs/constexpr_vector.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #ifndef CXP_CONSTEXPR_VECTOR_H
 #define CXP_CONSTEXPR_VECTOR_H
 
-#include <fused_kernel/core/utils/static_get.h>
+#include <fused_kernel/core/utils/utils.h>
 #include <fused_kernel/core/execution_model/operation_model/operation_types.h>
 
 namespace cxp {
@@ -23,7 +23,7 @@ namespace cxp {
         template <typename T>
         FK_HOST_DEVICE_FUSE bool f(const T& value) {
             if constexpr (fk::validCUDAVec<T>) {
-                using VecBoolType = fk::VectorType_t<bool, fk::cn<T>>;
+                using VecBoolType = fk::bool_<fk::cn<T>>;
                 const auto valBool = cast<VecBoolType>::f(value);
                 if constexpr (fk::cn<T> == 1) {
                     return valBool.x;
@@ -47,7 +47,7 @@ namespace cxp {
                                           const I& input) {
             using BaseType = fk::VBase<I>;
             using OutputType = typename fk::VectorType<BaseType, NewNumChannels>::type_v;
-            return OutputType{fk::static_get<Idx>::f(input)...};
+            return OutputType{fk::static_get<Idx>(input)...};
         }
         template <typename I>
         FK_HOST_DEVICE_FUSE auto f(const I& input)
@@ -65,7 +65,7 @@ namespace cxp {
             static_assert(fk::validCUDAVec<VT>, "Non valid CUDA vetor type: vector_reorder");
             static_assert(fk::cn<VT> >= 2, "Minimum number of channels is 2: vector_reorder");
             static_assert(sizeof...(Idx) == fk::cn<VT>, "Number of indices must match number of channels");
-            return {fk::static_get<Idx>::f(v)...};
+            return {fk::static_get<Idx>(v)...};
         }
     };
 

--- a/include/fused_kernel/core/data/array.h
+++ b/include/fused_kernel/core/data/array.h
@@ -1,4 +1,4 @@
-/* Copyright 2024 Oscar Amoros Huguet
+/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,68 +22,95 @@
 
 namespace fk {
     template <typename T, size_t SIZE>
-    union Array {
+    struct Array {
+        static constexpr size_t size{ SIZE };
+        T values[SIZE];
+        FK_HOST_DEVICE_CNST const T& operator[](const int index) const {
+            return values[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const int index) {
+            return values[index];
+        }
+        FK_HOST_DEVICE_CNST const T& operator[](const size_t index) const {
+            return values[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t index) {
+            return values[index];
+        }
+    };
+
+    template <typename T, size_t SIZE>
+    union ArrayVector {
         enum { size = SIZE };
         T at[SIZE];
-        FK_HOST_DEVICE_CNST Array(const T& initValue) {
+        FK_HOST_DEVICE_CNST ArrayVector(const T& initValue) {
             for (int i = 0; i < static_cast<int>(SIZE); i++) {
                 at[i] = initValue;
             }
         }
         template <typename... Types>
-        FK_HOST_DEVICE_CNST Array(const Types&... values) : at{static_cast<T>(values)...} {
+        FK_HOST_DEVICE_CNST ArrayVector(const Types&... values) : at{static_cast<T>(values)...} {
             static_assert(all_of_v<T, TypeList<Types...>>, "Not all input types are the expected type T");
-            static_assert(sizeof...(Types) == SIZE, "The number of elements passed to the constructor does not correspond with the Array size.");
+            static_assert(sizeof...(Types) == SIZE, "The number of elements passed to the constructor does not correspond with the ArrayVector size.");
         }
         FK_HOST_DEVICE_CNST T operator[](const size_t& index) const {
+            return at[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t& index) {
             return at[index];
         }
     };
 
     template <typename T>
-    union Array<T, 0> {
+    union ArrayVector<T, 0> {
         enum { size = 0 };
-        FK_HOST_DEVICE_CNST Array() {}
+        FK_HOST_DEVICE_CNST ArrayVector() {}
     };
 
     template <typename T>
-    union Array<T, 1> {
-        static_assert(std::is_fundamental_v<T>, "Array<T, 1> can only be used with fundamental types");
+    union ArrayVector<T, 1> {
+        static_assert(std::is_fundamental_v<T>, "ArrayVector<T, 1> can only be used with fundamental types");
         enum { size = 1 };
-        T at[size];
+        T at[1];
         struct {
             T x;
         };
-        FK_HOST_DEVICE_CNST Array(const T& x) : at{ x } {}
-        FK_HOST_DEVICE_CNST Array(const typename VectorType<T, 1>::type_v& other) : x(other.x) {}
+        FK_HOST_DEVICE_CNST ArrayVector(const T& x) : at{ x } {}
+        FK_HOST_DEVICE_CNST ArrayVector(const typename VectorType<T, 1>::type_v& other) : x(other.x) {}
         FK_HOST_DEVICE_CNST T operator[](const size_t& index) const {
+            return at[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t& index) {
             return at[index];
         }
         FK_HOST_DEVICE_CNST T operator()(const int& index) const {
             return x;
         }
-        FK_HOST_DEVICE_CNST Array<T, 1>& operator=(const VectorType_t<T, 1>& other) {
+        FK_HOST_DEVICE_CNST ArrayVector<T, 1>& operator=(const VectorType_t<T, 1>& other) {
             x = other.x;
             return *this;
         }
     };
 
     template <typename T>
-    union Array<T, 2> {
-        static_assert(std::is_fundamental_v<T>, "Array<T, 2> can only be used with fundamental types");
+    union ArrayVector<T, 2> {
+        static_assert(std::is_fundamental_v<T>, "ArrayVector<T, 2> can only be used with fundamental types");
         enum { size = 2 };
-        T at[size];
+        T at[2];
         struct {
             T x, y;
         };
-        FK_HOST_DEVICE_CNST Array(const T& x, const T& y) : at{ x, y } {}
-        FK_HOST_DEVICE_CNST Array(const VectorType_t<T, 2>& other) : x(other.x), y(other.y) {}
-        FK_HOST_DEVICE_CNST Array(const T& initValue) {
+        FK_HOST_DEVICE_CNST ArrayVector(const T& x, const T& y) : at{ x, y } {}
+        FK_HOST_DEVICE_CNST ArrayVector(const VectorType_t<T, 2>& other) : x(other.x), y(other.y) {}
+        FK_HOST_DEVICE_CNST ArrayVector(const T& initValue) {
             for (int i = 0; i < size; i++) {
                 at[i] = initValue;
             }
         }
         FK_HOST_DEVICE_CNST T operator[](const size_t& index) const {
+            return at[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t& index) {
             return at[index];
         }
         // This indexing method, is more costly than the previous one, but
@@ -92,7 +119,7 @@ namespace fk {
         FK_HOST_DEVICE_CNST T operator()(const int& index) const {
             return vector_at::f(index, make_<VectorType_t<T,size>>(x,y));
         }
-        FK_HOST_DEVICE_CNST Array<T, 2>& operator=(const VectorType_t<T, 2>& other) {
+        FK_HOST_DEVICE_CNST ArrayVector<T, 2>& operator=(const VectorType_t<T, 2>& other) {
             x = other.x;
             y = other.y;
             return *this;
@@ -100,21 +127,24 @@ namespace fk {
     };
 
     template <typename T>
-    union Array<T, 3> {
-        static_assert(std::is_fundamental_v<T>, "Array<T, 3> can only be used with fundamental types");
+    union ArrayVector<T, 3> {
+        static_assert(std::is_fundamental_v<T>, "ArrayVector<T, 3> can only be used with fundamental types");
         enum { size = 3 };
-        T at[size];
+        T at[3];
         struct {
             T x, y, z;
         };
-        FK_HOST_DEVICE_CNST Array(const T& x, const T& y, const T& z) : at{ x, y, z } {}
-        FK_HOST_DEVICE_CNST Array(const VectorType_t<T, 3>& other) : x(other.x), y(other.y), z(other.z) {}
-        FK_HOST_DEVICE_CNST Array(const T& initValue) {
+        FK_HOST_DEVICE_CNST ArrayVector(const T& x, const T& y, const T& z) : at{ x, y, z } {}
+        FK_HOST_DEVICE_CNST ArrayVector(const VectorType_t<T, 3>& other) : x(other.x), y(other.y), z(other.z) {}
+        FK_HOST_DEVICE_CNST ArrayVector(const T& initValue) {
             for (int i = 0; i < size; i++) {
                 at[i] = initValue;
             }
         }
         FK_HOST_DEVICE_CNST T operator[](const size_t& index) const {
+            return at[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t& index) {
             return at[index];
         }
         // This indexing method, is more costly than the previous one, but
@@ -123,7 +153,7 @@ namespace fk {
         FK_HOST_DEVICE_CNST T operator()(const int& index) const {
             return vector_at::f(index, make_<VectorType_t<T, size>>(x, y, z));
         }
-        FK_HOST_DEVICE_CNST Array<T, 3>& operator=(const VectorType_t<T, 3>& other) {
+        FK_HOST_DEVICE_CNST ArrayVector<T, 3>& operator=(const VectorType_t<T, 3>& other) {
             x = other.x;
             y = other.y;
             z = other.z;
@@ -132,21 +162,24 @@ namespace fk {
     };
 
     template <typename T>
-    union Array<T, 4> {
-        static_assert(std::is_fundamental_v<T>, "Array<T, 4> can only be used with fundamental types");
+    union ArrayVector<T, 4> {
+        static_assert(std::is_fundamental_v<T>, "ArrayVector<T, 4> can only be used with fundamental types");
         enum { size = 4 };
-        T at[size];
+        T at[4];
         struct {
             T x, y, z, w;
         };
-        FK_HOST_DEVICE_CNST Array(const T& x, const T& y, const T& z, const T& w) : at{ x, y, z, w } {}
-        FK_HOST_DEVICE_CNST Array(const VectorType_t<T, 4>& other) : x(other.x), y(other.y), z(other.z), w(other.w) {}
-        FK_HOST_DEVICE_CNST Array(const T& initValue) {
+        FK_HOST_DEVICE_CNST ArrayVector(const T& x, const T& y, const T& z, const T& w) : at{ x, y, z, w } {}
+        FK_HOST_DEVICE_CNST ArrayVector(const VectorType_t<T, 4>& other) : x(other.x), y(other.y), z(other.z), w(other.w) {}
+        FK_HOST_DEVICE_CNST ArrayVector(const T& initValue) {
             for (int i = 0; i < size; i++) {
                 at[i] = initValue;
             }
         }
         FK_HOST_DEVICE_CNST T operator[](const size_t& index) const {
+            return at[index];
+        }
+        FK_HOST_DEVICE_CNST T& operator[](const size_t& index) {
             return at[index];
         }
         // This indexing method, is more costly than the previous one, but
@@ -155,7 +188,7 @@ namespace fk {
         FK_HOST_DEVICE_CNST T operator()(const int& index) const {
             return vector_at::f(index, make_<VectorType_t<T, size>>(x, y, z, w));
         }
-        FK_HOST_DEVICE_CNST Array<T, 4>& operator=(const VectorType_t<T, 4>& other) {
+        FK_HOST_DEVICE_CNST ArrayVector<T, 4>& operator=(const VectorType_t<T, 4>& other) {
             x = other.x;
             y = other.y;
             z = other.z;
@@ -165,7 +198,7 @@ namespace fk {
     };
 
     template <typename CUDAVector>
-    using ToArray = Array<VBase<CUDAVector>, cn<CUDAVector>>;
+    using ToArray = ArrayVector<VBase<CUDAVector>, cn<CUDAVector>>;
 
     template <typename V>
     FK_HOST_DEVICE_CNST ToArray<V> toArray(const V& vector) {
@@ -173,12 +206,12 @@ namespace fk {
     }
 
     template <typename T, size_t SIZE, size_t... Idx>
-    FK_HOST_DEVICE_CNST VectorType_t<T, SIZE> toVector_helper(const Array<T, SIZE>& array_v, const std::integer_sequence<int, Idx...>&) {
+    FK_HOST_DEVICE_CNST VectorType_t<T, SIZE> toVector_helper(const ArrayVector<T, SIZE>& array_v, const std::integer_sequence<int, Idx...>&) {
         return { array_v.at[Idx]... };
     }
 
     template <typename T, size_t SIZE>
-    FK_HOST_DEVICE_CNST VectorType_t<T, SIZE> toVector(const Array<T, SIZE>& array_v) {
+    FK_HOST_DEVICE_CNST VectorType_t<T, SIZE> toVector(const ArrayVector<T, SIZE>& array_v) {
         static_assert(SIZE <= 4, "No Vector types available with size greater than 4");
         if constexpr (SIZE == 1) {
             return array_v.at[0];
@@ -187,14 +220,13 @@ namespace fk {
         }
     }
 
-    template <typename Value, size_t... Idx>
-    FK_HOST_DEVICE_CNST std::array<Value, sizeof...(Idx)> make_set_std_array_helper(const std::index_sequence<Idx...>&, const Value& value) {
-        return { { (static_cast<void>(Idx), value)... } };
-    }
-
     template <size_t BATCH, typename T>
-    FK_HOST_DEVICE_CNST std::array<T, BATCH> make_set_std_array(const T& value) {
-        return make_set_std_array_helper(std::make_index_sequence<BATCH>(), value);
+    FK_HOST_CNST std::array<T, BATCH> make_set_std_array(const T& value) {
+        std::array<T, BATCH> arr{};
+        for (size_t i = 0; i < BATCH; i++) {
+            arr[i] = value;
+        }
+        return arr;
     }
 
     template <typename ArrayLike>
@@ -237,8 +269,8 @@ namespace fk {
     }
 
     template <size_t N>
-    FK_HOST_DEVICE_CNST Array<size_t, N> makeIndexArray() {
-        return getIndexArray_helper<Array<size_t, N>>(std::make_index_sequence<N>{});
+    FK_HOST_DEVICE_CNST ArrayVector<size_t, N> makeIndexArray() {
+        return getIndexArray_helper<ArrayVector<size_t, N>>(std::make_index_sequence<N>{});
     }
 
     template <typename T, typename ArrayType, size_t... Idx>

--- a/include/fused_kernel/core/data/circular_tensor.h
+++ b/include/fused_kernel/core/data/circular_tensor.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 #include <fused_kernel/core/data/ptr_nd.h>
 #include <fused_kernel/core/execution_model/executors.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 
 namespace fk {
 

--- a/include/fused_kernel/core/data/point.h
+++ b/include/fused_kernel/core/data/point.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,14 +25,12 @@ namespace fk {
     template <typename T>
     struct Point_<T, ND::_1D> {
         T x;
-        FK_HOST_DEVICE_CNST Point_(const T x_ = 0) : x(x_) {}
     };
 
     template <typename T>
     struct Point_<T, ND::_2D> {
         T x;
         T y;
-        FK_HOST_DEVICE_CNST Point_(const T x_ = 0, const T y_ = 0) : x(x_), y(y_) {}
     };
 
     template <typename T>
@@ -40,7 +38,6 @@ namespace fk {
         T x;
         T y;
         T z;
-        FK_HOST_DEVICE_CNST Point_(const T x_ = 0, const T y_ = 0, const T z_ = 0) : x(x_), y(y_), z(z_) {}
     };
 
     using Point = Point_<int, ND::_3D>;

--- a/include/fused_kernel/core/data/ptr_nd.h
+++ b/include/fused_kernel/core/data/ptr_nd.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -133,15 +133,16 @@ namespace fk {
 
     template <enum ND D, typename T>
     class Ptr {
+    public:
         using Type = T;
         using At = PtrAccessor<D>;
-
+        static constexpr ND nd = D;
     protected:
         RefPtr* ref{ nullptr };
-        RawPtr<D, T> ptr_a;
-        RawPtr<D, T> ptr_pinned;
-        MemType type;
-        int deviceID;
+        RawPtr<D, T> ptr_a{};
+        RawPtr<D, T> ptr_pinned{};
+        MemType type{defaultMemType};
+        int deviceID{0};
 
         inline constexpr Ptr(const RawPtr<D, T>& ptr_a_, RefPtr* ref_, const MemType& type_, const int& devID) :
             ref(ref_), ptr_a(ptr_a_), ptr_pinned(ptr_a_), type(type_), deviceID(devID) {
@@ -409,7 +410,7 @@ namespace fk {
 
         inline constexpr operator RawPtr<D, T>() const { return ptr_a; }
 
-        inline constexpr Ptr<D, T> crop(const Point& p, const PtrDims<D>& newDims) {
+        inline constexpr Ptr<D, T> crop(const Point p, const PtrDims<D>& newDims) {
             T* ptr = At::point(p, ptr_a);
             if (ref) {
                 ref->cnt.fetch_add(1);
@@ -480,7 +481,6 @@ namespace fk {
             return *this;
         }
 
-#if !defined(NVRTC_COMPILER)
 #if defined(__NVCC__) || CLANG_HOST_DEVICE
         inline void uploadTo(Ptr<D, T>& other, cudaStream_t stream = 0) {
             constexpr cudaMemcpyKind kind = cudaMemcpyHostToDevice;
@@ -534,9 +534,8 @@ namespace fk {
         inline void upload(Stream& stream) {}
         inline void download(Stream& stream) {}
 #endif // defined(__NVCC__) || defined(__HIP__) || defined(NVRTC_ENABLED)
-#endif // defined(NVRTC_COMPILER)
 
-        inline T at(const Point& p) const {
+        inline T at(const Point p) const {
             if (type != MemType::Device) {
                 return *At::cr_point(p, ptr_pinned);
             } else {
@@ -545,23 +544,23 @@ namespace fk {
             }
         }
 
-        inline T at(const uint& x) const {
-            return at(Point(x, 0, 0));
+        inline T at(const int x) const {
+            return at(Point{x, 0, 0});
         }
 
         template <ND Dims = D>
         inline std::enable_if_t<(Dims == ND::_2D), T>
-        at(const uint& x, const uint& y) const {
-            return at(Point(x, y, 0));
+        at(const int x, const int y) const {
+            return at(Point{x, y, 0});
         }
 
         template <ND Dims = D>
         inline std::enable_if_t<(Dims == ND::_3D), T>
-        at(const uint& x, const uint& y, const uint& z) const {
-            return at(Point(x, y, z));
+        at(const int x, const int y, const int z) const {
+            return at(Point{x, y, z});
         }
 
-        inline T& at(const Point& p) {
+        inline T& at(const Point p) {
             if (type != MemType::Device) {
                 return *At::point(p, ptr_pinned);
             } else {
@@ -570,22 +569,22 @@ namespace fk {
             }
         }
 
-        inline T& at(const uint& x) {
-            T& val = at(Point(x, 0, 0));
+        inline T& at(const int x) {
+            T& val = at(Point{x, 0, 0});
             return val;
         }
 
         template <ND Dims = D>
         inline std::enable_if_t<(Dims == ND::_2D), T&>
-            at(const uint& x, const uint& y) {
-            T& val = at(Point(x, y, 0));
+            at(const int x, const int y) {
+            T& val = at(Point{x, y, 0});
             return val;
         }
 
         template <ND Dims = D>
         inline std::enable_if_t<(Dims == ND::_3D), T&>
-            at(const uint& x, const uint& y, const uint& z) {
-            T& val = at(Point(x, y, z));
+            at(const int x, const int y, const int z) {
+            T& val = at(Point{x, y, z});
             return val;
         }
 
@@ -621,7 +620,7 @@ namespace fk {
         inline constexpr Ptr1D<T>(T* data_, const PtrDims<ND::_1D>& dims_, const MemType& type_ = defaultMemType, const int& deviceID_ = 0) :
             Ptr<ND::_1D, T>(data_, dims_, type_, deviceID_) {}
 
-        inline constexpr Ptr1D<T> crop1D(const Point& p, const PtrDims<ND::_1D>& newDims) { return Ptr<ND::_1D, T>::crop(p, newDims); }
+        inline constexpr Ptr1D<T> crop1D(const Point p, const PtrDims<ND::_1D>& newDims) { return Ptr<ND::_1D, T>::crop(p, newDims); }
     };
 
     template <typename T>
@@ -638,7 +637,7 @@ namespace fk {
         inline Ptr2D<T>(T* data_, const uint& width_, const uint& height_, const uint& pitch_, const MemType& type_ = defaultMemType, const int& deviceID_ = 0) :
             Ptr<ND::_2D, T>(data_, PtrDims<ND::_2D>(width_, height_, pitch_), type_, deviceID_) {}
 
-        inline Ptr2D<T> crop2D(const Point& p, const PtrDims<ND::_2D>& newDims) { return Ptr<ND::_2D, T>::crop(p, newDims); }
+        inline Ptr2D<T> crop2D(const Point p, const PtrDims<ND::_2D>& newDims) { return Ptr<ND::_2D, T>::crop(p, newDims); }
         inline void Alloc(const fk::Size& size, const uint& pitch_ = 0, const MemType& type_ = defaultMemType, const int& deviceID_ = 0) {
             this->freePtr();
             this->allocPtr(PtrDims<ND::_2D>(size.width, size.height, pitch_), type_, deviceID_);
@@ -657,7 +656,7 @@ namespace fk {
         inline constexpr Ptr3D<T>(T* data_, const PtrDims<ND::_3D>& dims_, const MemType& type_ = defaultMemType, const int& deviceID_ = 0) :
             Ptr<ND::_3D, T>(data_, dims_, type_, deviceID_) {}
 
-        inline constexpr Ptr3D<T> crop3D(const Point& p, const PtrDims<ND::_3D>& newDims) { return Ptr<ND::_3D, T>::crop(p, newDims); }
+        inline constexpr Ptr3D<T> crop3D(const Point p, const PtrDims<ND::_3D>& newDims) { return Ptr<ND::_3D, T>::crop(p, newDims); }
     };
 
     // A color-plane-transposed 3D pointer PtrT3D
@@ -672,7 +671,7 @@ namespace fk {
         inline constexpr PtrT3D<T>(T* data_, const PtrDims<ND::T3D>& dims_, const MemType& type_ = defaultMemType, const int& deviceID_ = 0) :
             Ptr<ND::T3D, T>(data_, dims_, type_, deviceID_) {}
 
-        inline constexpr PtrT3D<T> crop3D(const Point& p, const PtrDims<ND::T3D>& newDims) { return Ptr<ND::T3D, T>::crop(p, newDims); }
+        inline constexpr PtrT3D<T> crop3D(const Point p, const PtrDims<ND::T3D>& newDims) { return Ptr<ND::T3D, T>::crop(p, newDims); }
     };
 
     // A Tensor pointer

--- a/include/fused_kernel/core/data/rawptr.h
+++ b/include/fused_kernel/core/data/rawptr.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace fk {
     template <typename T>
     struct RawPtr<ND::_1D, T> {
         T* data{nullptr};
-        PtrDims<ND::_1D> dims;
+        PtrDims<ND::_1D> dims{};
         using type = T;
         enum { NDim = static_cast<int>(ND::_1D) };
     };
@@ -135,7 +135,7 @@ namespace fk {
     template <typename T>
     struct RawPtr<ND::_2D, T> {
         T* data{nullptr};
-        PtrDims<ND::_2D> dims;
+        PtrDims<ND::_2D> dims{};
         using type = T;
         enum { NDim = static_cast<int>(ND::_2D) };
     };
@@ -143,7 +143,7 @@ namespace fk {
     template <typename T>
     struct RawPtr<ND::_3D, T> {
         T* data{nullptr};
-        PtrDims<ND::_3D> dims;
+        PtrDims<ND::_3D> dims{};
         using type = T;
         enum { NDim = static_cast<int>(ND::_3D) };
     };
@@ -151,7 +151,7 @@ namespace fk {
     template <typename T>
     struct RawPtr<ND::T3D, T> {
         T* data{nullptr};
-        PtrDims<ND::T3D> dims;
+        PtrDims<ND::T3D> dims{};
         using type = T;
         enum { NDim = static_cast<int>(ND::T3D) };
     };
@@ -189,12 +189,12 @@ namespace fk {
     template <>
     struct PtrAccessor<ND::_1D> {
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point& p, const RawPtr<ND::_1D, T>& ptr) {
+        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point p, const RawPtr<ND::_1D, T>& ptr) {
             return ((const BiggerType*)ptr.data) + p.x;
         }
 
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_STATIC BiggerType* point(const Point& p, const RawPtr<ND::_1D, T>& ptr) {
+        FK_HOST_DEVICE_STATIC BiggerType* point(const Point p, const RawPtr<ND::_1D, T>& ptr) {
             return (BiggerType*)ptr.data + p.x;
         }
     };
@@ -202,12 +202,12 @@ namespace fk {
     template <>
     struct PtrAccessor<ND::_2D> {
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point& p, const RawPtr<ND::_2D, T>& ptr) {
+        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point p, const RawPtr<ND::_2D, T>& ptr) {
             return (const BiggerType*)((const char*)ptr.data + (p.y * ptr.dims.pitch)) + p.x;
         }
 
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_STATIC BiggerType* point(const Point& p, const RawPtr<ND::_2D, T>& ptr) {
+        FK_HOST_DEVICE_STATIC BiggerType* point(const Point p, const RawPtr<ND::_2D, T>& ptr) {
             return (BiggerType*)((char*)ptr.data + (p.y * ptr.dims.pitch)) + p.x;
         }
     };
@@ -215,12 +215,12 @@ namespace fk {
     template <>
     struct PtrAccessor<ND::_3D> {
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point& p, const RawPtr<ND::_3D, T>& ptr) {
+        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point p, const RawPtr<ND::_3D, T>& ptr) {
             return (const BiggerType*)((const char*)ptr.data + (ptr.dims.plane_pitch * ptr.dims.color_planes * p.z) + (p.y * ptr.dims.pitch)) + p.x;
         }
 
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_STATIC BiggerType* point(const Point& p, const RawPtr<ND::_3D, T>& ptr) {
+        FK_HOST_DEVICE_STATIC BiggerType* point(const Point p, const RawPtr<ND::_3D, T>& ptr) {
             return (BiggerType*)((char*)ptr.data + (ptr.dims.plane_pitch * ptr.dims.color_planes * p.z) + (p.y * ptr.dims.pitch)) + p.x;
         }
     };
@@ -228,12 +228,12 @@ namespace fk {
     template <>
     struct PtrAccessor<ND::T3D> {
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point& p, const RawPtr<ND::T3D, T>& ptr, const uint& color_plane = 0) {
+        FK_HOST_DEVICE_FUSE const BiggerType* cr_point(const Point p, const RawPtr<ND::T3D, T>& ptr, const uint color_plane = 0) {
             return (const BiggerType*)((const char*)ptr.data + (color_plane * ptr.dims.color_planes_pitch) + (ptr.dims.plane_pitch * p.z) + (ptr.dims.pitch * p.y)) + p.x;
         }
 
         template <typename T, typename BiggerType = T>
-        FK_HOST_DEVICE_STATIC BiggerType* point(const Point& p, const RawPtr<ND::T3D, T>& ptr, const uint& color_plane = 0) {
+        FK_HOST_DEVICE_STATIC BiggerType* point(const Point p, const RawPtr<ND::T3D, T>& ptr, const uint color_plane = 0) {
             return (BiggerType*)((char*)ptr.data + (color_plane * ptr.dims.color_planes_pitch) + (ptr.dims.plane_pitch * p.z) + (ptr.dims.pitch * p.y)) + p.x;
         }
     };
@@ -244,12 +244,12 @@ namespace fk {
     template<>
     struct StaticPtrAccessor<ND::_1D> {
         template <int W, typename T>
-        FK_HOST_DEVICE_FUSE T read(const Point& p, const StaticRawPtr<StaticPtrDims1D<W>, T>& ptr) {
+        FK_HOST_DEVICE_FUSE T read(const Point p, const StaticRawPtr<StaticPtrDims1D<W>, T>& ptr) {
             return ptr.data[p.x];
         }
 
         template <int W, typename T>
-        FK_HOST_DEVICE_FUSE void write(const Point& p, StaticRawPtr<StaticPtrDims1D<W>, T>& ptr, const T& value) {
+        FK_HOST_DEVICE_FUSE void write(const Point p, StaticRawPtr<StaticPtrDims1D<W>, T>& ptr, const T value) {
             ptr.data[p.x] = value;
         }
     };
@@ -257,12 +257,12 @@ namespace fk {
     template<>
     struct StaticPtrAccessor<ND::_2D> {
         template <int W, int H, typename T>
-        FK_HOST_DEVICE_FUSE T read(const Point& p, const StaticRawPtr<StaticPtrDims2D<W, H>, T>& ptr) {
+        FK_HOST_DEVICE_FUSE T read(const Point p, const StaticRawPtr<StaticPtrDims2D<W, H>, T>& ptr) {
             return ptr.data[p.y][p.x];
         }
 
         template <int W, int H, typename T>
-        FK_HOST_DEVICE_FUSE void write(const Point& p, StaticRawPtr<StaticPtrDims2D<W, H>, T>& ptr, const T& value) {
+        FK_HOST_DEVICE_FUSE void write(const Point p, StaticRawPtr<StaticPtrDims2D<W, H>, T>& ptr, const T value) {
             ptr.data[p.y][p.x] = value;
         }
     };
@@ -270,12 +270,12 @@ namespace fk {
     template<>
     struct StaticPtrAccessor<ND::_3D> {
         template <int W, int H, int P, typename T>
-        FK_HOST_DEVICE_FUSE T read(const Point& p, const StaticRawPtr<StaticPtrDims3D<W, H, P>, T>& ptr) {
+        FK_HOST_DEVICE_FUSE T read(const Point p, const StaticRawPtr<StaticPtrDims3D<W, H, P>, T>& ptr) {
             return ptr.data[p.z][p.y][p.x];
         }
 
         template <int W, int H, int P, typename T>
-        FK_HOST_DEVICE_FUSE void write(const Point& p, StaticRawPtr<StaticPtrDims3D<W, H, P>, T>& ptr, const T& value) {
+        FK_HOST_DEVICE_FUSE void write(const Point p, StaticRawPtr<StaticPtrDims3D<W, H, P>, T>& ptr, const T value) {
             ptr.data[p.z][p.y][p.x] = value;
         }
     };

--- a/include/fused_kernel/core/data/rect.h
+++ b/include/fused_kernel/core/data/rect.h
@@ -24,8 +24,8 @@ namespace fk {
     struct Rect_ {
         P x{ 0 }, y{0};
         S width{ 0 }, height{0};
-        FK_HOST_DEVICE_CNST Rect_(const Point& point, const Size& size) : x(point.x), y(point.y), width(size.width), height(size.height) {}
-        FK_HOST_DEVICE_CNST Rect_(const P& x_, const P& y_, const S& width_, const S& height_) : x(x_), y(y_), width(width_), height(height_) {}
+        FK_HOST_DEVICE_CNST Rect_(const Point point, const Size size) : x(point.x), y(point.y), width(size.width), height(size.height) {}
+        FK_HOST_DEVICE_CNST Rect_(const P x_, const P y_, const S width_, const S height_) : x(x_), y(y_), width(width_), height(height_) {}
         FK_HOST_DEVICE_CNST Rect_(){}
     };
 

--- a/include/fused_kernel/core/data/tuple.h
+++ b/include/fused_kernel/core/data/tuple.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,24 +18,65 @@
 #include <fused_kernel/core/utils/type_lists.h>
 #include <fused_kernel/core/utils/vector_utils.h>
 #include <array>
+#include <type_traits>
+#include <utility>
 
 namespace fk {
-    // Generic Tuple
-    template <typename... Types>
-    struct Tuple {};
+    // 1. The Leaf Node
+    // Holds exactly one value.
+    template <size_t I, typename T>
+    struct TupleLeaf {
+        T value;
 
-    template <typename T>
-    struct Tuple<T> {
-        T instance;
-        enum { size = 1 };
+        FK_HOST_DEVICE_CNST TupleLeaf() {};
+
+        // FIX: Use a forwarding constructor that is constrained 
+        // to NOT match the TupleLeaf itself (prevent copy-ctor ambiguity)
+        template <typename U,
+            typename = std::enable_if_t<!std::is_same_v<std::decay_t<U>, TupleLeaf>>>
+        FK_HOST_DEVICE_CNST TupleLeaf(U&& v) : value(std::forward<U>(v)) {}
     };
 
-    template <typename T, typename... Types>
-    struct Tuple<T, Types...> {
-        T instance;
-        Tuple<Types...> next;
-        enum { size = sizeof...(Types) + 1 };
+    // 2. The Implementation Wrapper
+    template <typename IndxSeq, typename... Ts>
+    struct TupleImpl;
+
+    template <size_t... Is, typename... Ts>
+    struct TupleImpl<std::index_sequence<Is...>, Ts...> : TupleLeaf<Is, Ts>...
+    {
+        FK_HOST_DEVICE_CNST TupleImpl() {};
+
+        // FIX: Explicitly forward arguments to the base classes.
+        // The brace initialization {std::forward<Us>(args)...} ensures 
+        // that the pack expansion happens in order.
+        template <typename... Us>
+        FK_HOST_DEVICE_CNST TupleImpl(Us&&... args)
+            : TupleLeaf<Is, Ts>(std::forward<Us>(args))...
+        {}
     };
+
+    // 3. The User-Facing Tuple
+    template <typename... Ts>
+    struct Tuple : TupleImpl<std::make_index_sequence<sizeof...(Ts)>, Ts...> {
+        using Base = TupleImpl<std::make_index_sequence<sizeof...(Ts)>, Ts...>;
+
+        static constexpr size_t size = sizeof...(Ts);
+
+        FK_HOST_DEVICE_CNST Tuple() {};
+
+        // FIX: Use Universal References (U&&...) and std::forward
+        // This handles:
+        // 1. Tuple<int>(10)         -> moves 10
+        // 2. Tuple<int&>(x)         -> references x
+        // 3. Tuple<int&&>(std::move(x)) -> moves x
+        template <typename... Us,
+            typename = std::enable_if_t<sizeof...(Us) == sizeof...(Ts)>>
+            FK_HOST_DEVICE_CNST Tuple(Us&&... args)
+            : Base(std::forward<Us>(args)...) {}
+    };
+
+    // Deduction hint
+    template <typename... Types> Tuple(Types...) -> Tuple<Types...>;
 
     // Primary template: defaults to false
     template <typename T>
@@ -48,92 +89,195 @@ namespace fk {
     template <typename TypeToTest>
     constexpr bool isTuple_v = isTuple<std::decay_t<TypeToTest>>::value;
 
+    // Assuming FK_HOST_DEVICE_FUSE expands to:
+    // __host__ __device__ __forceinline__ static constexpr
+
     struct TupleUtil {
-        template <typename Tuple1, typename Tuple2, int... I1, int... I2>
-        FK_HOST_DEVICE_FUSE auto cat_impl(const Tuple1& t1, std::integer_sequence<int, I1...>,
-                                          const Tuple2& t2, std::integer_sequence<int, I2...>) {
-            return make_tuple(get<I1>(t1)..., get<I2>(t2)...);
+        // ==========================================
+        // 1. Get Helpers (unchanged, strictly typed)
+        // ==========================================
+
+        // The compiler deduces 'T' by upcasting 'leaf' to the specific base class TupleLeaf<I, T>
+        template <size_t I, typename T>
+        FK_HOST_DEVICE_FUSE T& get_leaf_value(TupleLeaf<I, T> &leaf) {
+            return leaf.value;
         }
 
-        template <int INDEX, typename... InstanceTypes>
-        FK_HOST_DEVICE_FUSE auto& get(Tuple<InstanceTypes...>& instances) {
-            constexpr int numberOfInstances = Tuple<InstanceTypes...>::size;
-            static_assert(INDEX < numberOfInstances,
-                "Index out of range. There are not so many instances in the tuple.");
-            if constexpr (INDEX > 0) {
-                return get<INDEX - 1>(instances.next);
-            } else if constexpr (INDEX == -1) {
-                if constexpr (numberOfInstances > 0) {
-                    return get<numberOfInstances - 1>(instances.next);
-                } else {
-                    return instances.instance;
-                }
-            } else {
-                return instances.instance;
-            }
+        template <size_t I, typename T>
+        FK_HOST_DEVICE_FUSE const T& get_leaf_value(const TupleLeaf<I, T> &leaf) {
+            return leaf.value;
         }
 
-        template <int INDEX, typename... InstanceTypes>
-        FK_HOST_DEVICE_FUSE auto get(const Tuple<InstanceTypes...>& instances) {
-            constexpr int numberOfInstances = Tuple<InstanceTypes...>::size;
-            static_assert(INDEX < numberOfInstances,
-                "Index out of range. There are not so many instances in the tuple.");
-            if constexpr (INDEX > 0) {
-                return get<INDEX - 1>(instances.next);
-            } else if constexpr (INDEX == -1) {
-                if constexpr (numberOfInstances > 0) {
-                    return get<numberOfInstances - 1>(instances);
-                } else {
-                    return instances.instance;
-                }
-            } else {
-                return instances.instance;
-            }
+        template <size_t I, typename T>
+        FK_HOST_DEVICE_FUSE T&& get_leaf_value(TupleLeaf<I, T>&& leaf) {
+            return static_cast<T&&>(leaf.value);
+        }
+
+        template <size_t I, typename T>
+        FK_HOST_DEVICE_FUSE const T&& get_leaf_value(const TupleLeaf<I, T>&& leaf) {
+            return static_cast<T&&>(leaf.value);;
+        }
+
+        // Accessor for the main Tuple
+        template <size_t I, typename... Ts>
+        FK_HOST_DEVICE_FUSE auto& get(Tuple<Ts...>& t) {
+            return get_leaf_value<I>(t);
+        }
+
+        template <size_t I, typename... Ts>
+        FK_HOST_DEVICE_FUSE const auto& get(const Tuple<Ts...>& t) {
+            return get_leaf_value<I>(t);
+        }
+
+        template <size_t I, typename... Ts>
+        FK_HOST_DEVICE_FUSE auto&& get(Tuple<Ts...>&& t) {
+            return get_leaf_value<I>(std::forward<Tuple<Ts...>>(t));
+        }
+
+        template <size_t I, typename... Ts>
+        FK_HOST_DEVICE_FUSE const auto&& get(const Tuple<Ts...>&& t) {
+            return get_leaf_value<I>(std::move(t));
+        }
+
+        // ==========================================
+        // 2. Concatenation (Flat Expansion)
+        // ==========================================
+        // Helper to extract and concatenate generic parameter packs
+        template <typename T1, typename T2>
+        struct TupleCatTraits;
+
+        // Specialization for two Tuples
+        template <typename... Ts, typename... Us>
+        struct TupleCatTraits<Tuple<Ts...>, Tuple<Us...>> {
+            using type = Tuple<Ts..., Us...>;
+        };
+
+        // Convenience alias
+        template <typename T1, typename T2>
+        using TupleCatResult_t = typename TupleCatTraits<std::decay_t<T1>, std::decay_t<T2>>::type;
+
+        template <typename Tuple1, typename Tuple2, size_t... I1, size_t... I2>
+        FK_HOST_DEVICE_FUSE auto cat_impl(Tuple1&& t1, Tuple2&& t2,
+            std::index_sequence<I1...>,
+            std::index_sequence<I2...>) {
+            // 1. Calculate the exact Result Type (e.g., Tuple<int, float&, double>)
+            using ResultTuple = TupleCatResult_t<Tuple1, Tuple2>;
+
+            // 2. Construct explicitly. 
+            //    We use std::forward to invoke the correct 'get' (move vs copy).
+            //    The ResultTuple constructor will accept the results of get.
+            return ResultTuple(
+                get<I1>(std::forward<Tuple1>(t1))...,
+                get<I2>(std::forward<Tuple2>(t2))...
+            );
         }
 
         template <typename Tuple1, typename Tuple2>
-        FK_HOST_DEVICE_FUSE auto cat(Tuple1& t1, Tuple2& t2) {
-            return cat_impl(t1, std::make_integer_sequence<int, Tuple1::size>(),
-                            t2, std::make_integer_sequence<int, Tuple2::size>());
+        FK_HOST_DEVICE_FUSE auto cat(Tuple1&& t1, Tuple2&& t2) {
+            using T1 = std::decay_t<Tuple1>;
+            using T2 = std::decay_t<Tuple2>;
+
+            return cat_impl(
+                std::forward<Tuple1>(t1),
+                std::forward<Tuple2>(t2),
+                std::make_index_sequence<T1::size>(),
+                std::make_index_sequence<T2::size>()
+            );
         }
 
-        template <typename Tuple1, typename Tuple2>
-        FK_HOST_DEVICE_FUSE auto cat(const Tuple1& t1, const Tuple2& t2) {
-            return cat_impl(t1, std::make_integer_sequence<int, Tuple1::size>(),
-                            t2, std::make_integer_sequence<int, Tuple2::size>());
+        // ==========================================
+        // 3. Make, forward and tie
+        // ==========================================
+
+        template <typename... Types>
+        FK_HOST_DEVICE_FUSE auto make_tuple(Types&&... args) {
+            // Forwarding references allow move semantics if 'instances' are temporary
+            // Store all velues in a new Tuple, effectively making a copy
+            return Tuple<std::decay_t<Types>...>(std::forward<Types>(args)...);
         }
 
         template <typename... Types>
-        FK_HOST_DEVICE_FUSE auto make_tuple(const Types&... instances) {
-            return Tuple<Types...>{instances...};
+        FK_HOST_DEVICE_FUSE auto forward_as_tuple(Types&&... args) {
+            // Constructs Tuple<T&&...> preserving exact value category (L-value vs R-value)
+            // This is essentially a "view" of the arguments.
+            return Tuple<Types&&...>(std::forward<Types>(args)...);
         }
 
-        template <int INDEX, typename T, typename Tuple_>
-        FK_HOST_DEVICE_FUSE auto tuple_insert(const T& instance, const Tuple_& tuple) {
-            constexpr int numberOfInstances = Tuple_::size;
-            static_assert(INDEX <= numberOfInstances,
-                "Index out of range. There are not so many instances in the tuple.");
-            if constexpr (INDEX == 0) {
-                return TupleUtil::cat(make_tuple(instance), tuple);
-            } else {
-                if constexpr (Tuple_::size > 1) {
-                    const auto [head, tail] = tuple;
-                    return TupleUtil::cat(make_tuple(head), tuple_insert<INDEX - 1>(instance, tail));
-                } else {
-                    return TupleUtil::cat(tuple, make_tuple(instance));
-                }
-            }
+        template <typename... Types>
+        FK_HOST_DEVICE_FUSE auto tie(Types&... args) {
+            // Constructs Tuple<T&...>
+            // Only accepts L-values (variables), refuses temporaries.
+            return Tuple<Types&...>(args...);
+        }
+
+        // ==========================================
+        // 4. Insert (Fully Flattened)
+        // ==========================================
+
+        template <size_t InsertIdx, typename T, typename TupleT, size_t... PreIdx, size_t... PostIdx>
+        FK_HOST_DEVICE_FUSE auto insert_impl(T&& val, TupleT&& t,
+            std::index_sequence<PreIdx...>,
+            std::index_sequence<PostIdx...>) {
+            // FIX: Remove explicit template arguments <decltype(...)>.
+            // rely on the Tuple(args...) deduction guide to decay types (int& -> int).
+            // This creates safe storage.
+            return Tuple(
+                // 1. Elements before
+                get<PreIdx>(std::forward<TupleT>(t))...,
+
+                // 2. The new element
+                std::forward<T>(val),
+
+                // 3. Elements after (shifted by InsertIdx)
+                get<PostIdx + InsertIdx>(std::forward<TupleT>(t))...
+            );
+        }
+
+        template <size_t INDEX, typename T, typename TupleT>
+        FK_HOST_DEVICE_FUSE auto tuple_insert(T&& instance, TupleT&& tuple) {
+            using BareTuple = std::decay_t<TupleT>;
+            constexpr size_t N = BareTuple::size;
+
+            static_assert(INDEX <= N, "Index out of range.");
+
+            // Split indices: [0, INDEX) and [INDEX, N)
+            // Note: The second sequence length is (N - INDEX)
+            return insert_impl<INDEX>(
+                std::forward<T>(instance),
+                std::forward<TupleT>(tuple),
+                std::make_index_sequence<INDEX>{},
+                std::make_index_sequence<N - INDEX>{}
+            );
         }
     };
 
-    template <int INDEX, typename... Types>
-    FK_HOST_DEVICE_CNST auto get(const Tuple<Types...>& tuple) {
-        return TupleUtil::get<INDEX>(tuple);
+    template <size_t Idx, typename TupleLike>
+    FK_HOST_DEVICE_CNST decltype(auto) get(TupleLike&& tuple) {
+        static_assert(isTuple_v<TupleLike>, "fk::get can only be used with fk::Tuple");
+
+        // decltype(auto) + std::forward preserves EXACTLY what TupleUtil returned
+        // (Value category, const-ness, and reference type)
+        return TupleUtil::get<Idx>(std::forward<TupleLike>(tuple));
     }
 
-    template <int INDEX, typename... Types>
-    FK_HOST_DEVICE_CNST auto& get(Tuple<Types...>& tuple) {
-        return TupleUtil::get<INDEX>(tuple);
+    template <typename... Types>
+    FK_HOST_DEVICE_CNST auto make_tuple(Types&&... args) {
+        // Store all values in a new Tuple, effectively making a copy
+        return TupleUtil::make_tuple(std::forward<Types>(args)...);
+    }
+
+    template <typename... Types>
+    FK_HOST_DEVICE_CNST auto forward_as_tuple(Types&&... args) {
+        // Constructs Tuple<T&&...> preserving exact value category (L-value vs R-value)
+        // This is essentially a "view" of the arguments.
+        return TupleUtil::forward_as_tuple(std::forward<Types>(args)...);
+    }
+
+    template <typename... Types>
+    FK_HOST_DEVICE_CNST auto tie(Types&... args) {
+        // Constructs Tuple<T&...>
+        // Only accepts L-values (variables), refuses temporaries.
+        return TupleUtil::tie(args...);
     }
 
     template <typename TupleType>
@@ -151,23 +295,18 @@ namespace fk {
     using get_t = TypeAt_t<INDEX, ToTypeList<TupleType>>;
 
     template <int INDEX, typename T, typename TupleLike>
-    FK_HOST_DEVICE_CNST auto tuple_insert(const T& element, const TupleLike& tuple) {
-        return TupleUtil::tuple_insert<INDEX,T>(element, tuple);
+    FK_HOST_DEVICE_CNST auto tuple_insert(T&& element, TupleLike&& tuple) {
+        return TupleUtil::tuple_insert<INDEX, T>(std::forward<T>(element), std::forward<TupleLike>(tuple));
     }
 
     template <typename T, typename TupleLike>
-    FK_HOST_DEVICE_CNST auto tuple_insert_back(const TupleLike& tuple, const T& element) {
-        return TupleUtil::tuple_insert<TupleLike::size, T>(element, tuple);
+    FK_HOST_DEVICE_CNST auto tuple_insert_back(TupleLike&& tuple, T&& element) {
+        return TupleUtil::tuple_insert<std::decay_t<TupleLike>::size, T>(std::forward<T>(element), std::forward<TupleLike>(tuple));
     }
 
     template <typename Tuple1, typename Tuple2>
-    FK_HOST_DEVICE_CNST auto cat(const Tuple1& t1, const Tuple2& t2) {
-        return TupleUtil::cat(t1, t2);
-    }
-
-    template <typename... Types>
-    FK_HOST_DEVICE_CNST auto make_tuple(const Types&... instances) {
-        return TupleUtil::make_tuple(instances...);
+    FK_HOST_DEVICE_CNST auto tuple_cat(Tuple1&& t1, Tuple2&& t2) {
+        return TupleUtil::cat(std::forward<Tuple1>(t1), std::forward<Tuple2>(t2));
     }
 
     template <int INDEX, typename TupleLike>
@@ -181,18 +320,28 @@ namespace fk {
     template <int INDEX, typename TupleLike>
     using get_type_t = typename GetType<INDEX, TupleLike>::type;
 
-    template <typename F, typename Tuple, size_t... I>
-    FK_HOST_DEVICE_CNST auto apply_impl(F&& f, Tuple& t, std::index_sequence<I...>)
-        -> decltype(std::forward<F>(f)(get<I>(std::forward<Tuple>(t))...)) {
-        return std::forward<F>(f)(get<I>(std::forward<Tuple>(t))...);
+    // ==========================================
+    // The apply Implementation (Now with Return Values)
+    // ==========================================
+
+    namespace detail {
+        template <typename F, typename TupleT, size_t... Is>
+        // decltype(auto) lets the compiler figure out the return type
+        FK_HOST_DEVICE_CNST decltype(auto) apply_impl(F &&f, TupleT &&t, std::index_sequence<Is...>) {
+
+            // We simply return the result of the function call.
+            return std::forward<F>(f)(get<Is>(std::forward<TupleT>(t))...);
+        }
+    } // namespace detail
+
+    template <typename F, typename... Ts>
+    FK_HOST_DEVICE_CNST decltype(auto) apply(F &&f, Tuple<Ts...> &t) {
+        return detail::apply_impl(std::forward<F>(f), t, std::make_index_sequence<sizeof...(Ts)>{});
     }
 
-    template <typename F, typename Tuple>
-    FK_HOST_DEVICE_CNST auto apply(F&& f, Tuple& t)
-        -> decltype(apply_impl(std::forward<F>(f), std::forward<Tuple>(t),
-            std::make_index_sequence<Tuple::size>())) {
-        return apply_impl(std::forward<F>(f), std::forward<Tuple>(t),
-            std::make_index_sequence<Tuple::size>());
+    template <typename F, typename... Ts>
+    FK_HOST_DEVICE_CNST decltype(auto) apply(F &&f, const Tuple<Ts...> &t) {
+        return detail::apply_impl(std::forward<F>(f), t, std::make_index_sequence<sizeof...(Ts)>{});
     }
 
     // Struct to hold a parameter pack, and be able to pass it arround
@@ -228,21 +377,6 @@ namespace fk {
         return tuple_insert<sizeof...(Args) - 1>(t, Tuple<Args...>{args...});
     }
 
-    /*template <typename TranslateType, typename SourceType, size_t NElems, int... Idx, typename... ExtraParams>
-    constexpr inline std::array<typename TranslateType::OutputType, NElems>
-        static_translate_helper(const int& usedPlanes,
-            const std::array<SourceType, NElems>& srcArray,
-            const std::integer_sequence<int, Idx...>&,
-            const ExtraParams&... extParams) {
-        return { (TranslateType::template translate<Idx>(usedPlanes, srcArray[Idx], extParams...))... };
-    }
-
-    template <typename TranslateType, typename SourceType, size_t NElems, typename... ExtraParams>
-    constexpr inline std::array<typename TranslateType::OutputType, NElems>
-        static_translate(const int& usedPlanes, const std::array<SourceType, NElems>& srcArray, const ExtraParams&... extParams) {
-        return static_translate_helper<TranslateType>(usedPlanes, srcArray, std::make_integer_sequence<int, NElems>{}, extParams...);
-    }*/
-
     template <typename FirstType, typename SecondType>
     struct GetFirst {
         using OutputType = FirstType;
@@ -260,18 +394,6 @@ namespace fk {
             return a_pair.second;
         }
     };
-
-    /*template <typename FT, typename ST, size_t NElems>
-    constexpr inline std::array<FT, NElems>
-        static_translate_get_first(const std::array<std::pair<FT, ST>, NElems>& srcArray) {
-        return static_translate_helper<GetFirst<FT, ST>>(NElems, srcArray, std::make_integer_sequence<int, NElems>{});
-    }
-
-    template <typename FT, typename ST, size_t NElems>
-    constexpr inline std::array<ST, NElems>
-        static_translate_get_second(const std::array<std::pair<FT, ST>, NElems>& srcArray) {
-        return static_translate_helper<GetSecond<FT, ST>>(NElems, srcArray, std::make_integer_sequence<int, NElems>{});
-    }*/
 
     template <typename T>
     FK_HOST_DEVICE_CNST auto cudaVectorToTuple(const T& cudaVectType) {

--- a/include/fused_kernel/core/data/vector_types.h
+++ b/include/fused_kernel/core/data/vector_types.h
@@ -1,4 +1,5 @@
 ﻿/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -260,8 +261,6 @@ namespace fk {
 
 #if defined(__NVCC__) || CLANG_HOST_DEVICE
 #include <vector_types.h>
-#elif defined(NVRTC_COMPILER)
-// Nothing to include here
 #else
 using char1 = fk::Char1;
 using uchar1 = fk::Uchar1;

--- a/include/fused_kernel/core/execution_model/data_parallel_patterns.h
+++ b/include/fused_kernel/core/execution_model/data_parallel_patterns.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include <cooperative_groups.h>
 namespace cooperative_groups {};
 namespace cg = cooperative_groups;
-#endif // defined(__NVCC__) || defined(__HIP__) || defined(__NVRTC__) || defined(NVRTC_COMPILER)
+#endif
 
 #include <fused_kernel/core/utils/parameter_pack_utils.h>
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
@@ -72,35 +72,24 @@ namespace fk { // namespace FusedKernel
     private:
         using Details = DPPDetails;
 
-        template <typename T, typename IOp, typename... IOpTypes>
-        FK_HOST_DEVICE_FUSE auto operate(const Point& thread, const T& i_data, const IOp& iOp, const IOpTypes&... iOpInstances) {
-            static_assert(!isIncompleteReadBackType<IOp>, "Trying to execute an incomplete IOp");
-            if constexpr (IOp::template is<WriteType>) {
-                return i_data;
-                // MidWriteOperation with continuations, based on FusedOperation
-            } else if constexpr (IOp::template is<MidWriteType> && isMidWriteType<typename IOp::Operation>) {
-                return IOp::Operation::exec(thread, i_data, iOp);
-            } else if constexpr (IOp::template is<MidWriteType> && !isMidWriteType<typename IOp::Operation>) {
-                IOp::Operation::exec(thread, i_data, iOp);
-                return i_data;
-            } else {
-                return operate(thread, compute(i_data, iOp), iOpInstances...);
-            }
+        template <typename InputType, typename... IOpTypes>
+        FK_HOST_DEVICE_FUSE auto operate(const Point thread, const InputType i_data, const IOpTypes&... iOpInstances) {
+            return (InputFoldType(thread, i_data) | ... | iOpInstances).input;
         }
 
         template <uint IDX, typename TFI, typename InputType, typename... IOpTypes>
-        FK_HOST_DEVICE_FUSE auto operate_idx(const Point& thread, const InputType& input, const IOpTypes&... instantiableOperationInstances) {
+        FK_HOST_DEVICE_FUSE auto operate_idx(const Point thread, const InputType input, const IOpTypes&... instantiableOperationInstances) {
             return operate(thread, TFI::template get<IDX>(input), instantiableOperationInstances...);
         }
 
         template <typename TFI, typename InputType, uint... IDX, typename... IOpTypes>
-        FK_HOST_DEVICE_FUSE auto operate_thread_fusion_impl(std::integer_sequence<uint, IDX...> idx, const Point& thread,
-            const InputType& input, const IOpTypes&... instantiableOperationInstances) {
+        FK_HOST_DEVICE_FUSE auto operate_thread_fusion_impl(std::integer_sequence<uint, IDX...> idx, const Point thread,
+            const InputType input, const IOpTypes&... instantiableOperationInstances) {
             return TFI::make(operate_idx<IDX, TFI>(thread, input, instantiableOperationInstances...)...);
         }
 
         template <typename TFI, typename InputType, typename... IOpTypes>
-        FK_HOST_DEVICE_FUSE auto operate_thread_fusion(const Point& thread, const InputType& input, const IOpTypes&... instantiableOperationInstances) {
+        FK_HOST_DEVICE_FUSE auto operate_thread_fusion(const Point thread, const InputType input, const IOpTypes&... instantiableOperationInstances) {
             if constexpr (TFI::elems_per_thread == 1) {
                 return operate(thread, input, instantiableOperationInstances...);
             } else {
@@ -109,7 +98,7 @@ namespace fk { // namespace FusedKernel
         }
         // We pass TFI as a template parameter because sometimes we need to disable the TF
         template <typename TFI, typename ReadIOp>
-        FK_HOST_DEVICE_FUSE auto read(const Point& thread, const ReadIOp& readDF) {
+        FK_HOST_DEVICE_FUSE auto read(const Point thread, const ReadIOp& readDF) {
             if constexpr (TFI::ENABLED) {
                 static_assert(isAnyReadType<ReadIOp>, "ReadIOp is not ReadType or ReadBackType");
                 return ReadIOp::Operation::template exec<TFI::elems_per_thread>(thread, readDF);
@@ -120,12 +109,12 @@ namespace fk { // namespace FusedKernel
 
         template <typename TFI, typename ReadIOp, typename... IOps>
         FK_HOST_DEVICE_FUSE
-        void execute_instantiable_operations_helper(const Point& thread, const ReadIOp& readDF,
+        void execute_instantiable_operations_helper(const Point thread, const ReadIOp& readDF,
                                                     const IOps&... iOps) {
             using ReadOperation = typename ReadIOp::Operation;
             using WriteOperation = typename LastType_t<IOps...>::Operation;
 
-            const auto writeDF = ppLast(iOps...);
+            const auto& writeDF = ppLast(iOps...);
 
             if constexpr (TFI::ENABLED) {
                 const auto tempI = read<TFI, ReadIOp>(thread, readDF);
@@ -147,12 +136,12 @@ namespace fk { // namespace FusedKernel
         }
 
         template <typename TFI, typename... IOps>
-        FK_HOST_DEVICE_FUSE void execute_instantiable_operations(const Point& thread, const IOps&... iOps) {
+        FK_HOST_DEVICE_FUSE void execute_instantiable_operations(const Point thread, const IOps&... iOps) {
             execute_instantiable_operations_helper<TFI>(thread, iOps...);
         }
 
         template <typename... IOps>
-        FK_HOST_DEVICE_FUSE void execute_thread(const Point& thread, const ActiveThreads& activeThreads, const IOps&... iOps) {
+        FK_HOST_DEVICE_FUSE void execute_thread(const Point thread, const ActiveThreads& activeThreads, const IOps&... iOps) {
             using TFI = typename Details::TFI;
             if constexpr (!TFI::ENABLED) {
                 execute_instantiable_operations<TFI>(thread, iOps...);
@@ -166,7 +155,7 @@ namespace fk { // namespace FusedKernel
                     } else if (iamlastActiveThread) {
                         const int initialX = thread.x * TFI::elems_per_thread;
                         using ReadOp = typename FirstType_t<IOps...>::Operation;
-                        const int finalX = ReadOp::num_elems_x(thread, get<0>(iOps...));
+                        const int finalX = ReadOp::num_elems_x(thread, get_arg<0>(iOps...));
                         int currentX = initialX;
                         while (currentX < finalX) {
                             const Point currentThread{ currentX , thread.y, thread.z };
@@ -212,27 +201,6 @@ namespace fk { // namespace FusedKernel
                 return Details{};
             }
         }
-        template <typename FirstIOp, typename... IOps>
-        FK_DEVICE_FUSE auto build_details(const ActiveThreads& activeThreads, const uint& readRow, const uint& writeRow) {
-            using Details = TransformDPPDetails<static_cast<bool>(TFEN), FirstIOp, IOps...>;
-            using TFI = typename Details::TFI;
-            if constexpr (TFI::ENABLED) {
-                const ActiveThreads gridActiveThreads(static_cast<uint>(ceil(activeThreads.x / static_cast<float>(TFI::elems_per_thread))),
-                                                      activeThreads.y, activeThreads.z);
-                bool threadDivisible;
-                if constexpr (TFI::ENABLED) {
-                    using ReadOperation = typename FirstIOp::Operation;
-                    using WriteOperation = typename LastType_t<IOps...>::Operation;
-                    threadDivisible = (readRow % TFI::elems_per_thread == 0) && (writeRow % TFI::elems_per_thread == 0);
-                } else {
-                    threadDivisible = true;
-                }
-                const Details details{ gridActiveThreads, threadDivisible };
-                return details;
-            } else {
-                return Details{};
-            }
-        }
     };
 
 // Note: there are no ParArch::GPU_NVIDIA_JIT DPP implementaitons, because
@@ -248,7 +216,7 @@ namespace fk { // namespace FusedKernel
         static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
         template <typename FirstIOp>
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const Details& details,
-                                                           const FirstIOp& iOp) {
+                                                            const FirstIOp& iOp) {
             return Parent::getActiveThreads(details, iOp);
         }
 
@@ -268,14 +236,14 @@ namespace fk { // namespace FusedKernel
 #endif
             const Point thread{ x, y, z };
 
-            const ActiveThreads activeThreads = getActiveThreads(details, get<0>(iOps...));
+            const ActiveThreads activeThreads = getActiveThreads(details, get_arg<0>(iOps...));
 
             if (x < activeThreads.x && y < activeThreads.y) {
                 Parent::execute_thread(thread, activeThreads, iOps...);
             }
         }
     };
-#endif // defined(__NVCC__) || defined(__HIPCC__) || defined(__NVRTC__) || defined(NVRTC_COMPILER)
+#endif // defined(__NVCC__) || CLANG_HOST_DEVICE
 
     template <enum TF TFEN, typename DPPDetails, bool THREAD_DIVISIBLE>
     struct TransformDPP<ParArch::CPU, TFEN, DPPDetails, THREAD_DIVISIBLE, std::enable_if_t<!std::is_same_v<DPPDetails, void>, void>> {
@@ -286,14 +254,14 @@ namespace fk { // namespace FusedKernel
         static constexpr ParArch PAR_ARCH = ParArch::CPU;
         template <typename FirstIOp>
         FK_HOST_FUSE ActiveThreads getActiveThreads(const Details& details,
-                                                    const FirstIOp& iOp) {
+                                                     const FirstIOp& iOp) {
             return Parent::getActiveThreads(details, iOp);
         }
 
         template <typename... IOps>
         FK_HOST_FUSE void exec(const Details& details, const IOps&... iOps) {
             using TFI = typename Details::TFI;
-            const ActiveThreads activeThreads = getActiveThreads(details, get<0>(iOps...));
+            const ActiveThreads activeThreads = getActiveThreads(details, get_arg<0>(iOps...));
 
             for (int z = 0; z < activeThreads.z; ++z) {
                 for (int y = 0; y < activeThreads.y; ++y) {
@@ -321,8 +289,9 @@ namespace fk { // namespace FusedKernel
         }
 
         template <int OpSequenceNumber, typename... IOps, typename... IOpSequenceTypes>
-        FK_HOST_DEVICE_FUSE void divergent_operate(const uint& z, const InstantiableOperationSequence<IOps...>& iOpSequence,
-            const IOpSequenceTypes&... iOpSequences) {
+        FK_HOST_DEVICE_FUSE void divergent_operate(const uint z,
+                                                   const InstantiableOperationSequence<IOps...>& iOpSequence,
+                                                   const IOpSequenceTypes&... iOpSequences) {
             if (OpSequenceNumber == SequenceSelector::at(z)) {
                 apply(launchTransformDPP<IOps...>, iOpSequence.iOps);
             } else if constexpr (sizeof...(iOpSequences) > 0) {

--- a/include/fused_kernel/core/execution_model/executors.h
+++ b/include/fused_kernel/core/execution_model/executors.h
@@ -1,4 +1,5 @@
 /* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,7 +19,7 @@
 
 #include <fused_kernel/core/execution_model/parallel_architectures.h>
 #include <fused_kernel/core/execution_model/data_parallel_patterns.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/basic_ops/set.h>
 #include <fused_kernel/core/execution_model/stream.h>
 
@@ -41,61 +42,26 @@ namespace fk {
     };
 #endif
 
-    struct Back {
-        template <typename First, typename Second, typename... IOps>
-        FK_HOST_FUSE auto fuse(const First& first, const Second& second, const IOps&... iOps) {
-            if constexpr (sizeof...(iOps) == 0 || noneIncompleteReadBackType<IOps...>) {
-                if constexpr (isIncompleteReadBackType<Second>) {
-                    return first.then(second);
-                } else {
-                    return first;
-                }
-            } else {
-                return fuse(first.then(second), iOps...);
-            }
-        }
-
-        template <typename First, typename... IOps>
-        FK_HOST_FUSE size_t idxFirstNonBack() {
-            if constexpr (sizeof...(IOps) == 0) {
-                return 1;
-            } else {
-                if constexpr (!noneIncompleteReadBackType<IOps...>) {
-                    return 1 + idxFirstNonBack<IOps...>();
-                } else {
-                    if constexpr (isReadBackType<First> || isIncompleteReadBackType<First>) {
-                        return 1;
-                    } else {
-                        return 0;
-                    }
-                }
-            }
-        }
-    };
-
     template <typename Child>
     struct BaseExecutor {
-        template <size_t firstNonBackOp, ParArch PA, size_t... Idx, typename... IOps>
-        FK_HOST_FUSE void executeOperationsBase_helper(const std::index_sequence<Idx...>&, Stream_<PA>& stream, const IOps&... iOps) {
-            // firstNonBackOp is the index of the first non back operation in the operation sequence
-            if constexpr (firstNonBackOp < 2) {
-                // Only the first operation is a back operation or there are no back operations
-                Child::executeOperations_helper(stream, iOps...);
-            } else {
-                // There are back operations that are not the first operation, fuse them
-                const auto firstOp = Back::fuse(iOps...);
-                // And call the executeOperations_helper with the fused back operation and the rest of operations
-                Child::executeOperations_helper(stream, firstOp, get<Idx + firstNonBackOp>(iOps...)...);
-            }
+      private:
+        template <typename StreamT, typename... Args>
+        FK_HOST_FUSE void applyExecuteOperations_helper(Tuple<StreamT, Args...>& argTuple) {
+            apply(Child::template executeOperations_helper<Args...>, argTuple);
+        }
+      public:
+        template <ParArch PA, typename... IOps>
+        FK_HOST_FUSE void executeOperationsBase_helper(Stream_<PA>& stream, const IOps&... iOps) {
+            const auto fb_iOps = BackFuser::fuse_back(iOps...);
+            auto fullArgs = tuple_cat(forward_as_tuple(stream), fb_iOps);
+            applyExecuteOperations_helper(fullArgs);
         }
 
         FK_STATIC_STRUCT(BaseExecutor, BaseExecutor)
 
         template <enum ParArch PA, typename... IOps>
         FK_HOST_FUSE void executeOperations(Stream_<PA>& stream, const IOps&... iOps) {
-            constexpr size_t firstNonBackIdx = Back::idxFirstNonBack<IOps...>();
-            constexpr size_t remainingOps = sizeof...(iOps) - firstNonBackIdx;
-            executeOperationsBase_helper<firstNonBackIdx>(std::make_index_sequence<remainingOps>{}, stream, iOps...);
+            executeOperationsBase_helper(stream, iOps...);
         }
 
         template <enum ParArch PA, enum ND D, typename I, typename... IOps>
@@ -319,7 +285,7 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
                     gpuErrchk(cudaGetLastError());
                 }
             } else {
-                const auto readOp = get<0>(iOps...);
+                const auto readOp = get_arg<0>(iOps...);
 
                 const ActiveThreads activeThreads = readOp.getActiveThreads();
 
@@ -356,23 +322,9 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
             return ActiveThreads{ x, y, z }; 
         }
 
-        template <size_t firstNonBack, size_t... Idx, typename FirstIOp, typename... IOps>
-        FK_HOST_FUSE auto getNewIOpSequence(const std::index_sequence<Idx...>&, const FirstIOp& firstIOp, const Tuple<IOps...>& iOps) {
-            if constexpr (firstNonBack < 2) {
-                return IOpSequence<IOps...>{iOps};
-            } else {
-                return IOpSequence<FirstIOp, get_t<firstNonBack + Idx, Tuple<IOps...>>...>{
-                    Tuple<FirstIOp, get_t<firstNonBack + Idx, Tuple<IOps...>>...>{firstIOp, get<firstNonBack + Idx>(iOps)...}
-                };
-            }
-        }
-
         template <typename... IOps>
         FK_HOST_FUSE auto fuseBackSequence(const IOpSequence<IOps...>& iOpSeq) {
-            const auto firstOp = fk::apply(Back::fuse<IOps...>, iOpSeq.iOps);
-            constexpr auto firstNonBackIdx = Back::idxFirstNonBack<IOps...>();
-            return getNewIOpSequence<firstNonBackIdx>(std::make_index_sequence<sizeof...(IOps) - firstNonBackIdx>{}, firstOp,
-                                     iOpSeq.iOps);
+            return buildOperationSequence_tup(apply(BackFuser::fuse_back<IOps...>, iOpSeq.iOps));
         }
 
         template <typename... IOpSequenceTypes>

--- a/include/fused_kernel/core/execution_model/operation_model/batch_operations.h
+++ b/include/fused_kernel/core/execution_model/operation_model/batch_operations.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,8 +51,8 @@ ReadBackOperation<TypeList<void, ...>>:
 
 ReadBackOperation<BackIOp>:
     Instantiable
-    Implements exec(const Point& thread, const OperationData<ReadBackOperation<BackIOp>>& opData)
-    Implements exec(const Point& thread, const ParamsType& params, const BackIOp& backIOp)
+    Implements exec(const Point thread, const OperationData<ReadBackOperation<BackIOp>>& opData)
+    Implements exec(const Point thread, const ParamsType& params, const BackIOp& backIOp)
     Implements build(const OperationData<ReadBackOperation<BackIOp>>& opData)
     Implements build(const ParamsType& params, const BackIOp& backIOp)
 
@@ -92,7 +92,7 @@ namespace fk {
 
     template <size_t BATCH, typename Operation, typename DefaultType>
     struct BatchReadParams<BATCH, PlanePolicy::CONDITIONAL_WITH_DEFAULT, Operation, DefaultType> {
-        OperationData<Operation> opData[BATCH];
+        Array<OperationData<Operation>, BATCH> opData;
         int usedPlanes;
         DefaultType default_value;
         ActiveThreads activeThreads;
@@ -100,51 +100,53 @@ namespace fk {
 
     template <size_t BATCH, typename Operation>
     struct BatchReadParams<BATCH, PlanePolicy::PROCESS_ALL, Operation, NullType> {
-        OperationData<Operation> opData[BATCH];
+        Array<OperationData<Operation>, BATCH> opData;
         ActiveThreads activeThreads;
     };
 
     struct BatchUtils {
         FK_STATIC_STRUCT(BatchUtils, BatchUtils)
-#ifndef NVRTC_COMPILER
-            template <typename InstantiableType>
-        FK_HOST_FUSE auto toArray(const InstantiableType& batchIOp) {
-            static_assert(isBatchOperation<typename InstantiableType::Operation>,
+
+        template <typename InstantiableType>
+        FK_HOST_FUSE auto toArray(InstantiableType&& batchIOp) {
+            using IOpType = std::decay_t<InstantiableType>;
+            static_assert(isBatchOperation<typename IOpType::Operation>,
                 "The IOp passed as parameter is not a batch operation");
-            constexpr size_t BATCH = InstantiableType::Operation::BATCH;
-            return toArray_helper(std::make_index_sequence<BATCH>{}, batchIOp);
-        }
-        template <typename Operation, size_t BATCH_N, typename FirstType, typename... ArrayTypes>
-        FK_HOST_FUSE auto build_batch(const std::array<FirstType, BATCH_N>& firstInstance, const ArrayTypes &...arrays) {
-            static_assert(allArraysSameSize_v<BATCH_N, ArrayTypes...>, "Not all arrays have the same size as BATCH");
-            return build_helper_generic<Operation>(std::make_index_sequence<BATCH_N>(), firstInstance, arrays...);
-        }
-    private:
-        template <typename InstantiableType, size_t... Idx>
-        FK_HOST_FUSE auto toArray_helper(const std::index_sequence<Idx...>&, const InstantiableType& batchIOp) {
-            using Operation = typename InstantiableType::Operation::Operation;
-            using OutputArrayType = std::array<Instantiable<Operation>, sizeof...(Idx)>;
-            if constexpr (InstantiableType::template is<ReadType>) {
-                return OutputArrayType{ Operation::build(batchIOp.params.opData[Idx])... };
-            } else {
-                static_assert(InstantiableType::template is<WriteType>, "InstantiableType is not a ReadType or WriteType. It means it is not a batch operation");
-                return OutputArrayType{ Operation::build(batchIOp.params[Idx])... };
+            using Operation = typename IOpType::Operation::Operation;
+            using OutputArrayType = std::array<Instantiable<Operation>, IOpType::Operation::BATCH>;
+            OutputArrayType resultingArray{};
+            for (int i = 0; i < IOpType::Operation::BATCH; i++) {
+                if constexpr (IOpType::template is<ReadType>) {
+                    resultingArray[i] = Operation::build(std::forward<InstantiableType>(batchIOp).params.opData[i]);
+                } else {
+                    static_assert(IOpType::template is<WriteType>, "IOpType must be ReadType or WriteType");
+                    resultingArray[i] = Operation::build(std::forward<InstantiableType>(batchIOp).params[i]);
+                }
             }
+            return resultingArray;
         }
-        template <size_t Idx, typename Array>
-        FK_HOST_FUSE auto get_element_at_index(const Array& paramArray) -> decltype(paramArray[Idx]) {
-            return paramArray[Idx];
+
+        template <typename Operation, size_t BATCH, typename ArrayType, typename... Arrays>
+        FK_HOST_FUSE auto build_batch(const std::array<ArrayType, BATCH>& firstArray, Arrays&&...arrays) {
+            static_assert(allArraysSameSize_v<BATCH, std::decay_t<Arrays>...>,
+                "Not all arrays have the same size as BATCH");
+
+            // Determine return type based on the first element
+            using OutputArrayType = decltype(Operation::build(
+                std::declval<ArrayType>(),
+                std::declval<std::decay_t<Arrays>>()[0]...
+            ));
+
+            std::array<OutputArrayType, BATCH> resultArray{};
+
+            // One simple loop handles both 0 and N extra arrays
+            for (int i = 0; i < BATCH; i++) {
+                // If 'arrays' is empty, this expands to just build(firstArray[i])
+                resultArray[i] = Operation::build(firstArray[i], std::forward<Arrays>(arrays)[i]...);
+            }
+
+            return resultArray;
         }
-        template <typename Operation, size_t Idx, typename... Arrays>
-        FK_HOST_FUSE auto call_build_at_index(const Arrays &...arrays) {
-            return Operation::build(get_element_at_index<Idx>(arrays)...);
-        }
-        template <typename Operation, size_t... Idx, typename... Arrays>
-        FK_HOST_FUSE auto build_helper_generic(const std::index_sequence<Idx...>&, const Arrays &...arrays) {
-            using OutputArrayType = decltype(call_build_at_index<Operation, 0>(std::declval<Arrays>()...));
-            return std::array<OutputArrayType, sizeof...(Idx)>{call_build_at_index<Operation, Idx>(arrays...)...};
-        }
-#endif // NVRTC_COMPILER
     };
 
     template <PlanePolicy PP = PlanePolicy::PROCESS_ALL, size_t BATCH = 1, typename Operation = TypeList<void>>
@@ -154,8 +156,8 @@ namespace fk {
     BatchRead<PP, BATCH, Operation>:
         Instantiable
         ParamsType = BatchReadParams<BATCH, PP, Operation::ParamsType>
-        Implements exec(const Point& thread, const OperationDataType& opData)
-        Implements exec(const Point& thread, const ParamsType& params)
+        Implements exec(const Point thread, const OperationDataType& opData)
+        Implements exec(const Point thread, const ParamsType& params)
         Implements build(const OperationDataType& opData)
         Implements build(const ParamsType& params)
     */
@@ -180,16 +182,16 @@ namespace fk {
         static constexpr bool IS_FUSED_OP = Operation::IS_FUSED_OP;
         static constexpr bool THREAD_FUSION = Operation::THREAD_FUSION;
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData[thread.z]);
         }
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
@@ -197,11 +199,11 @@ namespace fk {
         }
 
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE auto exec(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const OperationDataType& opData) {
             return exec<ELEMS_PER_THREAD>(thread, opData.params);
         }
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE auto exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const ParamsType& params) {
             if constexpr (THREAD_FUSION) {
                 return Operation::template exec<ELEMS_PER_THREAD>(thread, params.opData[thread.z]);
             } else {
@@ -237,16 +239,16 @@ namespace fk {
         static constexpr bool IS_FUSED_OP = Operation::IS_FUSED_OP;
         static constexpr bool THREAD_FUSION = false;
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData[thread.z]);
         }
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
@@ -254,11 +256,11 @@ namespace fk {
         }
 
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE auto exec(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const OperationDataType& opData) {
             return exec<ELEMS_PER_THREAD>(thread, opData.params);
         }
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE auto exec(const Point& thread, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const ParamsType& params) {
             if (params.usedPlanes <= thread.z) {
                 return params.default_value;
             } else {
@@ -302,16 +304,16 @@ namespace fk {
         static constexpr bool IS_FUSED_OP = Operation::IS_FUSED_OP;
         static constexpr bool THREAD_FUSION = Operation::THREAD_FUSION;
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData[thread.z]);
         }
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
@@ -350,16 +352,16 @@ namespace fk {
         static constexpr bool IS_FUSED_OP = Operation::IS_FUSED_OP;
         static constexpr bool THREAD_FUSION = false;
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_y(thread, opData.params.opData[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
             return BATCH;
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params.opData[thread.z]);
         }
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
@@ -398,31 +400,27 @@ namespace fk {
         FK_STATIC_STRUCT(BatchRead, SelfType)
         template <typename IOp, size_t BATCH>
         FK_HOST_FUSE auto build(const std::array<IOp, BATCH>& iOps) {
-            return build_helper(iOps, std::make_index_sequence<BATCH>{});
-        }
-    private:
-        template <typename IOp, size_t BATCH, size_t... Idx>
-        FK_HOST_FUSE auto build_helper(const std::array<IOp, BATCH>& iOps,
-                                       const std::index_sequence<Idx...>&) {
             using NewOperation = typename IOp::Operation;
-#ifdef NDEBUG
-            // Release mode. Use const variables and variadic template recursion for best performance
-            const uint max_width = cxp::max::f(NewOperation::num_elems_x(Point(0u, 0u, 0u), iOps[Idx])...);
-            const uint max_height = cxp::max::f(NewOperation::num_elems_y(Point(0u, 0u, 0u), iOps[Idx])...);
-#else
+
             // Debug mode. Loop to avoid stack overflow
-            uint max_width = NewOperation::num_elems_x(Point(0u, 0u, 0u), iOps[0]);
-            uint max_height = NewOperation::num_elems_y(Point(0u, 0u, 0u), iOps[0]);
-            for (int i = 1; i < BATCH; ++i) {
-                max_width = cxp::max::f(max_width, NewOperation::num_elems_x(Point(0u, 0u, 0u), iOps[i]));
-                max_height = cxp::max::f(max_height, NewOperation::num_elems_y(Point(0u, 0u, 0u), iOps[i]));
+            uint max_width{ 0 };
+            uint max_height{ 0 };
+            for (int i = 0; i < BATCH; ++i) {
+                max_width = cxp::max::f(max_width, NewOperation::num_elems_x(Point{0, 0, 0}, iOps[i]));
+                max_height = cxp::max::f(max_height, NewOperation::num_elems_y(Point{0, 0, 0}, iOps[i]));
             }
-#endif
             using BatchReadType = std::conditional_t<isCompleteOperation<NewOperation>,
-                                                        BatchRead<PlanePolicy::PROCESS_ALL, BATCH, NewOperation>,
-                                                        BatchRead<PlanePolicy::PROCESS_ALL, BATCH, TypeList<NewOperation>>>;
-            return BatchReadType::build( { {iOps[Idx]...},
-                                           ActiveThreads{ max_width, max_height, static_cast<uint>(BATCH) }});
+                BatchRead<PlanePolicy::PROCESS_ALL, BATCH, NewOperation>,
+                BatchRead<PlanePolicy::PROCESS_ALL, BATCH, TypeList<NewOperation>>>;
+            using ParamsStoreType = typename BatchReadType::ParamsType;
+
+            ParamsStoreType paramsStore{ {}, ActiveThreads{ max_width, max_height, static_cast<uint>(BATCH) } };
+
+            for (int i = 0; i < BATCH; ++i) {
+                paramsStore.opData[i] = iOps[i];
+            }
+
+            return BatchReadType::build(paramsStore);
         }
     };
 
@@ -434,23 +432,28 @@ namespace fk {
         FK_STATIC_STRUCT(BatchRead, SelfType)
         template <typename IOp, size_t BATCH, typename DefaultType, typename... ArrayTypes>
         FK_HOST_FUSE auto build(const std::array<IOp, BATCH>& iOps, const int& usedPlanes, const DefaultType& defaultValue) {
-            return build_helper(iOps, usedPlanes, defaultValue, std::make_index_sequence<BATCH>{});
-        }
-    private:
-        template <typename IOp, size_t BATCH, typename DefaultType, size_t... Idx>
-        FK_HOST_FUSE auto build_helper(const std::array<IOp, BATCH>& iOps,
-                                       const int& usedPlanes, const DefaultType& defaultValue,
-                                       const std::index_sequence<Idx...>&) {
             using NewOperation = typename IOp::Operation;
-            const uint max_width = cxp::max::f(NewOperation::num_elems_x(Point(0u, 0u, 0u), iOps[Idx])...);
-            const uint max_height = cxp::max::f(NewOperation::num_elems_y(Point(0u, 0u, 0u), iOps[Idx])...);
+
+            uint max_width{0};
+            uint max_height{0};
+            for (int i=0; i < BATCH; ++i) {
+                max_width = cxp::max::f(max_width, NewOperation::num_elems_x(Point{0, 0, 0}, iOps[i]));
+                max_height = cxp::max::f(max_height, NewOperation::num_elems_y(Point{0, 0, 0}, iOps[i]));
+            }
 
             using NewOutputType = std::conditional_t<std::is_same_v<typename NewOperation::OutputType, NullType>, DefaultType, typename NewOperation::OutputType>;
             using BatchReadType = std::conditional_t<isCompleteOperation<NewOperation>,
-                                                        BatchRead<PlanePolicy::CONDITIONAL_WITH_DEFAULT, BATCH, NewOperation>,
-                                                        BatchRead<PlanePolicy::CONDITIONAL_WITH_DEFAULT, BATCH, TypeList<NewOperation, NewOutputType>>>;
-            return BatchReadType::build( { {iOps[Idx]...}, usedPlanes, cxp::cast<NewOutputType>::f(defaultValue),
-                                           ActiveThreads{ max_width, max_height, static_cast<uint>(BATCH) }});
+                BatchRead<PlanePolicy::CONDITIONAL_WITH_DEFAULT, BATCH, NewOperation>,
+                BatchRead<PlanePolicy::CONDITIONAL_WITH_DEFAULT, BATCH, TypeList<NewOperation, NewOutputType>>>;
+            using ParamsStoreType = typename BatchReadType::ParamsType;
+            ParamsStoreType paramsStore{ {}, usedPlanes, cxp::cast<NewOutputType>::f(defaultValue),
+                                         ActiveThreads{max_width, max_height, static_cast<uint>(BATCH)} };
+
+            for (int i = 0; i < BATCH; ++i) {
+                paramsStore.opData[i] = iOps[i];
+            }
+
+            return BatchReadType::build(paramsStore);
         }
     };
     // ##################### END BATCH_READ #####################
@@ -469,8 +472,8 @@ namespace fk {
         DECLARE_WRITE_PARENT_BASIC
 
         template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread,
-            const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>& input,
+        FK_HOST_DEVICE_FUSE void exec(const Point thread,
+            const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> input,
             const ParamsType& params) {
             if constexpr (THREAD_FUSION) {
                 Operation::template exec<ELEMS_PER_THREAD>(thread, input, params[thread.z]);
@@ -478,21 +481,21 @@ namespace fk {
                 Operation::exec(thread, input, params[thread.z]);
             }
         }
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
             return Operation::num_elems_x(thread, opData.params[thread.z]);
         }
-        FK_HOST_DEVICE_FUSE uint pitch(const Point& thread, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
             return Operation::pitch(thread, opData.params[thread.z]);
         }
         // Build WriteBatch from array of IOps
         FK_HOST_FUSE InstantiableType build(const std::array<Instantiable<Operation>, BATCH>& iOps) {
-            return build_helper(iOps, std::make_index_sequence<BATCH>{});
-        }
-    private:
-        template <size_t... Idx>
-        FK_HOST_FUSE InstantiableType build_helper(const std::array<Instantiable<Operation>, BATCH>& iOps,
-                                                   const std::index_sequence<Idx...>&) {
-            return { {{(iOps[Idx].params)...}} };
+            InstantiableType iOp{};
+
+            for (int i = 0; i < BATCH; ++i) {
+                iOp.params[i] = iOps[i].params;
+            }
+
+            return iOp;
         }
     };
 
@@ -512,7 +515,7 @@ namespace fk {
 
 // BATCH BUILDERS FOR READ AND READBACK OPERATIONS
 #define DECLARE_PARENT_BATCH_BUILDER                                                                                   \
-   template <size_t B, typename... ArrayTypes>                                                                         \
+    template <size_t B, typename... ArrayTypes>                                                                         \
     FK_HOST_FUSE auto build_batch(const std::array<ArrayTypes, B>&... arrays) {                                        \
         return BatchUtils::template build_batch<typename Parent::Child>(arrays...);                                    \
     }
@@ -559,7 +562,7 @@ namespace fk {
   DECLARE_READBACK_PARENT_BASIC                                                                                        \
   DECLARE_PARENT_READBATCH_BUILDERS
 
-#define DECLARE_INCOMPLETEREADBACK_PARENT                                                                \
+#define DECLARE_INCOMPLETEREADBACK_PARENT                                                                              \
   DECLARE_INCOMPLETEREADBACK_PARENT_BASIC                                                                              \
   DECLARE_PARENT_READBATCH_BUILDERS
 

--- a/include/fused_kernel/core/execution_model/operation_model/fused_operation.h
+++ b/include/fused_kernel/core/execution_model/operation_model/fused_operation.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,399 +19,295 @@
 #include <fused_kernel/core/execution_model/operation_model/operation_tuple.h>
 
 namespace fk {
+ /*
+ * FusedOperation can be of the follwing types:
+ * - ReadType: if the first Op is ReadType and the last one is not WriteType.
+ * - WriteType: if the last Op is WriteType and the first one is not ReadType nor ReadBackType.
+ * - UnaryType: if all Ops are UnaryType.
+ * - BinaryType: if there is no ReadType, ReadBackType, WriteType nor MidWriteType, and not all Ops are UnaryType.
+ * - OpenType: if there is at least one MidWriteType, and no ReadType, ReadBackType nor WriteType.
+ * - ClosedType: if the first Op is ReadType or ReadBackType and the last Op is WriteType.
+ */
+
     // FusedOperation
-    namespace fused_operation_impl {
-        // FusedOperation implementation struct
-        template <typename Operation>
-        FK_HOST_DEVICE_CNST typename Operation::OutputType
-            exec_operate(const typename Operation::InputType& i_data) {
-            return Operation::exec(i_data);
-        }
-        template <typename Tuple_>
-        FK_HOST_DEVICE_CNST auto
-            exec_operate(const typename Tuple_::Operation::InputType& i_data, const Tuple_& tuple) {
-            using Operation = typename Tuple_::Operation;
-            static_assert(isComputeType<Operation>, "The operation is WriteType and shouldn't be.");
-            if constexpr (isUnaryType<Operation>) {
-                return Operation::exec(i_data);
-            } else {
-                return Operation::exec(i_data, tuple.instance);
-            }
-        }
-        template <typename Tuple_>
-        FK_HOST_DEVICE_CNST auto exec_operate(const Point& thread, const Tuple_& tuple) {
-            return Tuple_::Operation::exec(thread, tuple.instance);
-        }
-        template <typename Tuple_>
-        FK_HOST_DEVICE_CNST auto exec_operate(const Point& thread,
-            const typename Tuple_::Operation::InputType& i_data,
-            const Tuple_& tuple) {
-            using Operation = typename Tuple_::Operation;
-            if constexpr (isComputeType<Operation> && !isUnaryType<Operation>) {
-                return Operation::exec(i_data, tuple.instance);
-            } else if constexpr (isUnaryType<Operation>) {
-                return Operation::exec(i_data);
-            } else if constexpr (isWriteType<Operation>) {
-                // Assuming the behavior of a MidWriteType IOp
-                Operation::exec(thread, i_data, tuple.instance);
-                return i_data;
-            } else {
-                static_assert(isMidWriteType<Operation>, "The operation should be MidWriteType, and it's not.");
-                // We are executing another FusedOperation that is MidWriteType
-                return Operation::exec(thread, i_data, tuple.instance);
-            }
-        }
-
-        template <typename FirstOp, typename... RemOps>
-        FK_HOST_DEVICE_CNST auto tuple_operate(const typename FirstOp::InputType& i_data) {
-            if constexpr (sizeof...(RemOps) == 0) {
-                return FirstOp::exec(i_data);
-            } else {
-                return tuple_operate<RemOps...>(FirstOp::exec(i_data));
-            }
-        }
-
-        template <typename FirstOp, typename... RemOps>
-        FK_HOST_DEVICE_CNST auto tuple_operate(const typename FirstOp::InputType& i_data,
-            const OperationTuple<FirstOp, RemOps...>& tuple) {
-            const auto result = exec_operate(i_data, tuple);
-            if constexpr (sizeof...(RemOps) > 0) {
-                if constexpr (has_next_v<OperationTuple<FirstOp, RemOps...>>) {
-                    return tuple_operate(result, tuple.next);
-                } else {
-                    return tuple_operate<RemOps...>(result);
-                }
-            } else {
-                return result;
-            }
-        }
-        template <typename FirstOp, typename... RemOps>
-        FK_HOST_DEVICE_CNST auto tuple_operate(const Point& thread,
-            const typename FirstOp::InputType& input,
-            const OperationTuple<FirstOp, RemOps...>& tuple) {
-            const auto result = exec_operate(thread, input, tuple);
-            if constexpr (sizeof...(RemOps) > 0) {
-                if constexpr (has_next_v<OperationTuple<FirstOp, RemOps...>>) {
-                    return tuple_operate(thread, result, tuple.next);
-                } else {
-                    return tuple_operate<RemOps...>(result);
-                }
-            } else {
-                return result;
-            }
-        }
-        template <typename FirstOp, typename... RemOps>
-        FK_HOST_DEVICE_CNST auto tuple_operate(const Point& thread,
-            const OperationTuple<FirstOp, RemOps...>& tuple) {
-            const auto result = exec_operate(thread, tuple);
-            if constexpr (sizeof...(RemOps) > 0) {
-                if constexpr (has_next_v<OperationTuple<FirstOp, RemOps...>>) {
-                    return tuple_operate(thread, result, tuple.next);
-                } else {
-                    return tuple_operate<RemOps...>(result);
-                }
-            } else {
-                return result;
-            }
-        }
-    } // namespace fused_operation_impl
-
-    template <typename Enabler, typename... Operations>
-    struct FusedOperationOutputType;
-
-    template <typename Operation>
-    struct FusedOperationOutputType<std::enable_if_t<isWriteType<Operation>>, Operation> {
-        using type = typename Operation::InputType;
-    };
-
-    template <typename Operation>
-    struct FusedOperationOutputType<std::enable_if_t<!isWriteType<Operation>>, Operation> {
-        using type = typename Operation::OutputType;
-    };
-
-    template <typename... Operations>
-    using FOOT = typename FusedOperationOutputType<void, Operations...>::type;
-
     template <typename Enabler, typename... Operations>
     struct FusedOperation_;
 
-    template <typename FirstOp, typename... RemOps>
-    struct FusedOperation_<std::enable_if_t<allUnaryTypes<FirstOp, RemOps...> && (sizeof...(RemOps) + 1 > 1)>, FirstOp, RemOps...> {
+    // 1. OpenType Specialization
+    // Changed to use IOps... for consistency
+    template <typename... IOps>
+    struct FusedOperation_<std::enable_if_t<!isAnyReadType<FirstType_t<IOps...>> && 
+                                            !opIs<WriteType, LastType_t<IOps...>> && 
+                                            atLeastOneMidWriteType<IOps...>>,
+                           IOps...> {
     private:
-        using SelfType = FusedOperation_<std::enable_if_t<allUnaryTypes<FirstOp, RemOps...> && (sizeof...(RemOps) + 1 > 1)>, FirstOp, RemOps...>;
+        using SelfType = FusedOperation_<std::enable_if_t<!isAnyReadType<FirstType_t<IOps...>> && 
+                                                          !opIs<WriteType, LastType_t<IOps...>> && 
+                                                          atLeastOneMidWriteType<IOps...>>,
+                                         IOps...>;
+        
+        using Parent = OpenOperationParent<typename FirstType_t<IOps...>::Operation::InputType, 
+                                           OperationTuple<IOps...>,
+                                           typename LastType_t<IOps...>::Operation::OutputType, 
+                                           SelfType, true>;
     public:
         FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using Parent =
-            UnaryOperation<typename FirstOp::InputType,
-            typename LastType_t<RemOps...>::OutputType,
-            FusedOperation_<std::enable_if_t<allUnaryTypes<FirstOp, RemOps...> && (sizeof...(RemOps) + 1 > 1)>, FirstOp, RemOps...>,
-            true>;
-        DECLARE_UNARY_PARENT
-
-        using Operations = TypeList<FirstOp, RemOps...>;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
-            return fused_operation_impl::tuple_operate<FirstOp, RemOps...>(input);
+        DECLARE_OPEN_PARENT
+        using Operations = TypeList<IOps...>;
+        
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const InputType input, const ParamsType& params) {
+            return exec_helper(std::make_index_sequence<ParamsType::size>{}, thread, input, params);
+        }
+    private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE OutputType exec_helper(const std::index_sequence<Idx...>&,
+                                                   const Point thread,
+                                                   const InputType input,
+                                                   const ParamsType& params) {
+            return (InputFoldType<InputType>{thread, input} | ... | get_opt<Idx>(params)).input;
         }
     };
 
-    template <typename Operation>
-    struct FusedOperation_<std::enable_if_t<isUnaryType<Operation>>, Operation> {
+    // 2. ReadType Specialization
+    // Changed to use IOps... for consistency
+    template <typename... IOps>
+    struct FusedOperation_<
+        std::enable_if_t<isAnyReadType<FirstType_t<IOps...>> && !(opIs<WriteType, LastType_t<IOps...>>)>,
+        IOps...> {
     private:
-        using SelfType = FusedOperation_<std::enable_if_t<isUnaryType<Operation>>, Operation>;
+      using SelfType = FusedOperation_<
+        std::enable_if_t<isAnyReadType<FirstType_t<IOps...>> && !(opIs<WriteType, LastType_t<IOps...>>)>,
+        IOps...>;
+      
+      using FusedReadDataType = typename std::decay_t<FirstType_t<IOps...>>::Operation::ReadDataType;
+      using FusedOutputType = typename LastType_t<IOps...>::Operation::OutputType;
+
+      using Parent = ReadOperation<FusedReadDataType, OperationTuple<IOps...>, FusedOutputType, TF::DISABLED, SelfType, true>;
     public:
         FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using Parent =
-            UnaryOperation<typename Operation::InputType,
-            typename Operation::OutputType,
-            FusedOperation_<std::enable_if_t<isUnaryType<Operation>>, Operation>,
-            true>;
-        DECLARE_UNARY_PARENT
-
-        using Operations = TypeList<Operation>;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
-            return Operation::exec(input);
-        }
-    };
-
-    template <typename... Operations>
-    struct FusedOperation_<std::enable_if_t<isComputeType<FirstType_t<Operations...>> &&
-                           !allUnaryTypes<Operations...>>, Operations...> {
-    private:
-        using SelfType = FusedOperation_<std::enable_if_t<isComputeType<FirstType_t<Operations...>> &&
-                                         !allUnaryTypes<Operations...>>, Operations...>;
-    public:
-        FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using Parent =
-            BinaryOperation<typename FirstType_t<Operations...>::InputType,
-            OperationTuple<Operations...>,
-            FOOT<LastType_t<Operations...>>,
-            SelfType, true>;
-        DECLARE_BINARY_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input,
-                                            const ParamsType& params) {
-            return fused_operation_impl::tuple_operate(input, params);
-        }
-
-    };
-
-    template <typename... Operations>
-    struct FusedOperation_<std::enable_if_t<isAnyReadType<FirstType_t<Operations...>>>, Operations...> {
-    private:
-        static constexpr bool isTFEnabled = std::is_same_v<typename FirstType_t<Operations...>::ReadDataType, FOOT<LastType_t<Operations...>>> && ((sizeof...(Operations) > 1) ? false :
-            FirstType_t<Operations...>::THREAD_FUSION);
-        using SelfType = FusedOperation_<std::enable_if_t<isAnyReadType<FirstType_t<Operations...>>>, Operations...>;
-    public:
-        FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using Parent = ReadOperation<typename FirstType_t<Operations...>::ReadDataType,
-                                     OperationTuple<Operations...>,
-                                     FOOT<LastType_t<Operations...>>,
-                                     isTFEnabled ? TF::ENABLED : TF::DISABLED,
-                                     SelfType, true>;
         DECLARE_READ_PARENT
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread,
-                                            const ParamsType& params) {
-            return fused_operation_impl::tuple_operate(thread, params);
+        using Operations = TypeList<IOps...>;
+        
+        FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const ParamsType& params) {
+            return exec_helper(std::make_index_sequence<ParamsType::size>{}, thread, params);
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point& thread,
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread,
                                              const OperationDataType& opData) {
-            return ParamsType::Operation::num_elems_x(thread, opData.params.instance);
+            return FirstType_t<IOps...>::Operation::num_elems_x(thread, get_opt<0>(opData.params));
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point& thread,
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread,
                                              const OperationDataType& opData) {
-            return ParamsType::Operation::num_elems_y(thread, opData.params.instance);
+            return FirstType_t<IOps...>::Operation::num_elems_y(thread, get_opt<0>(opData.params));
         }
 
-        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point& thread,
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread,
                                              const OperationDataType& opData) {
-            return ParamsType::Operation::num_elems_z(thread, opData.params.instance);
+            return FirstType_t<IOps...>::Operation::num_elems_z(thread, get_opt<0>(opData.params));
         }
 
         FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
-            return { num_elems_x(Point(), opData), num_elems_y(Point(), opData), num_elems_z(Point(), opData) };
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
+        }
+
+    private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE OutputType exec_helper(const std::index_sequence<Idx...>&,
+                                                   const Point thread,
+                                                   const ParamsType& params) {
+            return (thread | ... | get_opt<Idx>(params)).input;
         }
     };
 
-    template <typename... Operations>
-    struct FusedOperation_<std::enable_if_t<isWriteType<FirstType_t<Operations...>>>, Operations...> {
-    private:
-        using SelfType = FusedOperation_<std::enable_if_t<isWriteType<FirstType_t<Operations...>>>, Operations...>;
-    public:
+    // 3. UnaryType Specialization
+    template <typename... IOps>
+    struct FusedOperation_<std::enable_if_t<allUnaryTypes<IOps...>>, IOps...> {
+      private:
+        using SelfType = FusedOperation_<std::enable_if_t<allUnaryTypes<IOps...>>, IOps...>;
+        using Parent = UnaryOperation<typename FirstType_t<IOps...>::Operation::InputType,
+                                      typename LastType_t<IOps...>::Operation::OutputType, SelfType, true>;
+      public:
         FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using ParamsType = OperationTuple<Operations...>;
-        using OutputType = FOOT<LastType_t<Operations...>>;
-        using InputType = typename FirstType_t<Operations...>::InputType;
-        using InstanceType = MidWriteType;
-        // THREAD_FUSION in this case will not be used in the current Transform implementation
-        // May be used in future implementations
-        static constexpr bool IS_FUSED_OP{ true };
-        static constexpr bool THREAD_FUSION{ false };
-        using WriteDataType = typename FirstType_t<Operations...>::WriteDataType;
-        using OperationDataType = OperationData<FusedOperation_<void, Operations...>>;
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const InputType& input,
-                                            const ParamsType& params) {
-            return fused_operation_impl::tuple_operate(thread, input, params);
+        DECLARE_UNARY_PARENT
+        using Operations = TypeList<IOps...>;
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return exec_helper(std::make_index_sequence<OperationTuple<IOps...>::size>{}, input);
         }
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const InputType& input,
-                                            const OperationDataType& opData) {
-            return exec(thread, input, opData.params);
-        }
-        using InstantiableType = MidWrite<FusedOperation_<void, Operations...>>;
-        FK_HOST_DEVICE_FUSE auto build(const OperationDataType& opData) {
-            return InstantiableType{ opData };
-        }
-        FK_HOST_DEVICE_FUSE auto build(const ParamsType& params) {
-            return InstantiableType{ { params } };
-        }
-        template <size_t BATCH_N, typename FirstType, typename... ArrayTypes>
-        FK_HOST_FUSE auto build_batch(const std::array<FirstType, BATCH_N>& firstInstance,
-            const ArrayTypes&... arrays) {
-            return BatchUtils::build_batch<SelfType>(firstInstance, arrays...);
-        }
-        template <size_t BATCH_N, typename FirstType, typename... ArrayTypes>
-        FK_HOST_FUSE auto build(const std::array<FirstType, BATCH_N>& firstInstance,
-            const ArrayTypes&... arrays) {
-            return BatchWrite<BATCH_N, SelfType>::build(firstInstance, arrays...);
+
+      private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE OutputType exec_helper(const std::index_sequence<Idx...>&, const InputType input) {
+            constexpr OperationTuple<IOps...> poTup{};
+            // Optimization, we use a version of operator| that does not use InputTypeFold,
+            // thus it does not propagate Point thread, because it is not needed.
+            return (input | ... | get_opt<Idx>(poTup));
         }
     };
 
-    template <typename... Operations>
-    struct FusedOperation_<std::enable_if_t<isMidWriteType<FirstType_t<Operations...>>>, Operations...> {
-    private:
-        using SelfType = FusedOperation_<std::enable_if_t<isMidWriteType<FirstType_t<Operations...>>>, Operations...>;
-    public:
+    // 4. ClosedType Specialization
+    template <typename... IOps>
+    struct FusedOperation_<std::enable_if_t<isAnyReadType<FirstType_t<IOps...>> && opIs<WriteType, LastType_t<IOps...>>>,
+                           IOps...> {
+      private:
+        using SelfType =
+            FusedOperation_<std::enable_if_t<isAnyReadType<FirstType_t<IOps...>> && opIs<WriteType, LastType_t<IOps...>>>, IOps...>;
+        using Parent = ClosedOperation<OperationTuple<IOps...>, SelfType, true>;
+
+      public:
         FK_STATIC_STRUCT(FusedOperation_, SelfType)
-        using ParamsType = OperationTuple<Operations...>;
-        using OutputType = FOOT<LastType_t<Operations...>>;
-        using InputType = typename FirstType_t<Operations...>::InputType;
-        using InstanceType = MidWriteType;
-        // THREAD_FUSION in this case will not be used in the current Transform implementation
-        // May be used in future implementations
-        static constexpr bool IS_FUSED_OP{ true };
-        static constexpr bool THREAD_FUSION{ false };
-        using WriteDataType = typename FirstType_t<Operations...>::WriteDataType;
-        using OperationDataType = OperationData<FusedOperation_<void, Operations...>>;
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const InputType& input,
-                                            const ParamsType& params) {
-            return fused_operation_impl::tuple_operate(thread, input, params);
+        DECLARE_CLOSED_PARENT
+        using Operations = TypeList<IOps...>;
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const ParamsType &params) {
+            exec_helper(std::make_index_sequence<ParamsType::size>{}, thread, params);
         }
-        FK_HOST_DEVICE_FUSE OutputType exec(const Point& thread, const InputType& input,
-                                            const OperationDataType& opData) {
-            return exec(thread, input, opData.params);
-        }
-        using InstantiableType = MidWrite<FusedOperation_<void, Operations...>>;
-        FK_HOST_DEVICE_FUSE auto build(const OperationDataType& opData) {
-            return InstantiableType{ opData };
-        }
-        FK_HOST_DEVICE_FUSE auto build(const ParamsType& params) {
-            return InstantiableType{ { params } };
-        }
-        template <size_t BATCH_N, typename FirstType, typename... ArrayTypes>
-        FK_HOST_FUSE auto build_batch(const std::array<FirstType, BATCH_N>& firstInstance,
-                                      const ArrayTypes&... arrays) {
-            return BatchUtils::build_batch<SelfType>(firstInstance, arrays...);
-        }
-        template <size_t BATCH_N, typename FirstType, typename... ArrayTypes>
-        FK_HOST_FUSE auto build(const std::array<FirstType, BATCH_N>& firstInstance,
-                                const ArrayTypes&... arrays) {
-            return BatchWrite<BATCH_N, SelfType>::build(firstInstance, arrays...);
+
+      private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE void exec_helper(const std::index_sequence<Idx...>&, const Point thread,
+                                             const ParamsType &params) {
+            LastType_t<typename ParamsType::Operations>::Operation::exec(thread,
+                (thread | ... | get_opt<Idx>(params)).input,
+                get_opt<sizeof...(Idx) - 1>(params));
         }
     };
 
-    template <typename... Operations>
-    using FusedOperation = FusedOperation_<void, Operations...>;
+    // 5. WriteType Specialization
+    template <typename... IOps>
+    struct FusedOperation_<std::enable_if_t<!isAnyReadType<FirstType_t<IOps...>> && opIs<WriteType, LastType_t<IOps...>>>,
+                           IOps...> {
+      private:
+        using SelfType =
+            FusedOperation_<std::enable_if_t<!isAnyReadType<FirstType_t<IOps...>> && opIs<WriteType, LastType_t<IOps...>>>,
+                            IOps...>;
+        using FusedInputType = typename FirstType_t<IOps...>::Operation::InputType;
+        using FusedWriteDataType = typename LastType_t<IOps...>::Operation::WriteDataType;
+        using Parent = WriteOperation<FusedInputType,
+            OperationTuple<IOps...>, FusedWriteDataType, TF::DISABLED, SelfType, true>;
 
-    template <typename FusedOperationType, typename = void>
-    struct IsAllUnaryFusedOperation : std::false_type {};
-
-    template <typename FusedOperationType>
-    struct IsAllUnaryFusedOperation<FusedOperationType, std::void_t<typename FusedOperationType::Operations>> : std::true_type {};
-
-    template <typename FusedOperationType, typename = void>
-    struct IsNotAllUnaryFusedOperation : std::true_type {};
-
-    template <typename FusedOperationType>
-    struct IsNotAllUnaryFusedOperation<FusedOperationType, std::void_t<typename FusedOperationType::Operations>> : std::false_type {};
-
-    template <typename FusedOperationType>
-    constexpr bool isAllUnaryFusedOperation = IsAllUnaryFusedOperation<FusedOperationType>::value;
-
-    template <typename FusedOperationType>
-    constexpr bool isNotAllUnaryFusedOperation = IsNotAllUnaryFusedOperation<FusedOperationType>::value;
-
-    template <typename IOp, typename Enabler = void>
-    struct InstantiableFusedOperationToOperationTuple {};
-
-    template <typename FusedIOp>
-    struct InstantiableFusedOperationToOperationTuple<FusedIOp, std::enable_if_t<isAllUnaryFusedOperation<typename FusedIOp::Operation>, void>> {
-    private:
-        using SelfType = InstantiableFusedOperationToOperationTuple<FusedIOp, std::enable_if_t<isAllUnaryFusedOperation<typename FusedIOp::Operation>, void>>;
-    public:
-        FK_STATIC_STRUCT(InstantiableFusedOperationToOperationTuple, SelfType)
-        FK_HOST_FUSE auto value(const FusedIOp& iOp) {
-            return TypeListToOT<typename FusedIOp::Operation::Operations>{};
+      public:
+        FK_STATIC_STRUCT(FusedOperation_, SelfType)
+        DECLARE_WRITE_PARENT
+        using Operations = TypeList<IOps...>;
+        FK_HOST_DEVICE_FUSE void exec(const Point thread, const InputType input, const ParamsType &params) {
+            exec_helper(std::make_index_sequence<ParamsType::size - 1>{}, thread, input, params);
         }
-    };
-    template <typename FusedIOp>
-    struct InstantiableFusedOperationToOperationTuple<FusedIOp, std::enable_if_t<isNotAllUnaryFusedOperation<typename FusedIOp::Operation>, void>> {
-    private:
-        using SelfType = InstantiableFusedOperationToOperationTuple<FusedIOp, std::enable_if_t<isNotAllUnaryFusedOperation<typename FusedIOp::Operation>, void>>;
-    public:
-        FK_STATIC_STRUCT(InstantiableFusedOperationToOperationTuple, SelfType)
-        FK_HOST_FUSE auto value(const FusedIOp& iOp) {
-            return iOp.params;
+
+      private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE void exec_helper(const std::index_sequence<Idx...> &, const Point thread,
+                                             const InputType input, const ParamsType &params) {
+            LastType_t<typename ParamsType::Operations>::Operation::exec(
+                thread, (InputFoldType<>::build(thread, input) | ... | get_opt<Idx>(params)).input,
+                get_opt<ParamsType::size - 1>(params));
         }
     };
 
-    template <typename OperationTupleType, typename Enabler = void>
-    struct OperationTupleToInstantiableOperation;
+    // 6. BinaryType (ComputeType) Specialization
+    template <typename... IOps>
+    struct FusedOperation_<std::enable_if_t<allComputeTypes<IOps...> && !allUnaryTypes<IOps...>>, IOps...> {
+      private:
+        using SelfType =
+            FusedOperation_<std::enable_if_t<allComputeTypes<IOps...> && !allUnaryTypes<IOps...>>, IOps...>;
+        using FusedInputType = typename FirstType_t<IOps...>::Operation::InputType;
+        using FusedOutputType = typename LastType_t<IOps...>::Operation::OutputType;
+        using Parent = BinaryOperation<FusedInputType, OperationTuple<IOps...>, FusedOutputType, SelfType, true>;
 
-    template <typename... Operations>
-    struct OperationTupleToInstantiableOperation<OperationTuple<Operations...>, std::enable_if_t<allUnaryTypes<Operations...>, void>> {
-    private:
-        using SelfType = OperationTupleToInstantiableOperation<OperationTuple<Operations...>, std::enable_if_t<allUnaryTypes<Operations...>, void>>;
-    public:
-        FK_STATIC_STRUCT(OperationTupleToInstantiableOperation, SelfType)
-        FK_HOST_FUSE auto value(const OperationTuple<Operations...>& opTuple) {
-            return Instantiable<FusedOperation<Operations...>>{};
+      public:
+        FK_STATIC_STRUCT(FusedOperation_, SelfType)
+        DECLARE_BINARY_PARENT
+        using Operations = TypeList<IOps...>;
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType &params) {
+            return exec_helper(std::make_index_sequence<ParamsType::size>{}, input, params);
+        }
+
+      private:
+        template <size_t... Idx>
+        FK_HOST_DEVICE_FUSE OutputType exec_helper(const std::index_sequence<Idx...>&,
+                                                   const InputType input, const ParamsType& params) {
+            // Optimization, we use a version of operator| that does not use InputTypeFold,
+            // thus it does not propagate Point thread, because it is not needed.
+            return (input | ... | get_opt<Idx>(params));
         }
     };
 
-    template <typename... Operations>
-    struct OperationTupleToInstantiableOperation<OperationTuple<Operations...>, std::enable_if_t<notAllUnaryTypes<Operations...>, void>> {
-    private:
-        using SelfType = OperationTupleToInstantiableOperation<OperationTuple<Operations...>, std::enable_if_t<notAllUnaryTypes<Operations...>, void>>;
-    public:
-        FK_STATIC_STRUCT(OperationTupleToInstantiableOperation, SelfType)
-        FK_HOST_FUSE auto value(const OperationTuple<Operations...>& opTuple) {
-            return Instantiable<FusedOperation<Operations...>>{opTuple};
+    // 7. Builder / Proxy Specialization
+    template <>
+    struct FusedOperation_<void> {
+      private:
+        template <typename T>
+        struct FuseProxy {
+            T iOp;
+
+            template <typename U>
+            FK_HOST_CNST FuseProxy(U &&u) : iOp(std::forward<U>(u)) {}
+
+            template <typename IOp1, typename IOp2>
+            FK_HOST_FUSE auto fuse(IOp1 &&iOp1, IOp2 &&iOp2) {
+                constexpr bool iOp1Fused = std::decay_t<IOp1>::Operation::IS_FUSED_OP;
+                constexpr bool iOp2Fused = std::decay_t<IOp2>::Operation::IS_FUSED_OP;
+                
+                if constexpr (iOp1Fused && iOp2Fused) {
+                    return FusedOperation_<void>::build(
+                        cat(get_params(std::forward<IOp1>(iOp1)), get_params(std::forward<IOp2>(iOp2))));
+                } else if constexpr (iOp1Fused) {
+                    return FusedOperation_<void>::build(
+                        cat(get_params(std::forward<IOp1>(iOp1)), make_new_operation_tuple(std::forward<IOp2>(iOp2))));
+                } else if constexpr (iOp2Fused) {
+                    return FusedOperation_<void>::build(
+                        cat(make_new_operation_tuple(std::forward<IOp1>(iOp1)), get_params(std::forward<IOp2>(iOp2))));
+                } else {
+                    return FusedOperation_<void>::build(make_new_operation_tuple(std::forward<IOp1>(iOp1), std::forward<IOp2>(iOp2)));
+                }
+            }
+
+            template <typename LeftIOp>
+            FK_HOST_CNST friend auto operator&&(const FuseProxy<LeftIOp>& left, const FuseProxy<T>& right) {
+                return FuseProxy<decltype(FuseProxy<T>::fuse(std::declval<LeftIOp>(), std::declval<T>()))>{
+                    FuseProxy<T>::fuse(left.iOp, right.iOp)
+                };
+            }
+
+            private:
+            template <typename... IOps>
+            FK_HOST_FUSE auto get_unary_params(const Unary<FusedOperation_<void, IOps...>>&)
+                -> OperationTuple<IOps...> {
+                return OperationTuple<IOps...>{};
+            }
+            template <typename IOp>
+            FK_HOST_FUSE decltype(auto) get_params(IOp&& iOp) {
+                if constexpr (opIs<UnaryType, std::decay_t<IOp>>) {
+                    return get_unary_params(std::forward<IOp>(iOp));
+                } else {
+                    return std::forward<IOp>(iOp).params;
+                }
+            }
+        };
+
+        template <typename... IOps>
+        FK_HOST_FUSE auto build_helper(const OperationTuple_<void, IOps...>& opTup) {
+            if constexpr (allUnaryTypes<IOps...>) {
+                return Unary<FusedOperation_<void, IOps...>>{};
+            } else {
+                return FusedOperation_<void, IOps...>::build(opTup);
+            }
+        }
+
+      public:
+        template <typename... IOps>
+        FK_HOST_FUSE auto build(IOps&&... iOps) {
+            if constexpr (and_v<isOperation<std::decay_t<IOps>>...>) {
+                return (... && FuseProxy<std::decay_t<IOps>>{std::forward<IOps>(iOps)}).iOp;
+            } else { 
+                static_assert(sizeof...(IOps) == 1,
+                              "If the argument is not an operation, it should be a single OperationTuple");
+                return build_helper(iOps...);
+            }
         }
     };
 
-    template <typename IOp>
-    FK_HOST_CNST auto iOpsToOperationTuple(const IOp& iOp) {
-        using Op = typename IOp::Operation;
-        if constexpr (is_fused_operation<Op>::value) {
-            return InstantiableFusedOperationToOperationTuple<IOp>::value(iOp);
-        } else if constexpr (hasParamsAndBackIOp_v<Op>) {
-            return OperationTuple<Op>{ {iOp.params, iOp.backIOp} };
-        } else if constexpr (hasParams_v<Op>) {
-            return OperationTuple<Op>{ {iOp.params} };
-        } else { // UnaryType case
-            return OperationTuple<Op>{};
-        }
-    }
-
-    template <typename IOp, typename... InstantiableOperations>
-    FK_HOST_CNST auto iOpsToOperationTuple(const IOp& iOp, const InstantiableOperations&... iOps) {
-        return cat(iOpsToOperationTuple(iOp), iOpsToOperationTuple(iOps...));
-    }
-
-    template <typename OperationTuple>
-    FK_HOST_CNST auto operationTupleToIOp(const OperationTuple& opTuple) {
-        return OperationTupleToInstantiableOperation<OperationTuple>::value(opTuple);
-    }
+    template <typename... IOps>
+    using FusedOperation = FusedOperation_<void, IOps...>;
     // END FusedOperation
 } // namespace fk
 

--- a/include/fused_kernel/core/execution_model/operation_model/instantiable_operations.h
+++ b/include/fused_kernel/core/execution_model/operation_model/instantiable_operations.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -59,12 +59,38 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
 
     struct Fuser;
 
+    template <typename InputType = void>
+    struct InputFoldType {
+        Point thread;
+        InputType input;
+
+        FK_HOST_DEVICE_CNST InputFoldType(const Point thread_, const InputType input_)
+            : thread(thread_), input(input_) {}
+    };
+
+    template <>
+    struct InputFoldType<void> {
+        template <typename InputT>
+        FK_HOST_DEVICE_FUSE auto build(const Point thread, InputT&& input) {
+            return InputFoldType<std::decay_t<InputT>>(thread, std::forward<InputT>(input));
+        }
+    };
+
     template <typename Operation_t>
     struct ReadInstantiableOperation final : public OperationData<Operation_t> {
         INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT_THEN(ReadType)
 
         FK_HOST_DEVICE_CNST ActiveThreads getActiveThreads() const {
             return Operation::getActiveThreads(*this);
+        }
+
+        FK_HOST_DEVICE_CNST friend auto operator|(const Point thread, const OperationData<Operation_t>& opData) {
+            return InputFoldType<>::build(thread, Operation::exec(thread, opData));
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const ReadInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
         }
     };
 
@@ -75,6 +101,15 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
         FK_HOST_DEVICE_CNST ActiveThreads getActiveThreads() const {
             return Operation::getActiveThreads(*this);
         }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const ReadBackInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
+
+        FK_HOST_DEVICE_CNST friend auto operator|(const Point thread, const OperationData<Operation_t>& opData) {
+            return InputFoldType<>::build(thread, Operation::exec(thread, opData));
+        }
     };
 
     template <typename Operation_t>
@@ -83,6 +118,11 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
 
         FK_HOST_DEVICE_CNST ActiveThreads getActiveThreads() const {
             return Operation::getActiveThreads(*this);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const IncompleteReadBackInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
         }
     };
 
@@ -94,11 +134,26 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
     * It can be composed of a single Operation or of a chain of Operations, in which case it wraps them into an
     * FusedOperation.
     * Expects Operation_t to have an static __device__ function member with the following parameters:
-    * OutputType exec(const InputType& input, const OperationData<Operation_t>& opDat)
+    * OutputType exec(const InputType input, const OperationData<Operation_t>& opDat)
     */
     template <typename Operation_t>
     struct BinaryInstantiableOperation final : public OperationData<Operation_t> {
         INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT_THEN(BinaryType)
+
+        template <typename Input>
+        FK_HOST_DEVICE_CNST friend auto operator|(Input&& input, const OperationData<Operation_t>& opData) {
+            return InputFoldType<>::build(std::forward<Input>(input).thread,
+                                          Operation::exec(std::forward<Input>(input).input, opData));
+        }
+        FK_HOST_DEVICE_CNST friend typename Operation::OutputType operator|(const typename Operation::InputType &input,
+                                                  const BinaryInstantiableOperation<Operation_t> &opData) {
+            return Operation::exec(input, opData.params);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const BinaryInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
     };
 
     /**
@@ -109,11 +164,28 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
     * Third parameter (back_function): it's a IOp that will be used at some point in the implementation of the
     * Operation. It can be any kind of IOp.
     * Expects Operation_t to have an static __device__ function member with the following parameters:
-    * OutputType exec(const InputType& input, const OperationData<Operation_t>& opData)
+    * OutputType exec(const InputType input, const OperationData<Operation_t>& opData)
     */
     template <typename Operation_t>
     struct TernaryInstantiableOperation final : public OperationData<Operation_t> {
         INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT_THEN(TernaryType)
+
+        template <typename Input>
+        FK_HOST_DEVICE_CNST friend auto operator|(Input&& input, const OperationData<Operation_t>& opData) {
+            return InputFoldType<>::build(std::forward<Input>(input).thread,
+                                          Operation::exec(std::forward<Input>(input).input, opData));
+        }
+        FK_HOST_DEVICE_CNST
+        friend typename Operation::OutputType operator|(const typename Operation::InputType &input,
+                                                        const TernaryInstantiableOperation<Operation_t> &opData) {
+            return Operation::exec(input, opData.params, opData.backIOp);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp,
+                                           const TernaryInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
     };
 
     /**
@@ -122,11 +194,29 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
     * It allows to execute the Operation (or chain of Unary Operations) on the input, and returns the result as output
     * in register memory.
     * Expects Operation_t to have an static __device__ function member with the following parameters:
-    * OutputType exec(const InputType& input)
+    * OutputType exec(const InputType input)
     */
     template <typename Operation_t>
     struct UnaryInstantiableOperation {
         INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT_THEN(UnaryType)
+
+        template <typename InputType>
+        FK_HOST_DEVICE_CNST friend auto operator|(const InputFoldType<InputType>& input,
+                                                  const UnaryInstantiableOperation<Operation_t>& opData) {
+            return InputFoldType<>::build(input.thread, Operation::exec(input.input));
+        }
+
+        FK_HOST_DEVICE_CNST friend typename Operation::OutputType operator|(
+                const typename Operation::InputType& input,
+                const UnaryInstantiableOperation<Operation_t> &opData) {
+            return Operation::exec(input);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp,
+                                           const UnaryInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
     };
 
     /**
@@ -143,6 +233,51 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
                 "Operation is not WriteType or MidWriteType");
 
         INSTANTIABLE_OPERATION_THEN
+
+        template <typename Input>
+        FK_HOST_DEVICE_CNST friend auto operator|(Input&& input, const OperationData<Operation_t>& opData) {
+            Operation::exec(std::forward<Input>(input).thread, std::forward<Input>(input).input, opData);
+            return std::forward<Input>(input);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const MidWriteInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
+    };
+
+    /**
+    * @brief OpenInstantiableOperation: represents a IOp that takes the result of the previous IOp as input
+    * (which will reside on GPU registers) and ParamsType, plus a Point thread.
+    */
+    template <typename Operation_t>
+    struct OpenInstantiableOperation final : public OperationData<Operation_t> {
+        INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT(OpenType)
+        INSTANTIABLE_OPERATION_THEN
+
+        template <typename Input>
+        FK_HOST_DEVICE_CNST friend auto operator|(Input&& input, const OperationData<Operation_t>& opData) {
+            return InputFoldType<>::build(input.thread, Operation::exec(std::forward<Input>(input).thread,
+                                                                        std::forward<Input>(input).input, opData));
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const OpenInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
+    };
+
+    /**
+     * @brief ClosedInstantiableOperation: represents a IOp that does not take an input and does not return an output
+     * It only gets a thread index and it's parameters. It will read and write from/to global memory.
+     */
+    template <typename Operation_t>
+    struct ClosedInstantiableOperation final : public OperationData<Operation_t> {
+        INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT(ClosedType)
+
+        FK_HOST_DEVICE_CNST friend void operator|(const Point thread, const OperationData<Operation_t>& opData) {
+            Operation::exec(thread, opData);
+        }
     };
 
     /**
@@ -154,6 +289,17 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
     template <typename Operation_t>
     struct WriteInstantiableOperation final : public OperationData<Operation_t> {
         INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT(WriteType)
+
+        template <typename Input>
+        FK_HOST_DEVICE_CNST friend auto operator|(Input &&input,
+                                                            const WriteInstantiableOperation<Operation_t> &self) {
+            return std::forward<Input>(input);
+        }
+
+        template <typename PreviousIOp, typename Fuser_t = Fuser>
+        FK_HOST_CNST friend auto operator&(PreviousIOp&& prevIOp, const WriteInstantiableOperation<Operation_t>& self) {
+            return Fuser_t::fuse(std::forward<PreviousIOp>(prevIOp), self);
+        }
     };
 
 #undef INSTANTIABLE_OPERATION_DETAILS_IS_ASSERT_THEN
@@ -174,6 +320,10 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
     template <typename Operation>
     using Ternary = TernaryInstantiableOperation<Operation>;
     template <typename Operation>
+    using Open = OpenInstantiableOperation<Operation>;
+    template <typename Operation>
+    using Closed = ClosedInstantiableOperation<Operation>;
+    template <typename Operation>
     using MidWrite = MidWriteInstantiableOperation<Operation>;
     template <typename Operation>
     using Write = WriteInstantiableOperation<Operation>;
@@ -183,37 +333,37 @@ FK_HOST_CNST auto then(const ContinuationIOp& cIOp, const ContinuationIOps&... c
 
     // Single Operation cases
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isReadType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<ReadType, Operation>>> {
         using type = Read<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isReadBackType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<ReadBackType, Operation>>> {
         using type = ReadBack<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isIncompleteReadBackType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<IncompleteReadBackType, Operation>>> {
         using type = IncompleteReadBack<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isUnaryType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<UnaryType, Operation>>> {
         using type = Unary<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isBinaryType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<BinaryType, Operation>>> {
         using type = Binary<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isTernaryType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<TernaryType, Operation>>> {
         using type = Ternary<Operation>;
     };
 
     template <typename Operation>
-    struct InstantiableOperationType<Operation, std::enable_if_t<isWriteType<Operation>>> {
+    struct InstantiableOperationType<Operation, std::enable_if_t<opIs<WriteType, Operation>>> {
         using type = Write<Operation>;
     };
 

--- a/include/fused_kernel/core/execution_model/operation_model/iop_fuser.h
+++ b/include/fused_kernel/core/execution_model/operation_model/iop_fuser.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,34 +20,14 @@
 namespace fk {
 
     struct Fuser {
-        template <typename FirstIOp, typename SecondIOp>
-        FK_HOST_FUSE auto fuse(const FirstIOp& firstIOp, const SecondIOp& secondIOp) {
-            return fuseAllIOps(firstIOp, secondIOp);
-        }
-
-        template <typename FirstIOp, typename SecondIOp, typename... RestIOps>
-        FK_HOST_FUSE auto fuse(const FirstIOp& firstIOp, const SecondIOp& secondIOp, const RestIOps&... restIOps) {
-            return fuse(fuse(firstIOp, secondIOp), restIOps...);
-        }
-    private:
-        /** @brief fuseIOps: function that creates either a Read or a Binary IOp, composed of a
-        * FusedOperation, where the operations are the ones found in the InstantiableOperations in the
-        * iOps parameter pack.
-        * This is a convenience function to simplify the implementation of ReadBack and Ternary InstantiableOperations
-        * and Operations.
-        */
-        template <typename... InstantiableOperations>
-        FK_HOST_FUSE auto fuseNonBatchForwardIOps(const InstantiableOperations&... iOps) {
-            return operationTupleToIOp(iOpsToOperationTuple(iOps...));
-        }
-
         template <typename SelfType, typename ContinuationIOp>
-        FK_HOST_FUSE auto fuseAllIOps(const SelfType& selfIOp, const ContinuationIOp& cIOp) {
+        FK_HOST_FUSE auto fuse(const SelfType& selfIOp, const ContinuationIOp& cIOp) {
+            static_assert(isOperation<SelfType> && isOperation<ContinuationIOp>, "SelfType and ContinuationIOp should be IOps");
             using Operation = typename SelfType::Operation;
             if constexpr (isBatchOperation<Operation> && isBatchOperation<typename ContinuationIOp::Operation>) {
                 static_assert(Operation::BATCH == ContinuationIOp::Operation::BATCH,
                     "Fusing two batch operations of different BATCH size is not allowed.");
-                static_assert(isIncompleteReadBackType<typename ContinuationIOp::Operation::Operation>,
+                static_assert(opIs<IncompleteReadBackType, typename ContinuationIOp::Operation::Operation>,
                     "Read or ReadBack Operation as continuation is not allowed. It has to be an IncompleteReadBackOperation.");
                 const auto backOpArray = BatchUtils::toArray(selfIOp);
                 const auto forwardOpArray = BatchUtils::toArray(cIOp);
@@ -63,8 +43,7 @@ namespace fk {
                     static_assert((Operation::PP == PlanePolicy::CONDITIONAL_WITH_DEFAULT && ContinuationIOp::Operation::PP == PlanePolicy::PROCESS_ALL), "We should not be here");
                     using BackType = std::decay_t<decltype(backOpArray)>;
                     using ForType = std::decay_t<decltype(forwardOpArray)>;
-                    constexpr size_t BATCH = static_cast<size_t>(ContinuationIOp::Operation::BATCH);
-                    using FusedType = typename decltype(make_fusedArray(std::declval<std::make_index_sequence<BATCH>>(), std::declval<BackType>(), std::declval<ForType>()))::value_type;
+                    using FusedType = typename decltype(make_fusedArray(std::declval<BackType>(), std::declval<ForType>()))::value_type;
                     using DefaultValueType = typename FusedType::Operation::OutputType;
                     if constexpr (std::is_same_v<typename Operation::OutputType, DefaultValueType>) {
                         return BuilderType::build(selfIOp.params.usedPlanes, selfIOp.params.default_value, backOpArray, forwardOpArray);
@@ -75,7 +54,7 @@ namespace fk {
                     }
                 }
             } else if constexpr (!isBatchOperation<Operation> && isBatchOperation<typename ContinuationIOp::Operation>) {
-                static_assert(isIncompleteReadBackType<typename ContinuationIOp::Operation::Operation>,
+                static_assert(opIs<IncompleteReadBackType, typename ContinuationIOp::Operation::Operation>,
                     "ReadOperation as continuation is not allowed. It has to be a ReadBackOperation.");
                 constexpr size_t BATCH = static_cast<size_t>(ContinuationIOp::Operation::BATCH);
                 const auto backOpArray = make_set_std_array<BATCH>(selfIOp);
@@ -87,17 +66,17 @@ namespace fk {
                     return BuilderType::build(backOpArray, forwardOpArray);
                 }
             } else if constexpr (isBatchOperation<Operation> && !isBatchOperation<typename ContinuationIOp::Operation>) {
-                static_assert(!isAnyReadType<ContinuationIOp> || isIncompleteReadBackType<ContinuationIOp>,
+                static_assert(!isAnyReadType<ContinuationIOp> || opIs<IncompleteReadBackType, ContinuationIOp>,
                     "ReadOperation as continuation is not allowed. It has to be a ReadBackOperation.");
                 constexpr size_t BATCH = static_cast<size_t>(Operation::BATCH);
-                if constexpr (isIncompleteReadBackType<ContinuationIOp>) {
+                if constexpr (opIs<IncompleteReadBackType, ContinuationIOp>) {
                     const auto backOpArray = BatchUtils::toArray(selfIOp);
                     const auto forwardOpArray = make_set_std_array<BATCH>(cIOp);
                     using BuilderType = typename ContinuationIOp::Operation;
                     if constexpr (Operation::PP == PlanePolicy::CONDITIONAL_WITH_DEFAULT) {
                         using BackType = std::decay_t<decltype(backOpArray)>;
                         using ForType = std::decay_t<decltype(forwardOpArray)>;
-                        using FusedType = typename decltype(make_fusedArray<BATCH>(std::declval<std::make_index_sequence<BATCH>>(), std::declval<BackType>(), std::declval<ForType>()))::value_type;
+                        using FusedType = typename decltype(make_fusedArray<BATCH>(std::declval<BackType>(), std::declval<ForType>()))::value_type;
                         using DefaultValueType = typename FusedType::Operation::OutputType;
                         if constexpr (std::is_same_v<typename Operation::OutputType, DefaultValueType>) {
                             return BuilderType::build(selfIOp.params.usedPlanes, selfIOp.params.default_value, backOpArray, forwardOpArray);
@@ -112,39 +91,105 @@ namespace fk {
                 } else {
                     const auto backOpArray = BatchUtils::toArray(selfIOp);
                     const auto forwardOpArray = make_set_std_array<BATCH>(cIOp);
-                    const auto iOpsArray = make_fusedArray(std::make_index_sequence<BATCH>{}, backOpArray, forwardOpArray);
+                    const auto iOpsArray = make_fusedArray(backOpArray, forwardOpArray);
                     using BuilderType = typename decltype(iOpsArray)::value_type::Operation;
                     return BuilderType::build(iOpsArray);
                 }
             } else if constexpr (!isBatchOperation<Operation> && !isBatchOperation<typename ContinuationIOp::Operation>) {
                 static_assert(!isAnyCompleteReadType<ContinuationIOp>,
                     "Complete Read Operations as continuations are not allowed. It has to be an IncompleteReadBackOperation.");
-                if constexpr (isIncompleteReadBackType<ContinuationIOp>) {
+                if constexpr (opIs<IncompleteReadBackType, ContinuationIOp>) {
                     using BuilderType = typename ContinuationIOp::Operation;
                     return BuilderType::build(selfIOp, cIOp);
                 } else {
-                    return fuseNonBatchForwardIOps(selfIOp, cIOp);
+                    return FusedOperation<>::build(selfIOp, cIOp);
                 }
             }
         }
-
-        template <size_t BATCH, size_t... Idx, typename ThisIOp, typename ForwardIOp>
-        FK_HOST_FUSE auto make_fusedArray(const std::index_sequence<Idx...>&, const std::array<ThisIOp, BATCH>& thisArray,
-                                                                              const std::array<ForwardIOp, BATCH>& fwdArray) {
-            if constexpr (isIncompleteReadBackType<ForwardIOp>) {
+        private:
+        template <size_t BATCH, typename ThisIOp, typename ForwardIOp>
+        FK_HOST_FUSE auto make_fusedArray(const std::array<ThisIOp, BATCH>& thisArray,
+                                          const std::array<ForwardIOp, BATCH>& fwdArray) {
+            if constexpr (opIs<IncompleteReadBackType, ForwardIOp>) {
                 using BuilderType = typename ForwardIOp::Operation;
                 using ResultingType = decltype(BuilderType::build(std::declval<ThisIOp>(), std::declval<ForwardIOp>()));
-                return std::array<ResultingType, BATCH>{ BuilderType::build(thisArray[Idx], fwdArray[Idx])... };
+                std::array<ResultingType, BATCH> resultArray{};
+                for (size_t i = 0; i < BATCH; ++i) {
+                    resultArray[i] = BuilderType::build(thisArray[i], fwdArray[i]);
+                }
+                return resultArray;
             } else {
-                using ResultingType = decltype(fuseNonBatchForwardIOps(std::declval<ThisIOp>(), std::declval<ForwardIOp>()));
-                return std::array<ResultingType, BATCH>{fuseNonBatchForwardIOps(thisArray[Idx], fwdArray[Idx])...};
+                using ResultingType = decltype(FusedOperation<>::build(std::declval<ThisIOp>(), std::declval<ForwardIOp>()));
+                std::array<ResultingType, BATCH> resultArray{};
+                for (size_t i = 0; i < BATCH; ++i) {
+                    resultArray[i] = FusedOperation<>::build(thisArray[i], fwdArray[i]);
+                }
+                return resultArray;
             }
         }
     };
 
-    template <typename... IOps>
-    FK_HOST_CNST auto fuse(const IOps&... iOps) {
-        return Fuser::fuse(iOps...);
+    template <typename FirstIOp, typename... IOps>
+    FK_HOST_CNST decltype(auto) fuse(FirstIOp&& firstIOp, IOps&&... iOps) {
+        return (std::forward<FirstIOp>(firstIOp) & ... & std::forward<IOps>(iOps));
     }
+
+    struct BackFuser {
+      protected:
+        template <typename... IOps>
+        FK_HOST_FUSE size_t idxFirstNonBack() {
+            size_t index = 0;
+            size_t result = 0;
+
+            // Iterate through every type in Ts...
+            // The comma operator ensures left-to-right evaluation.
+            ((index++, // Increment index for every type (1-based)
+              (opIs<ReadBackType, IOps> || opIs<IncompleteReadBackType, IOps>) 
+                  ? result = index // If it's a Back type, update the result
+                  : 0              // Otherwise do nothing
+             ), ...);
+
+            return result;
+        }
+
+        template <typename T, size_t... Is>
+        FK_HOST_FUSE auto get_head(T&& t, const std::index_sequence<Is...>&) {
+            // Forward the specific elements to your function
+            return fuse(get<Is>(std::forward<T>(t))...);
+        }
+
+        // Helper to unpack the Tail (indices split_idx to End)
+        // Creates a new tuple starting from Offset
+        template <size_t Offset, typename T, size_t... Is>
+        FK_HOST_FUSE auto get_tail(T&& t, const std::index_sequence<Is...>&) {
+            // Apply Offset to grab the correct elements from the end of the tuple
+            return make_tuple(get<Offset + Is>(std::forward<T>(t))...);
+        }
+
+      public:
+        template <typename... IOps>
+        FK_HOST_FUSE auto fuse_back(IOps&&... iOps) {
+            // 1. Calculate the split point at compile time
+            constexpr size_t split_idx = idxFirstNonBack<std::decay_t<IOps>...>();
+            if constexpr (split_idx < 2) {
+                return forward_as_tuple(std::forward<IOps>(iOps)...);
+            } else {
+                constexpr size_t total_size = sizeof...(IOps);
+
+                // 2. Pack arguments into a tuple so we can access them by index
+                //    Using a reference tuple prevents unnecessary copies.
+                auto full_tuple = forward_as_tuple(std::forward<IOps>(iOps)...);
+
+                // 3. Execute the split
+                //    Head: sequence 0..split_idx
+                //    Tail: sequence 0..(total - split_idx)
+                auto new_element = get_head(full_tuple, std::make_index_sequence<split_idx>{});
+                auto tail_tuple = get_tail<split_idx>(full_tuple, std::make_index_sequence<total_size - split_idx>{});
+
+                // 4. Concatenate the result
+                return tuple_cat(make_tuple(new_element), tail_tuple);
+            }
+        }
+    };
 } // namespace fk
 #endif // IOP_FUSER_CUH

--- a/include/fused_kernel/core/execution_model/operation_model/operation_data.h
+++ b/include/fused_kernel/core/execution_model/operation_model/operation_data.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_OPERATION_DATA_CUH
-#define FK_OPERATION_DATA_CUH
+#ifndef FK_OPERATION_DATA_H
+#define FK_OPERATION_DATA_H
 
 #include <type_traits>
 #include <fused_kernel/core/execution_model/operation_model/operation_types.h>
@@ -79,94 +79,23 @@ namespace fk {
     template <typename Operation, typename Enabler = void>
     struct OperationData;
 
-#if !defined(COPYABLE_IOPS)
-    using ParamsTypes = TypeList<BinaryType, ReadType, WriteType, MidWriteType>;
+    using ParamsTypes = TypeList<BinaryType, ReadType, WriteType, MidWriteType, OpenType, ClosedType>;
     using ParamsAndBackIOpTypes = TypeList<ReadBackType, IncompleteReadBackType, TernaryType>;
 
     template <typename Operation>
     struct OperationData<Operation, std::enable_if_t<one_of_v<typename Operation::InstanceType, ParamsTypes>>> {
-        typename Operation::ParamsType params;
+        FK_HOST_DEVICE_CNST OperationData() {};
+        FK_HOST_DEVICE_CNST OperationData(const typename Operation::ParamsType &params_) : params(params_) {}
+        typename Operation::ParamsType params{};
     };
 
     template <typename Operation>
     struct OperationData<Operation, std::enable_if_t<one_of_v<typename Operation::InstanceType, ParamsAndBackIOpTypes>>> {
-        typename Operation::ParamsType params;
-        typename Operation::BackIOp backIOp;
-    };
-#else
-    template <typename Operation>
-    struct OperationData<Operation, std::enable_if_t<hasParamsNoArray<Operation>&& hasNoBackIOp_v<Operation>, void>> {
-
         FK_HOST_DEVICE_CNST OperationData() {};
-        FK_HOST_DEVICE_CNST OperationData(const typename Operation::ParamsType& params_) : params(params_) {}
-
-        typename Operation::ParamsType params;
+        FK_HOST_DEVICE_CNST OperationData(const typename Operation::ParamsType& params_, const typename Operation::BackIOp& backIOp_) : params(params_), backIOp(backIOp_) {}
+        typename Operation::ParamsType params{};
+        typename Operation::BackIOp backIOp{};
     };
-
-    template <typename Operation>
-    struct OperationData<Operation, std::enable_if_t<hasParamsArray<Operation>&& hasNoBackIOp_v<Operation>, void>> {
-        FK_HOST_DEVICE_CNST OperationData() {};
-        __host__ __forceinline__ OperationData(const typename Operation::ParamsType& params_) {
-            std::copy(std::begin(params_), std::end(params_), std::begin(params));
-        }
-        __host__ __forceinline__ OperationData<Operation>& operator=(const OperationData<Operation>& other) {
-            if (this != &other) {
-                std::copy(std::begin(other.params), std::end(other.params), std::begin(params));
-            }
-            return *this;
-        }
-        typename Operation::ParamsType params;
-    };
-
-    template <typename Operation>
-    struct OperationData<Operation, std::enable_if_t<hasParamsAndBackIOp_v<Operation> &&
-        !std::is_array_v<typename Operation::ParamsType> &&
-        !std::is_array_v<typename Operation::BackIOp>, void>> {
-        FK_HOST_DEVICE_CNST OperationData() {};
-        FK_HOST_DEVICE_CNST OperationData(const typename Operation::ParamsType& params_,
-            const typename Operation::BackIOp& backIOp_) :
-            params(params_), backIOp(backIOp_) {}
-        typename Operation::ParamsType params;
-        typename Operation::BackIOp backIOp;
-    };
-
-    template <typename Operation>
-    struct OperationData<Operation, std::enable_if_t<hasParamsAndBackIOp_v<Operation> &&
-        (std::is_array_v<typename Operation::ParamsType> ||
-            std::is_array_v<typename Operation::BackIOp>), void>> {
-        __host__ __forceinline__ OperationData() {};
-        __host__ __forceinline__ OperationData(const typename Operation::ParamsType& params_,
-            const typename Operation::BackIOp& backIOp_) {
-            if constexpr (std::is_array_v<typename Operation::ParamsType>) {
-                std::copy(std::begin(params_), std::end(params_), std::begin(params));
-            } else {
-                params = params_;
-            }
-            if constexpr (std::is_array_v<typename Operation::BackIOp>) {
-                std::copy(std::begin(backIOp_), std::end(backIOp_), std::begin(backIOp));
-            } else {
-                backIOp = backIOp_;
-            }
-        }
-        __host__ __forceinline__ OperationData<Operation>& operator=(const OperationData<Operation>& other) {
-            if (this != &other) {
-                if constexpr (std::is_array_v<typename Operation::ParamsType>) {
-                    std::copy(std::begin(other.params), std::end(other.params), std::begin(params));
-                } else {
-                    params = other.params;
-                }
-                if constexpr (std::is_array_v<typename Operation::BackIOp>) {
-                    std::copy(std::begin(other.backIOp), std::end(other.backIOp), std::begin(backIOp));
-                } else {
-                    backIOp = other.backIOp;
-                }
-            }
-            return *this;
-        }
-        typename Operation::ParamsType params;
-        typename Operation::BackIOp backIOp;
-    };
-#endif
 } // namespace fk
 
-#endif
+#endif // FK_OPERATION_DATA_H

--- a/include/fused_kernel/core/execution_model/operation_model/operation_tuple.h
+++ b/include/fused_kernel/core/execution_model/operation_model/operation_tuple.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,190 +19,133 @@
 #include <fused_kernel/core/execution_model/operation_model/operation_data.h>
 
 namespace fk {
+    struct NotIsUnaryRestriction {
+        template <typename Type>
+        FK_HOST_DEVICE_FUSE bool complies() {
+            return !opIs<UnaryType, Type>;
+        }
+    };
+
+    template <typename IndexSequence, typename... Operations>
+    struct FilteredOps;
+
+    template <size_t... Idx, typename... Operations>
+    struct FilteredOps<std::index_sequence<Idx...>, Operations...> {
+        using type = Tuple<TypeAt_t<Idx, TypeList<Operations...>>...>;
+    };
+
+    template <typename... Operations>
+    using FilteredOperations = typename FilteredOps<filtered_index_sequence_t<NotIsUnaryRestriction, TypeList<std::decay_t<Operations>...>>, Operations...>::type;
+
     template <typename Enabler, typename... Operations>
     struct OperationTuple_;
 
-    template <typename Operation_t, typename... Operations>
-    struct OperationTuple_<std::enable_if_t<!isUnaryType<Operation_t> &&
-                                            (sizeof...(Operations) > 0), void>, Operation_t, Operations...> {
-        using Operation = Operation_t;
-        using Next = OperationTuple_<void, Operations...>;
-        OperationData<Operation> instance;
-        OperationTuple_<void, Operations...> next;
-        enum { size = sizeof...(Operations) + 1 };
+    template <typename... Operations_>
+    struct OperationTuple_<std::enable_if_t<!allUnaryTypes<Operations_...>, void>, Operations_...> {
+        using Operations = TypeList<std::decay_t<Operations_>...>;
+        using Indexes = filtered_index_sequence_t<NotIsUnaryRestriction, Operations>;
+        using InstancesType = FilteredOperations<Operations_...>;
+        static constexpr size_t size{sizeof...(Operations_)};
+        InstancesType instances{};
     };
 
-    template <typename Operation_t, typename... Operations>
-    struct OperationTuple_<std::enable_if_t<isUnaryType<Operation_t> &&
-                                            !allUnaryTypes<Operations...> &&
-                                            (sizeof...(Operations) > 0), void>, Operation_t, Operations...> {
-        using Operation = Operation_t;
-        using Next = OperationTuple_<void, Operations...>;
-        OperationTuple_<void, Operations...> next;
-        enum { size = sizeof...(Operations) + 1 };
-    };
-
-    template <typename Operation_t, typename... Operations>
-    struct OperationTuple_<std::enable_if_t<allUnaryTypes<Operation_t, Operations...> &&
-                                            (sizeof...(Operations) > 0), void>, Operation_t, Operations...> {
-        using Operation = Operation_t;
-        using Next = OperationTuple_<void, Operations...>;
-        enum { size = sizeof...(Operations) + 1 };
-    };
-
-    template <typename Operation_t>
-    struct OperationTuple_<std::enable_if_t<!isUnaryType<Operation_t>, void>, Operation_t> {
-        using Operation = Operation_t;
-        OperationData<Operation> instance;
-        enum { size = 1 };
-    };
-
-    template <typename Operation_t>
-    struct OperationTuple_<std::enable_if_t<isUnaryType<Operation_t>, void>, Operation_t> {
-        using Operation = Operation_t;
-        enum { size = 1 };
+    template <typename... Operations_>
+    struct OperationTuple_<std::enable_if_t<allUnaryTypes<Operations_...>, void>, Operations_...> {
+        using Operations = TypeList<std::decay_t<Operations_>...>;
+        using Indexes = filtered_index_sequence_t<NotIsUnaryRestriction, Operations>;
+        static constexpr size_t size{ sizeof...(Operations_) };
     };
 
     template <typename... Operations>
     using OperationTuple = OperationTuple_<void, Operations...>;
 
-    template <typename... Operations>
-    FK_HOST_DEVICE_CNST bool allOpTupleUnary_f(const OperationTuple<Operations...>& opTup) {
-        return allUnaryTypes<Operations...>;
-    }
+     // Primary template: defaults to false
+    template <typename T>
+    struct IsOpTuple : std::false_type {};
 
-    template <typename OpTuple>
-    constexpr bool allOpTupleUnary = allOpTupleUnary_f(OpTuple{});
-
-    template <int INDEX, typename... Instances>
-    struct GetType<INDEX, OperationTuple_<void, Instances...>> {
-        using type = TypeAt_t<INDEX, TypeList<Instances...>>;
-    };
-
-    template <typename... Operations, typename... OperationDatas>
-    FK_HOST_DEVICE_CNST OperationTuple<Operations...> make_operation_tuple_(const OperationDatas&... instances) {
-        return OperationTuple<Operations...>{instances...};
-    }
-
-    template <int INDEX, typename... InstanceTypes>
-    FK_HOST_DEVICE_CNST auto& get(OperationTuple<InstanceTypes...>& instances) {
-        using Operation = typename OperationTuple<InstanceTypes...>::Operation;
-        constexpr int numberOfInstances = OperationTuple<InstanceTypes...>::size;
-        static_assert(INDEX < numberOfInstances, "Index out of range. There are not so many instances in the tuple.");
-        if constexpr (INDEX > 0) {
-            return get<INDEX - 1>(instances.next);
-        } else if constexpr (INDEX == -1) {
-            if constexpr (numberOfInstances > 0) {
-                return get<numberOfInstances - 1>(instances.next);
-            } else {
-                static_assert(hasParams_v<Operation>, "This is an Unary operation, and it does not have params.");
-                return instances.instance;
-            }
-        } else {
-            static_assert(hasParams_v<Operation>, "This is an Unary operation, and it does not have params.");
-            return instances.instance;
-        }
-    }
-
-    template <int INDEX, typename... InstanceTypes>
-    FK_HOST_DEVICE_CNST auto get(const OperationTuple<InstanceTypes...>& instances) {
-        using Operation = typename OperationTuple<InstanceTypes...>::Operation;
-        constexpr int numberOfInstances = OperationTuple<InstanceTypes...>::size;
-        static_assert(INDEX < numberOfInstances, "Index out of range. There are not so many instances in the tuple.");
-        if constexpr (INDEX > 0) {
-            return get<INDEX - 1>(instances.next);
-        } else if constexpr (INDEX == -1) {
-            if constexpr (numberOfInstances > 0) {
-                return get<numberOfInstances - 1>(instances.next);
-            } else {
-                static_assert(hasParams_v<Operation>, "This is an Unary operation, and it does not have params.");
-                return instances.instance;
-            }
-        } else {
-            static_assert(hasParams_v<Operation>, "This is an Unary operation, and it does not have params.");
-            return instances.instance;
-        }
-    }
-
-    template <typename TupleType>
-    struct OperationTupleTypeToTypeList;
-
+    // Partial specialization: matches any specialization of Tuple
     template <typename... Types>
-    struct OperationTupleTypeToTypeList<OperationTuple<Types...>> {
-        using type = TypeList<Types...>;
+    struct IsOpTuple<OperationTuple_<void, Types...>> : std::true_type {};
+
+    template <typename TypeToTest>
+    constexpr bool isOpTuple_v = IsOpTuple<std::decay_t<TypeToTest>>::value;
+
+    template <typename IndexSeq, size_t IdxValue>
+    struct GetIndex;
+
+    template <typename IndexSeq, typename IndexSeqOut, size_t IdxValue>
+    struct GetIndexHelper;
+
+    template <size_t... Idx, size_t... IdxOut, size_t IdxValue>
+    struct  GetIndexHelper<std::index_sequence<Idx...>, std::index_sequence<IdxOut...>, IdxValue> {
+        static constexpr size_t value = []() {
+            size_t result = 0;
+            ((result = (Idx == IdxValue ? IdxOut : result)), ...);
+            return result;
+            }();
     };
 
-    template <typename TupleType>
-    using OTToTypeList = typename OperationTupleTypeToTypeList<TupleType>::type;
-
-    template <typename TypeList_t>
-    struct TypeListToOperationTuple;
-
-    template <typename... Operations>
-    struct TypeListToOperationTuple<TypeList<Operations...>> {
-        using type = OperationTuple<Operations...>;
+    template <size_t... Idx, size_t IdxValue>
+    struct GetIndex<std::index_sequence<Idx...>, IdxValue> {
+        static constexpr size_t value = GetIndexHelper<std::index_sequence<Idx...>,
+            decltype(std::make_index_sequence<sizeof...(Idx)>()), IdxValue>::value;
     };
 
-    template <typename TypeList_t>
-    using TypeListToOT = typename TypeListToOperationTuple<TypeList_t>::type;
-
-    template <int INDEX, typename TupleType>
-    using get_ot = TypeAt_t<INDEX, OTToTypeList<TupleType>>;
-
-    template <int INDEX, typename... OperationTypes>
-    FK_HOST_DEVICE_CNST auto getIOp(const OperationTuple<OperationTypes...>& instances) {
-        using SelectedOperation = get_ot<INDEX, OperationTuple<OperationTypes...>>;
-        if constexpr (isUnaryType<SelectedOperation>) {
-            return SelectedOperation::build();
+    template <size_t Idx, typename OpTuple>
+    FK_HOST_DEVICE_CNST decltype(auto) get_opt(OpTuple&& opTuple) {
+        static_assert(isOpTuple_v<std::decay_t<OpTuple>>, "get_opt only works with OperationTuple.");
+        if constexpr (opIs<UnaryType, TypeAt_t<Idx, typename std::decay_t<OpTuple>::Operations>>) {
+            // Unary types are stateless, return a new temporary by value.
+            // decltype(auto) deduces this as 'T' (Value).
+            return typename TypeAt_t<Idx, typename std::decay_t<OpTuple>::Operations>::Operation::InstantiableType{};
         } else {
-            return SelectedOperation::build(get<INDEX>(instances));
+            // Stored types return whatever is stored in the OpTuple
+            return get<GetIndex<typename std::decay_t<OpTuple>::Indexes, Idx>::value>(
+                std::forward<OpTuple>(opTuple).instances);
         }
     }
 
-    struct NotUnaryRestriction {
-        template <typename Type>
-        FK_HOST_DEVICE_FUSE bool complies() {
-            return !std::is_same_v<Type, UnaryType>;
-        }
-    };
+    template <size_t... Idx, typename... IOps>
+    FK_HOST_CNST auto make_new_operation_tuple_helper(const std::index_sequence<Idx...>&, const IOps&... iOps) {
+        // 1. Pack arguments into a tuple ONCE.
+        auto args_tuple = forward_as_tuple(iOps...);
 
-    template <typename... Operations1, typename... Operations2, int... I1, int... I2>
-    FK_HOST_DEVICE_CNST auto cat_impl(const OperationTuple<Operations1...>& t1, const std::integer_sequence<int, I1...>& is1,
-                                      const OperationTuple<Operations2...>& t2, const std::integer_sequence<int, I2...>& is2) {
-        return make_operation_tuple_<Operations1..., Operations2...>(get<I1>(t1)..., get<I2>(t2)...);
-    }
+        // 2. Capture elements as value (std::decay_t)
+        using ResultType = OperationTuple<std::decay_t<IOps>...>;
 
-    template <typename... Operations1, typename... Operations2>
-    FK_HOST_DEVICE_CNST auto cat(OperationTuple<Operations1...>& t1, OperationTuple<Operations2...>& t2) {
-        return cat_impl(t1, filtered_integer_sequence_t<int, NotUnaryRestriction, TypeList<typename Operations1::InstanceType...>>{},
-                        t2, filtered_integer_sequence_t<int, NotUnaryRestriction, TypeList<typename Operations2::InstanceType...>>{});
-    }
-
-    template <typename... Operations1, typename... Operations2>
-    FK_HOST_DEVICE_CNST auto cat(const OperationTuple<Operations1...>& t1, const OperationTuple<Operations2...>& t2) {
-        return cat_impl(t1, filtered_integer_sequence_t<int, NotUnaryRestriction, TypeList<typename Operations1::InstanceType...>>{},
-                        t2, filtered_integer_sequence_t<int, NotUnaryRestriction, TypeList<typename Operations2::InstanceType...>>{});
+        // 3. Expand a single tuple using fk::get
+        return ResultType{{get<Idx>(args_tuple)...}};
     }
 
     template <typename... IOps>
-    FK_HOST_DEVICE_CNST auto make_operation_tuple(const IOps&... iOps) {
-        const auto fusedOp = fuseIOps(iOps...);
-        return fusedOp.params;
+    FK_HOST_CNST auto make_new_operation_tuple(const IOps&... iOps) {
+        if constexpr (allUnaryTypes<IOps...>) {
+            return OperationTuple<std::decay_t<IOps>...>{};
+        } else {
+            using IdxType = typename OperationTuple<std::decay_t<IOps>...>::Indexes;
+            return make_new_operation_tuple_helper(IdxType{}, iOps...);
+        }
     }
 
-
-    template <typename Type, typename = void>
-    struct HasOperation : std::false_type {};
-
-    template <typename Type>
-    struct HasOperation<Type, std::void_t<typename Type::Operation>> : std::true_type {};
-
-    struct IsInstantiableOperation {
-        template <typename Type>
-        FK_HOST_DEVICE_FUSE bool complies() {
-            return HasOperation<Type>::value;
+    // cat and cat_helper must return auto, since they are creating a new OperationTuple 
+    namespace detail {
+        template <size_t... Idx1, size_t... Idx2,
+                  typename... IOps1, typename... IOps2>
+        FK_HOST_CNST auto cat_helper(const std::index_sequence<Idx1...>&,
+                                               const std::index_sequence<Idx2...>&,
+                                               const OperationTuple<IOps1...>& opTup1,
+                                               const OperationTuple<IOps2...>& opTup2) {
+            return make_new_operation_tuple(get_opt<Idx1>(opTup1)..., get_opt<Idx2>(opTup2)...);
         }
-    };
+    } // namespace detail
+
+    template <typename... IOps1, typename... IOps2>
+    FK_HOST_CNST auto cat(const OperationTuple<IOps1...>& opTup1,
+                                           const OperationTuple<IOps2...>& opTup2) {
+        return detail::cat_helper(std::make_index_sequence<OperationTuple<IOps1...>::size>{},
+                          std::make_index_sequence<OperationTuple<IOps2...>::size>{},
+                          opTup1, opTup2);
+    }
 } // namespace fk
 
 #endif

--- a/include/fused_kernel/core/execution_model/operation_model/operation_types.h
+++ b/include/fused_kernel/core/execution_model/operation_model/operation_types.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,116 +20,92 @@
 #include <fused_kernel/core/utils/type_lists.h>
 
 namespace fk {
+    /* Operation types are linked to the exec() function definition in the Operation. 
+    *  The elements that can change across Operation types are:
+    *   - OutputType: whether the exec function returns a value or not, and which type it is. The value resides on registers.
+    *   - ElementIdx (using the type Point): whether the exec function gets the thread idx as input or not.
+    *     It is used to compute DRAM or Shared Memory addresses to read from or write into.
+    *   - InputType: whether the exec function gets an input value or not. This value resides on registers.
+    *   - ParamsType: whether the exec function gets an any additional data that is not computed inside the kernel
+    *     and that is needed for the execution of the operation.
+    *   - BackIOp: whether the exec function gets an additional IOp as input, that is executed as part of the operation
+    *     implementation.
+    * 
+    *    An example of the exec function with all the types would be:
+    *    OutputType exec(Point, InputType, ParamsType, BackIOp)
+
+         +------------------------+----------+----------+----------+----------+----------+
+         |                        |   Out    |   EIdx   |    In    |   Par    |   BIOp   |
+         +------------------------+----------+----------+----------+----------+----------+
+         | ReadType               |    X     |    X     |          |    X     |          |  OutputType exec(Point, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | WriteType              |          |    X     |    X     |    X     |          |  void exec(Point, InputType, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | UnaryType              |    X     |          |    X     |          |          |  OutputType exec(InputType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | BinaryType             |    X     |          |    X     |    X     |          |  OutputType exec(InputType, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | ReadBackType           |    X     |    X     |          |    X     |    X     |  OutputType exec(Point, ParamsType, BackIOp)
+         +------------------------+----------+----------+----------+----------+----------+
+         | IncompleteReadBackType |          |          |          |          |          |  no exec function present
+         +------------------------+----------+----------+----------+----------+----------+
+         | TernaryType            |    X     |          |    X     |    X     |    X     |  OutputType exec(InputType, ParamsType, BackIOp)
+         +------------------------+----------+----------+----------+----------+----------+
+         | IncompleteTernaryType  |          |          |          |          |          |  no exec function present
+         +------------------------+----------+----------+----------+----------+----------+
+         | MidWriteType *         |    X     |    X     |    X     |    X     |          |  InputType exec(Point, InputType, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | OpenType **            |    X     |    X     |    X     |    X     |          |  OutputType exec(Point, InputType, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+         | ClosedType **          |          |    X     |          |    X     |          |  void exec(Point, ParamsType)
+         +------------------------+----------+----------+----------+----------+----------+
+
+         * Applicable only to Instantiapble Operations. In and Out must be the same type and value. Operation must be of WriteType.
+         ** OpenType and ClosedType are only applicable to FusedOperations. FusedOperations can also be ReadType or WriteType.
+    */
+
     struct ReadType;
-    struct ReadBackType;
-    struct IncompleteReadBackType;
+    struct WriteType;
     struct UnaryType;
     struct BinaryType;
+    struct ReadBackType;
+    struct IncompleteReadBackType;
     struct TernaryType;
+    struct IncompleteTernaryType;
     struct MidWriteType;
-    struct WriteType;
+    struct OpenType;
+    struct ClosedType;
 
     template <typename T, typename = void>
     struct HasInstanceType : std::false_type {};
     template <typename T>
     struct HasInstanceType<T, std::void_t<typename T::InstanceType>> : std::true_type {};
 
-    template <typename T, typename = void>
-    struct IsReadType : std::false_type {};
-    template <typename T>
-    struct IsReadType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, ReadType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsReadType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, ReadType>, void>> : std::true_type {};
+    template <typename OperationType, typename OpOrIOp, typename = void>
+    struct OpIs : std::false_type {};
+    template <typename OperationType, typename OpOrIOp>
+    struct OpIs<OperationType, OpOrIOp,
+              std::enable_if_t<std::is_same_v<typename OpOrIOp::InstanceType, OperationType>, void>> : std::true_type {};
 
-    template <typename T, typename = void>
-    struct IsReadBackType : std::false_type {};
-    template <typename T>
-    struct IsReadBackType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, ReadBackType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsReadBackType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, ReadBackType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsIncompleteReadBackType : std::false_type {};
-    template <typename T>
-    struct IsIncompleteReadBackType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, IncompleteReadBackType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsIncompleteReadBackType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, IncompleteReadBackType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsUnaryType : std::false_type {};
-    template <typename T>
-    struct IsUnaryType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, UnaryType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsUnaryType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, UnaryType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsBinaryType : std::false_type {};
-    template <typename T>
-    struct IsBinaryType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, BinaryType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsBinaryType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, BinaryType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsTernaryType : std::false_type {};
-    template <typename T>
-    struct IsTernaryType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, TernaryType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsTernaryType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, TernaryType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsMidWriteType : std::false_type {};
-    template <typename T>
-    struct IsMidWriteType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, MidWriteType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsMidWriteType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, MidWriteType>, void>> : std::true_type {};
-
-    template <typename T, typename = void>
-    struct IsWriteType : std::false_type {};
-    template <typename T>
-    struct IsWriteType<T, std::enable_if_t<!std::is_same_v<typename T::InstanceType, WriteType>, void>> : std::false_type {};
-    template <typename T>
-    struct IsWriteType<T, std::enable_if_t<std::is_same_v<typename T::InstanceType, WriteType>, void>> : std::true_type {};
+    template <typename OperationType, typename OpOrIOp>
+    constexpr bool opIs = OpIs<OperationType, OpOrIOp>::value;
 
     template <typename T>
     constexpr bool isOperation = HasInstanceType<T>::value;
 
     template <typename OpORIOp>
-    constexpr bool isReadType = IsReadType<OpORIOp>::value;
+    constexpr bool isAnyReadType = opIs<ReadType, OpORIOp> || opIs<ReadBackType, OpORIOp> || opIs<IncompleteReadBackType, OpORIOp>;
 
     template <typename OpORIOp>
-    constexpr bool isReadBackType = IsReadBackType<OpORIOp>::value;
+    constexpr bool isAnyCompleteReadType = opIs<ReadType, OpORIOp> || opIs<ReadBackType, OpORIOp>;
 
     template <typename OpORIOp>
-    constexpr bool isIncompleteReadBackType = IsIncompleteReadBackType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isAnyReadType = isReadType<OpORIOp> || isReadBackType<OpORIOp> || isIncompleteReadBackType<OpORIOp>;
-
-    template <typename OpORIOp>
-    constexpr bool isAnyCompleteReadType = isReadType<OpORIOp> || isReadBackType<OpORIOp>;
-
-    template <typename OpORIOp>
-    constexpr bool isUnaryType = IsUnaryType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isBinaryType = IsBinaryType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isTernaryType = IsTernaryType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isWriteType = IsWriteType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isMidWriteType = IsMidWriteType<OpORIOp>::value;
-
-    template <typename OpORIOp>
-    constexpr bool isComputeType = isUnaryType<OpORIOp> || isBinaryType<OpORIOp> || isTernaryType<OpORIOp>;
+    constexpr bool isComputeType = opIs<UnaryType, OpORIOp> || opIs<BinaryType, OpORIOp> || opIs<TernaryType, OpORIOp>;
 
     using WriteTypeList = TypeList<WriteType, MidWriteType>;
 
     template <typename OpORIOp>
-    constexpr bool isAnyWriteType = isWriteType<OpORIOp> || isMidWriteType<OpORIOp>;
+    constexpr bool isAnyWriteType = opIs<WriteType, OpORIOp> || opIs<MidWriteType, OpORIOp>;
 
     template <typename IOp>
     using GetInputType_t = typename IOp::Operation::InputType;
@@ -142,7 +118,7 @@ namespace fk {
                                                      const IOp& instantiableOperation) {
         static_assert(isComputeType<IOp>,
             "Function compute only works with IOp InstanceTypes UnaryType, BinaryType and TernaryType");
-        if constexpr (isUnaryType<IOp>) {
+        if constexpr (opIs<UnaryType, IOp>) {
             return IOp::Operation::exec(input);
         } else {
             return IOp::Operation::exec(input, instantiableOperation);
@@ -150,7 +126,12 @@ namespace fk {
     }
 
     template <typename... OpsOrIOps>
-    constexpr bool allUnaryTypes = and_v<isUnaryType<OpsOrIOps>...>;
+    constexpr bool allUnaryTypes = and_v<opIs<UnaryType, OpsOrIOps>...>;
+    template <typename... OpsOrIOps>
+    constexpr bool allComputeTypes = and_v<isComputeType<OpsOrIOps>...>;
+
+    template <typename... OpsOrIOps>
+    constexpr bool atLeastOneMidWriteType = or_v<opIs<MidWriteType, OpsOrIOps>...>;
 
     template <typename = void, typename... OpsOrIOps>
     struct NotAllUnary final : public std::false_type {};
@@ -172,22 +153,22 @@ namespace fk {
                                OperationsOrInstantiableOperations...> : std::true_type {};
 
     template <typename... OperationORInstantiableOperation>
-    constexpr bool noneWriteType = and_v<(!isWriteType<OperationORInstantiableOperation>)...>;
+    constexpr bool noneWriteType = and_v<(!opIs<WriteType, OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
-    constexpr bool noneMidWriteType = and_v<(!isMidWriteType<OperationORInstantiableOperation>)...>;
+    constexpr bool noneMidWriteType = and_v<(!opIs<MidWriteType, OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
     constexpr bool noneAnyWriteType = and_v<(!isAnyWriteType<OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
-    constexpr bool noneReadType = and_v<(!isReadType<OperationORInstantiableOperation>)...>;
+    constexpr bool noneReadType = and_v<(!opIs<ReadType, OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
-    constexpr bool noneReadBackType = and_v<(!isReadBackType<OperationORInstantiableOperation>)...>;
+    constexpr bool noneReadBackType = and_v<(!opIs<ReadBackType, OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
-    constexpr bool noneIncompleteReadBackType = and_v<(!isIncompleteReadBackType<OperationORInstantiableOperation>)...>;
+    constexpr bool noneIncompleteReadBackType = and_v<(!opIs<IncompleteReadBackType, OperationORInstantiableOperation>)...>;
 
     template <typename... OperationORInstantiableOperation>
     constexpr bool noneAnyReadType = and_v<(!isAnyReadType<OperationORInstantiableOperation>)...>;
@@ -196,7 +177,7 @@ namespace fk {
     struct IsCompleteOperation : std::false_type {};
 
     template <typename T>
-    struct IsCompleteOperation<T, std::enable_if_t<isOperation<T> && !isIncompleteReadBackType<T>>> : std::true_type {};
+    struct IsCompleteOperation<T, std::enable_if_t<isOperation<T> && !opIs<IncompleteReadBackType, T>>> : std::true_type {};
 
     template <typename T>
     constexpr bool isCompleteOperation = IsCompleteOperation<T>::value;

--- a/include/fused_kernel/core/execution_model/operation_model/parent_operations.h
+++ b/include/fused_kernel/core/execution_model/operation_model/parent_operations.h
@@ -1,4 +1,5 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
+*  Copyright 2026 Grup Mediapro S.L.U (Oscar Amoros Huguet)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +18,17 @@
 
 #include <fused_kernel/core/execution_model/operation_model/instantiable_operations.h>
 
+/* Notes on implementation decisions
+* 
+*  Having exec and build functions defined in macros:
+*   - It may be inconvenient sometimes for debugging.
+*   - The alternative is to have them defined in the parent operations and then call them from
+*     the macro exec and build definitions. This option, we observed that increases compilation
+*     times.
+*   - We may decide to move the exec functions that have threa fusion management to the parent
+*     operations, or do it temporarily just for debugging.
+*/
+
 namespace fk {
     // PARENT OPERATIONS
     // PARENT COMPUTE OPERATIONS
@@ -32,16 +44,15 @@ namespace fk {
         using InstanceType = UnaryType;
         using InstantiableType = Unary<Child>;
         static constexpr bool IS_FUSED_OP = IS_FUSED;
-        FK_HOST_FUSE auto build() { return typename Child::InstantiableType{}; }
     };
 
-#define DECLARE_UNARY_PARENT                                                                                           \
-  using InputType = typename Parent::InputType;                                                                        \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  FK_HOST_FUSE InstantiableType build() { return Parent::build(); }
+#define DECLARE_UNARY_PARENT                                    \
+  using InputType = typename Parent::InputType;                 \
+  using OutputType = typename Parent::OutputType;               \
+  using InstanceType = typename Parent::InstanceType;           \
+  using InstantiableType = typename Parent::InstantiableType;   \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;      \
+  FK_HOST_FUSE InstantiableType build() { return {}; }
 
     template <typename I, typename P, typename O, typename ChildImplementation, bool IS_FUSED = false>
     struct BinaryOperation {
@@ -57,26 +68,21 @@ namespace fk {
         using OperationDataType = OperationData<Child>;
         using InstantiableType = Binary<Child>;
         static constexpr bool IS_FUSED_OP = IS_FUSED;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const OperationDataType& opData) {
-            return Child::exec(input, opData.params);
-        }
-        FK_HOST_FUSE InstantiableType build(const OperationDataType& opData) { return InstantiableType{ opData }; }
-        FK_HOST_FUSE InstantiableType build(const ParamsType& params) { return InstantiableType{ {params} }; }
     };
 
-#define DECLARE_BINARY_PARENT                                                                                          \
-  using InputType = typename Parent::InputType;                                                                        \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  FK_HOST_DEVICE_FUSE OutputType exec(const InputType &input, const OperationDataType &opData) {                       \
-    return Parent::exec(input, opData);                                                                                \
-  }                                                                                                                    \
-  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return Parent::build(opData); }               \
-  FK_HOST_FUSE InstantiableType build(const ParamsType &params) { return Parent::build(params); }
+#define DECLARE_BINARY_PARENT                                                                    \
+  using InputType = typename Parent::InputType;                                                  \
+  using OutputType = typename Parent::OutputType;                                                \
+  using ParamsType = typename Parent::ParamsType;                                                \
+  using InstanceType = typename Parent::InstanceType;                                            \
+  using OperationDataType = typename Parent::OperationDataType;                                  \
+  using InstantiableType = typename Parent::InstantiableType;                                    \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                       \
+  FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const OperationDataType &opData) { \
+    return exec(input, opData.params);                                                           \
+  }                                                                                              \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType& opData) { return {opData}; }      \
+  FK_HOST_FUSE InstantiableType build(const ParamsType& params) { return {{params}}; }
 
     template <typename I, typename P, typename BIOp, typename O, typename ChildImplementation, bool IS_FUSED = false>
     struct TernaryOperation {
@@ -93,31 +99,23 @@ namespace fk {
         using OperationDataType = OperationData<Child>;
         using InstantiableType = Ternary<Child>;
         static constexpr bool IS_FUSED_OP = IS_FUSED;
-
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const OperationDataType& opData) {
-            return Child::exec(input, opData.params, opData.backIOp);
-        }
-        FK_HOST_FUSE InstantiableType build(const OperationDataType& opData) { return InstantiableType{opData}; }
-        FK_HOST_FUSE InstantiableType build(const ParamsType& params, const BackIOp& backFunc) {
-            return InstantiableType{{params, backFunc}};
-        }
     };
 
-#define DECLARE_TERNARY_PARENT                                                                                         \
-  using InputType = typename Parent::InputType;                                                                        \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using BackIOp = typename Parent::BackIOp;                                                                            \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  FK_HOST_DEVICE_FUSE OutputType exec(const InputType &input, const OperationDataType &opData) {                       \
-    return Parent::exec(input, opData);                                                                                \
-  }                                                                                                                    \
-  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return Parent::build(opData); }               \
-  FK_HOST_FUSE InstantiableType build(const ParamsType &params, const BackIOp &backFunc) {                             \
-    return Parent::build(params, backFunc);                                                                            \
+#define DECLARE_TERNARY_PARENT                                                                    \
+  using InputType = typename Parent::InputType;                                                   \
+  using OutputType = typename Parent::OutputType;                                                 \
+  using ParamsType = typename Parent::ParamsType;                                                 \
+  using BackIOp = typename Parent::BackIOp;                                                       \
+  using InstanceType = typename Parent::InstanceType;                                             \
+  using OperationDataType = typename Parent::OperationDataType;                                   \
+  using InstantiableType = typename Parent::InstantiableType;                                     \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                        \
+  FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const OperationDataType &opData) {  \
+    return exec(input, opData.params, opData.backIOp);                                            \
+  }                                                                                               \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return {opData}; }       \
+  FK_HOST_FUSE InstantiableType build(const ParamsType &params, const BackIOp &backFunc) {        \
+    return {{params, backFunc}};                                                                  \
   }
     // END PARENT COMPUTE OPERATIONS
     // PARENT MEMORY OPERATIONS
@@ -136,48 +134,30 @@ namespace fk {
         using OperationDataType = OperationData<Child>;
         using InstantiableType = Read<Child>;
         static constexpr bool IS_FUSED_OP = IS_FUSED;
-
-        template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType>
-        exec(const Point& thread, const OperationDataType& opData) {
-            if constexpr (std::bool_constant<THREAD_FUSION>::value) {
-                return Child::template exec<ELEMS_PER_THREAD>(thread, opData.params);
-            } else {
-                return Child::exec(thread, opData.params);
-            }
-        }
-        FK_HOST_FUSE auto build(const OperationDataType& opData) { return InstantiableType{opData}; }
-        FK_HOST_FUSE auto build(const ParamsType& params) { return InstantiableType{{params}}; }
     };
 
-#define DECLARE_READ_PARENT_DEVICE_BASIC                                                                               \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using ReadDataType = typename Parent::ReadDataType;                                                                  \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                                         \
-  template <uint ELEMS_PER_THREAD = 1>                                                                                 \
-  FK_HOST_DEVICE_FUSE ThreadFusionType<ReadDataType, ELEMS_PER_THREAD, OutputType>                                     \
-  exec(const Point &thread, const OperationDataType &opData) {                                                         \
-    if constexpr (std::bool_constant<THREAD_FUSION>::value) {                                                          \
-      return Parent::template exec<ELEMS_PER_THREAD>(thread, opData);                                                  \
-    } else {                                                                                                           \
-      return Parent::exec(thread, opData);                                                                             \
-    }                                                                                                                  \
+#define DECLARE_READ_PARENT_DEVICE_BASIC                                                       \
+  using ParamsType = typename Parent::ParamsType;                                              \
+  using ReadDataType = typename Parent::ReadDataType;                                          \
+  using InstanceType = typename Parent::InstanceType;                                          \
+  using OutputType = typename Parent::OutputType;                                              \
+  using OperationDataType = typename Parent::OperationDataType;                                \
+  using InstantiableType = typename Parent::InstantiableType;                                  \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                     \
+  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                 \
+  template <uint ELEMS_PER_THREAD = 1>                                                         \
+  FK_HOST_DEVICE_FUSE auto exec(const Point thread, const OperationDataType& opData) {        \
+    if constexpr (std::bool_constant<THREAD_FUSION>::value) {                                  \
+      return exec<ELEMS_PER_THREAD>(thread, opData.params);                                    \
+    } else {                                                                                   \
+      return exec(thread, opData.params);                                                      \
+    }                                                                                          \
   }
 
-#ifndef NVRTC_COMPILER
-#define DECLARE_READ_PARENT_BASIC                                                                                      \
-  DECLARE_READ_PARENT_DEVICE_BASIC                                                                                     \
-  FK_HOST_FUSE auto build(const OperationDataType &opData) { return Parent::build(opData); }                           \
-  FK_HOST_FUSE auto build(const ParamsType &params) { return Parent::build(params); }
-#else
-#define DECLARE_READ_PARENT_BASIC                                                                                      \
-DECLARE_READ_PARENT_DEVICE_BASIC
-#endif // 
+#define DECLARE_READ_PARENT_BASIC                                                              \
+  DECLARE_READ_PARENT_DEVICE_BASIC                                                             \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType& opData) { return {opData}; }    \
+  FK_HOST_FUSE InstantiableType build(const ParamsType& params) { return {{params}}; }
 
     template <typename I, typename P, typename WT, enum TF TFE, typename ChildImplementation, bool IS_FUSED = false>
     struct WriteOperation {
@@ -194,38 +174,88 @@ DECLARE_READ_PARENT_DEVICE_BASIC
         using OperationDataType = OperationData<Child>;
         using InstantiableType = Write<Child>;
         static constexpr bool IS_FUSED_OP = IS_FUSED;
-
-        template <uint ELEMS_PER_THREAD = 1>
-        FK_HOST_DEVICE_FUSE void exec(const Point& thread,
-                                      const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType>& input,
-                                      const OperationDataType& opData) {
-            if constexpr (THREAD_FUSION) {
-                Child::template exec<ELEMS_PER_THREAD>(thread, input, opData.params);
-            } else {
-                Child::exec(thread, input, opData.params);
-            }
-        }
-        FK_HOST_FUSE auto build(const OperationDataType& opData) { return InstantiableType{ opData }; }
-        FK_HOST_FUSE auto build(const ParamsType& params) { return InstantiableType{ {params} }; }
     };
 
-#define DECLARE_WRITE_PARENT_BASIC                                                                                     \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using InputType = typename Parent::InputType;                                                                        \
-  using WriteDataType = typename Parent::WriteDataType;                                                                \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                                         \
-  template <uint ELEMS_PER_THREAD = 1>                                                                                 \
-  FK_HOST_DEVICE_FUSE void exec(const Point &thread,                                                                   \
-                                const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> &input,                 \
-                                const OperationDataType &opData) {                                                     \
-    Parent::template exec<ELEMS_PER_THREAD>(thread, input, opData);                                                    \
-  }                                                                                                                    \
-  FK_HOST_FUSE auto build(const OperationDataType &opData) { return Parent::build(opData); }                           \
-  FK_HOST_FUSE auto build(const ParamsType &params) { return Parent::build(params); }
+#define DECLARE_WRITE_PARENT_BASIC                                                                      \
+  using ParamsType = typename Parent::ParamsType;                                                       \
+  using InputType = typename Parent::InputType;                                                         \
+  using WriteDataType = typename Parent::WriteDataType;                                                 \
+  using InstanceType = typename Parent::InstanceType;                                                   \
+  using OperationDataType = typename Parent::OperationDataType;                                         \
+  using InstantiableType = typename Parent::InstantiableType;                                           \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                              \
+  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                          \
+  template <uint ELEMS_PER_THREAD = 1>                                                                  \
+  FK_HOST_DEVICE_FUSE void exec(const Point thread,                                                    \
+                                const ThreadFusionType<InputType, ELEMS_PER_THREAD, InputType> &input,  \
+                                const OperationDataType &opData) {                                      \
+    if constexpr (THREAD_FUSION) {                                                                      \
+        exec<ELEMS_PER_THREAD>(thread, input, opData.params);                                           \
+    } else {                                                                                            \
+        exec(thread, input, opData.params);                                                             \
+    }                                                                                                   \
+  }                                                                                                     \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return {opData}; }             \
+  FK_HOST_FUSE InstantiableType build(const ParamsType &params) { return {{params}}; }
+
+    template <typename I, typename P, typename O, typename ChildImplementation, bool IS_FUSED = false>
+    struct OpenOperationParent {
+    private:
+        using SelfType = OpenOperationParent<I, P, O, ChildImplementation, IS_FUSED>;
+    public:
+        FK_STATIC_STRUCT(OpenOperationParent, SelfType)
+        using Child = ChildImplementation;
+        using ParamsType = P;
+        using InputType = I;
+        using OutputType = O;
+        using InstanceType = OpenType;
+        using OperationDataType = OperationData<Child>;
+        using InstantiableType = Open<Child>;
+        static constexpr bool IS_FUSED_OP = IS_FUSED;
+    };
+
+#define DECLARE_OPEN_PARENT                                                                 \
+  using ParamsType = typename Parent::ParamsType;                                           \
+  using InputType = typename Parent::InputType;                                             \
+  using OutputType = typename Parent::OutputType;                                           \
+  using InstanceType = typename Parent::InstanceType;                                       \
+  using OperationDataType = typename Parent::OperationDataType;                             \
+  using InstantiableType = typename Parent::InstantiableType;                               \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                  \
+  FK_HOST_DEVICE_FUSE OutputType exec(const Point thread,                                  \
+                                      const InputType input,                               \
+                                      const OperationDataType& opData) {                    \
+    return exec(thread, input, opData.params);                                              \
+  }                                                                                         \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return {opData}; } \
+  FK_HOST_FUSE InstantiableType build(const ParamsType &params) { return {{params}}; }
+
+template <typename P, typename ChildImplementation, bool IS_FUSED = false>
+struct ClosedOperation {
+    private:
+    using SelfType = ClosedOperation<P, ChildImplementation, IS_FUSED>;
+
+    public:
+    FK_STATIC_STRUCT(ClosedOperation, SelfType)
+    using Child = ChildImplementation;
+    using ParamsType = P;
+    using InstanceType = ClosedType;
+    using OperationDataType = OperationData<Child>;
+    using InstantiableType = Closed<Child>;
+    static constexpr bool IS_FUSED_OP = IS_FUSED;
+};
+
+#define DECLARE_CLOSED_PARENT                                                                   \
+    using ParamsType = typename Parent::ParamsType;                                             \
+    using InstanceType = typename Parent::InstanceType;                                         \
+    using OperationDataType = typename Parent::OperationDataType;                               \
+    using InstantiableType = typename Parent::InstantiableType;                                 \
+    static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                    \
+    FK_HOST_DEVICE_FUSE void exec(const Point thread, const OperationDataType &opData) {       \
+        exec(thread, opData.params);                                                            \
+    }                                                                                           \
+    FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return { opData }; } \
+    FK_HOST_FUSE InstantiableType build(const ParamsType &params) { return {{ params }}; }
 
     template <typename RT, typename P, typename B, typename O, typename ChildImplementation>
     struct ReadBackOperation {
@@ -243,34 +273,24 @@ DECLARE_READ_PARENT_DEVICE_BASIC
         using InstantiableType = ReadBack<Child>;
         static constexpr bool IS_FUSED_OP = false;
         static constexpr bool THREAD_FUSION = false;
-
-        template <typename BIOp = BackIOp>
-        FK_HOST_DEVICE_FUSE std::enable_if_t<!std::is_same_v<BIOp, NullType>, OutputType>
-        exec(const Point& thread, const OperationDataType& opData) {
-            return Child::exec(thread, opData.params, opData.backIOp);
-        }
-        FK_HOST_FUSE auto build(const OperationDataType& opData) { return InstantiableType{ opData }; }
-        FK_HOST_FUSE auto build(const ParamsType& params, const BackIOp& backFunc) {
-            return InstantiableType{{params, backFunc}};
-        }
     };
 
-#define DECLARE_READBACK_PARENT_BASIC                                                                                  \
-  using ReadDataType = typename Parent::ReadDataType;                                                                  \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using BackIOp = typename Parent::BackIOp;                                                                            \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                                         \
-  FK_HOST_DEVICE_FUSE OutputType exec(const Point &thread, const OperationDataType &opData) {                          \
-    return Parent::exec(thread, opData);                                                                               \
-  }                                                                                                                    \
-  FK_HOST_FUSE auto build(const OperationDataType &opData) { return Parent::build(opData); }                           \
-  FK_HOST_FUSE auto build(const ParamsType &params, const BackIOp &backIOp) {                                          \
-    return Parent::build(params, backIOp);                                                                             \
+#define DECLARE_READBACK_PARENT_BASIC                                                          \
+  using ReadDataType = typename Parent::ReadDataType;                                          \
+  using OutputType = typename Parent::OutputType;                                              \
+  using ParamsType = typename Parent::ParamsType;                                              \
+  using BackIOp = typename Parent::BackIOp;                                                    \
+  using InstanceType = typename Parent::InstanceType;                                          \
+  using OperationDataType = typename Parent::OperationDataType;                                \
+  using InstantiableType = typename Parent::InstantiableType;                                  \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                     \
+  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                 \
+  FK_HOST_DEVICE_FUSE OutputType exec(const Point thread, const OperationDataType &opData) {  \
+    return exec(thread, opData.params, opData.backIOp);                                        \
+  }                                                                                            \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return {opData}; }    \
+  FK_HOST_FUSE InstantiableType build(const ParamsType &params, const BackIOp &backIOp) {      \
+    return {{params, backIOp}};                                                                \
   }
 
     template <typename RT, typename P, typename B, typename O, typename ChildImplementation>
@@ -289,47 +309,42 @@ DECLARE_READ_PARENT_DEVICE_BASIC
         using InstantiableType = IncompleteReadBack<Child>;
         static constexpr bool IS_FUSED_OP = false;
         static constexpr bool THREAD_FUSION = false;
-
-        FK_HOST_FUSE auto build(const OperationDataType& opData) { return InstantiableType{ opData }; }
-        FK_HOST_FUSE auto build(const ParamsType& params, const BackIOp& backFunc) {
-            return InstantiableType{ {params, backFunc} };
-        }
     };
-#define DECLARE_INCOMPLETEREADBACK_PARENT_BASIC \
-  using ReadDataType = typename Parent::ReadDataType;                                                                  \
-  using OutputType = typename Parent::OutputType;                                                                      \
-  using ParamsType = typename Parent::ParamsType;                                                                      \
-  using BackIOp = typename Parent::BackIOp;                                                                            \
-  using InstanceType = typename Parent::InstanceType;                                                                  \
-  using OperationDataType = typename Parent::OperationDataType;                                                        \
-  using InstantiableType = typename Parent::InstantiableType;                                                          \
-  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                                             \
-  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                                                         \
-  FK_HOST_FUSE auto build(const OperationDataType &opData) { return Parent::build(opData); }                           \
-  FK_HOST_FUSE auto build(const ParamsType &params, const BackIOp &backFunc) {                                         \
-    return Parent::build(params, backFunc);                                                                            \
+#define DECLARE_INCOMPLETEREADBACK_PARENT_BASIC                                             \
+  using ReadDataType = typename Parent::ReadDataType;                                       \
+  using OutputType = typename Parent::OutputType;                                           \
+  using ParamsType = typename Parent::ParamsType;                                           \
+  using BackIOp = typename Parent::BackIOp;                                                 \
+  using InstanceType = typename Parent::InstanceType;                                       \
+  using OperationDataType = typename Parent::OperationDataType;                             \
+  using InstantiableType = typename Parent::InstantiableType;                               \
+  static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;                                  \
+  static constexpr bool THREAD_FUSION = Parent::THREAD_FUSION;                              \
+  FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return {opData}; } \
+  FK_HOST_FUSE InstantiableType build(const ParamsType &params, const BackIOp &backFunc) {  \
+    return {{params, backFunc}};                                                            \
   }
 // END PARENT OPERATIONS
 
     struct NumElems {
         template <typename IOp>
-        FK_HOST_DEVICE_FUSE uint x(const Point& thread, const IOp& iOp) {
-            static_assert(isAnyReadType<IOp> || isTernaryType<IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::x");
+        FK_HOST_DEVICE_FUSE uint x(const Point thread, const IOp& iOp) {
+            static_assert(isAnyReadType<IOp> || opIs<TernaryType, IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::x");
             return IOp::Operation::num_elems_x(thread, iOp);
         }
         template <typename IOp>
-        FK_HOST_DEVICE_FUSE uint y(const Point& thread, const IOp& iOp) {
-            static_assert(isAnyReadType<IOp> || isTernaryType<IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::y");
+        FK_HOST_DEVICE_FUSE uint y(const Point thread, const IOp& iOp) {
+            static_assert(isAnyReadType<IOp> || opIs<TernaryType, IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::y");
             return IOp::Operation::num_elems_y(thread, iOp);
         }
         template <typename IOp>
-        FK_HOST_DEVICE_FUSE Size size(const Point& thread, const IOp& iOp) {
-            static_assert(isAnyReadType<IOp> || isTernaryType<IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::size");
+        FK_HOST_DEVICE_FUSE Size size(const Point thread, const IOp& iOp) {
+            static_assert(isAnyReadType<IOp> || opIs<TernaryType, IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::size");
             return Size(x(thread, iOp), y(thread, iOp));
         }
         template <typename IOp>
-        FK_HOST_DEVICE_FUSE uint z(const Point& thread, const IOp& iOp) {
-            static_assert(isAnyReadType<IOp> || isTernaryType<IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::z");
+        FK_HOST_DEVICE_FUSE uint z(const Point thread, const IOp& iOp) {
+            static_assert(isAnyReadType<IOp> || opIs<TernaryType, IOp>, "Only Read, ReadBack, IncompleteReadBack and Ternary Types work with NumElems::z");
             return IOp::Operation::num_elems_z(thread, iOp);
         }
     };

--- a/include/fused_kernel/core/execution_model/operation_model/vector_operations.h
+++ b/include/fused_kernel/core/execution_model/operation_model/vector_operations.h
@@ -32,7 +32,7 @@ namespace fk {
         using InputType = I;
         using OutputType = O;
         using InstanceType = UnaryType;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             static_assert(cn<InputType> == cn<OutputType>,
                 "Unary struct requires same number of channels for input and output types.");
             constexpr bool allCUDAOrNotCUDA =
@@ -73,7 +73,7 @@ namespace fk {
         using InputType = I;
         using OutputType = O;
         using InstanceType = UnaryType;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             const auto input1 = get<0>(input);
             const auto input2 = get<1>(input);
             using I1 = get_t<0, I>;
@@ -138,10 +138,10 @@ namespace fk {
         using ParamsType = P;
         using InstanceType = BinaryType;
         using OperationDataType = OperationData<BinaryV<Operation, I, P, O>>;
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const OperationDataType& opData) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const OperationDataType& opData) {
             return BinaryV<Operation, I, P, O>::exec(input, opData.params);
         }
-        FK_HOST_DEVICE_FUSE OutputType exec(const InputType& input, const ParamsType& params) {
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             static_assert(cn<I> == cn<O>,
                 "Binary struct requires same number of channels for input and output types.");
             constexpr bool allCUDAOrNotCUDA =

--- a/include/fused_kernel/core/execution_model/parallel_architectures.h
+++ b/include/fused_kernel/core/execution_model/parallel_architectures.h
@@ -16,6 +16,7 @@
 #define PARALLEL_ARCHITECTURES_H
 
 #include <string_view>
+#include <fused_kernel/core/utils/compiler_macros.h>
 
 namespace fk {
 
@@ -35,7 +36,7 @@ namespace fk {
         PARALLEL_ARCHITECTURES
 #undef PAR_ARCH_VALUE
     };
-#if !defined(NVRTC_COMPILER)
+
     constexpr inline std::string_view toStrView(const ParArch& arch) {
         switch (arch) {
 #define PAR_ARCH_VALUE(name) case ParArch::name: { return std::string_view{#name}; }
@@ -44,16 +45,14 @@ namespace fk {
         default: return "Unknown";
     }
 }
-#endif
 #undef PARALLEL_ARCHITECTURES
 
-#if defined(__NVCC__) || CLANG_HOST_DEVICE
+#ifndef CLANG_HOST_DEVICE
+static_assert(false);
+#endif
+
+#if defined(__NVCC__) || (CLANG_HOST_DEVICE == 1)
     constexpr ParArch defaultParArch = ParArch::GPU_NVIDIA;
-#elif defined(NVRTC_ENABLED)
-    // Note: when using JIT, code compiled with the Host compiler 
-    // will have defaultParArch = ParArch::GPU_NVIDIA_JIT
-    // Device code, compiled at runtime, will have ParArch::GPU_NVIDIA
-    constexpr ParArch defaultParArch = ParArch::GPU_NVIDIA_JIT;
 #else
     constexpr ParArch defaultParArch = ParArch::CPU;
 #endif

--- a/include/fused_kernel/core/execution_model/thread_fusion.h
+++ b/include/fused_kernel/core/execution_model/thread_fusion.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ namespace fk {
     Times bigger can be: 1, 2, 4
     */
 
-    using TFSourceTypes = typename TypeList<TypeListCat_t<BaseTypes, VOne>, VTwo, VThree, VFour>::type;
+    using TFSourceTypes = TypeListCat_t<BaseTypes, VOne, VTwo, VThree, VFour>;
     using TFBiggerTypes = TypeList<bool4, uchar4,  char4,  ushort2,  short2,  uint2, int2, ulong,  long,  ulonglong,  longlong,  float2, double,
                                    bool4, uchar4,  char4,  ushort2,  short2,  uint2, int2, ulong,  long,  ulonglong,  longlong,  float2, double,
                                    bool4, uchar4,  char4,  ushort2,  short2,  uint2, int2, ulong2, long2, ulonglong2, longlong2, float2, double2,
@@ -84,7 +84,7 @@ namespace fk {
         public:
             static constexpr bool ENABLED = ENABLED_ && isValidChannelNumber<(cn<TFBiggerType_t<ReadType>> / cn<ReadType>) * cn<WriteType>>;
             using BiggerReadType = std::conditional_t<ENABLED, TFBiggerType_t<ReadType>, ReadType>;
-            static constexpr uint elems_per_thread{ cn<BiggerReadType> / cn<ReadType> };
+            static constexpr uint elems_per_thread{ static_cast<uint>(cn<BiggerReadType> / cn<ReadType>) };
             using BiggerWriteType = VectorType_t<VBase<WriteType>, elems_per_thread * cn<WriteType>>;
 
             template <int IDX>
@@ -151,8 +151,8 @@ namespace fk {
             const auto& writeOp = ppLast(iOps...);
             using ReadOperation = typename FirstType_t<IOpTypes...>::Operation;
             using WriteOperation = typename LastType_t<IOpTypes...>::Operation;
-            const uint readRow = ReadOperation::num_elems_x(Point(0, 0, 0), { readOp.params });
-            const uint writeRow = WriteOperation::num_elems_x(Point(0, 0, 0), { writeOp.params });
+            const uint readRow = ReadOperation::num_elems_x(Point{0, 0, 0}, { readOp.params });
+            const uint writeRow = WriteOperation::num_elems_x(Point{0, 0, 0}, { writeOp.params });
             return (readRow % elems_per_thread == 0) && (writeRow % elems_per_thread == 0);
         } else {
             return true;

--- a/include/fused_kernel/core/utils/compiler_macros.h
+++ b/include/fused_kernel/core/utils/compiler_macros.h
@@ -1,4 +1,5 @@
 /* Copyright 2025 Oscar Amoros Huguet
+   Copyright 2025 Albert Andaluz Gonzalez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,24 +13,14 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_STATIC_GET_H
-#define FK_STATIC_GET_H
+#ifndef COMPILER_MACROS_H
+#define COMPILER_MACROS_H
 
-#include <fused_kernel/core/utils/utils.h>
+#if defined(__clang__) && defined(__CUDA__) 
+// clang compiling CUDA code, both host and device mode
+#define CLANG_HOST_DEVICE 1
+#else
+#define CLANG_HOST_DEVICE 0
+#endif
 
-namespace fk {
-    template <typename VT>
-    class IsCudaVector;
-    template <typename VT>
-    class VectorTraits;
-
-    template <size_t Idx>
-    struct static_get {
-        template <typename VT>
-        FK_HOST_DEVICE_FUSE auto f(const VT& v) -> std::enable_if_t<IsCudaVector<VT>::value,
-            typename VectorTraits<VT>::base>;
-    };
-} // namespace fk
-
-
-#endif // FK_STATIC_GET_H
+#endif // COMPILER_MACROS_H

--- a/include/fused_kernel/core/utils/compiler_macros.h.rej
+++ b/include/fused_kernel/core/utils/compiler_macros.h.rej
@@ -1,0 +1,10 @@
+diff a/include/fused_kernel/core/utils/compiler_macros.h b/include/fused_kernel/core/utils/compiler_macros.h	(rejected hunks)
+@@ -0,5 +0,7 @@
+ #define CLANG_HOST_DEVICE 0
+ #endif
+ 
++#define VS2017_COMPILER (_MSC_VER_EXISTS && _MSC_VER >= 1910 && _MSC_VER < 1920)
++#define NO_VS2017_COMPILER !VS2017_COMPILER
+ 
+ #endif // COMPILER_MACROS_H
+\ No newline at end of file

--- a/include/fused_kernel/core/utils/parameter_pack_utils.h
+++ b/include/fused_kernel/core/utils/parameter_pack_utils.h
@@ -1,5 +1,5 @@
-/* Copyright 2023 Mediaproduccion S.L.U. (Oscar Amoros Huguet)
-   Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023 Grup Mediapro S.L.U. (Oscar Amoros Huguet)
+   Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #define FK_PARAMETER_PACK_UTILS
 
 #include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/data/tuple.h>
 #include <utility>
 
 namespace fk { // namespace fused kernel
@@ -25,41 +26,31 @@ namespace fk { // namespace fused kernel
     constexpr auto indexSequence = std::make_index_sequence<N>{};
 
     // Util to get the parameters of a parameter pack
-    template <int Index, typename T, typename... Args>
-    FK_HOST_DEVICE_CNST auto get(const T& current, const Args&... args) {
-        static_assert(sizeof...(args) + 1 > Index, "Index out of range when looking for a parameter in a parameter pack.");
-        if constexpr (Index == 0) {
-            return current;
-        } else {
-            return get<Index - 1>(args...);
-        }
-    }
-
-    template <int Index, typename T, typename... Args>
-    FK_HOST_DEVICE_CNST auto& get(T& current, Args&... args) {
-        static_assert(sizeof...(args) + 1 > Index, "Index out of range when looking for a parameter in a parameter pack.");
-        if constexpr (Index == 0) {
-            return current;
-        } else {
-            return get<Index - 1>(args...);
-        }
+    template <size_t I, typename... Args>
+    FK_HOST_DEVICE_CNST decltype(auto) get_arg(Args&&... args) {
+        // 1. Args&& captures the exact category (L-value vs R-value)
+        // 2. std::forward preserves it
+        // 3. forward_as_tuple creates a Tuple of references (Tuple<T&, U&&...>)
+        // 4. get extracts it
+        // 5. decltype(auto) returns exactly that reference
+        return TupleUtil::get<I>(forward_as_tuple(std::forward<Args>(args)...));
     }
 
     // Util to get the last parameter of a parameter pack
     template <typename... Args>
-    FK_HOST_DEVICE_CNST auto ppLast(const Args&... args) {
-        return get<sizeof...(args) - 1>(args...);
+    FK_HOST_DEVICE_CNST const auto& ppLast(const Args&... args) {
+        return get_arg<sizeof...(args) - 1>(args...);
     }
 
     // Util to get the first parameter of a parameter pack
     template <typename... Args>
-    FK_HOST_DEVICE_CNST auto ppFirst(const Args&... args) {
-        return get<0>(args...);
+    FK_HOST_DEVICE_CNST const auto& ppFirst(const Args&... args) {
+        return get_arg<0>(args...);
     }
 
     template <size_t idx, size_t... iseq>
     constexpr inline size_t get_index_f(const std::index_sequence<iseq...>&) {
-        return get<static_cast<int>(idx)>(iseq...);
+        return get_arg<idx>(iseq...);
     }
 
     template <size_t idx, typename ISeq>
@@ -67,7 +58,7 @@ namespace fk { // namespace fused kernel
 
     template <typename T, T idx, T... iseq>
     constexpr inline size_t get_integer_f(const std::integer_sequence<T, iseq...>&) {
-        return get<static_cast<int>(idx)>(iseq...);
+        return get_arg<static_cast<size_t>(idx)>(iseq...);
     }
 
     template <typename T, T idx, typename ISeq>

--- a/include/fused_kernel/core/utils/type_lists.h
+++ b/include/fused_kernel/core/utils/type_lists.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2024 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
    Copyright 2023 David Del Rio Astorga
    Copyright 2023 Grup Mediapro S.L.U. (Oscar Amoros Huguet)
 
@@ -19,41 +19,59 @@
 #define FK_TYPE_LIST
 
 #include <utility>
+#include <type_traits>
 #include <fused_kernel/core/utils/utils.h>
 
 namespace fk { // namespace fused kernel
-    /**
-     * @struct TypeList
-     * @brief Struct to hold a list of types, and be able to work with them at compile time.
-     *
-     * This the base defintion of the struct. Contains no implementation
-     */
-    template <typename... Types>
-    struct TypeList {
-    private:
-        template <size_t n, typename... TypeList_t>
-        struct At;
-        template <typename Head>
-        struct At<0, TypeList<Head>> {
-            using type = Head;
-        };
-        template <typename Head, typename... Tail>
-        struct At<0, TypeList<Head, Tail...>> {
-            using type = Head;
-        };
-        template <size_t n, typename Head, typename... Tail>
-        struct At<n, TypeList<Head, Tail...>> {
-            static_assert(n < TypeList<Head, Tail...>::size, "Index out of range");
-            using type = typename At<n - 1, TypeList<Tail...>>::type;
-        };
-    public:
-        static constexpr size_t size{sizeof...(Types)};
+
+    // Type identity implementation that avoids adding to namespace std
+    // Uses std::type_identity when available, otherwise provides our own
+#if defined(__cpp_lib_type_identity) && __cpp_lib_type_identity >= 201806L
+    template <typename T>
+    using type_identity = std::type_identity<T>;
+#else
+    template <typename T>
+    struct type_identity {
+        using type = T;
+    };
+#endif
+
+    template <size_t I, typename T>
+    struct TypeLeaf {
+        using type = T;
+    };
+
+    namespace detail {
+        // Declaration only.
+        // We rely on the compiler matching the specific base class TypeLeaf<I, T>
+        // to the explicitly provided index 'I'.
+        template <size_t I, typename T>
+        fk::type_identity<T> getter(const TypeLeaf<I, T> &);
+    } // namespace detail
+
+    template <typename IndxSeq, typename... Ts>
+    struct TypeListImpl;
+
+    template <size_t... Is, typename... Ts>
+    struct TypeListImpl<std::index_sequence<Is...>, Ts...> 
+        : TypeLeaf<Is, Ts>... 
+    {
+    };
+
+    template <typename... Ts>
+    struct TypeList : TypeListImpl<std::make_index_sequence<sizeof...(Ts)>, Ts...> {
+        static constexpr size_t size = sizeof...(Ts);
 
         template <size_t Idx>
-        using at = typename At<Idx, TypeList<Types...>>::type;
-        using first = at<0>;
-        using last = at<sizeof...(Types)-1>;
+        using at = typename decltype(detail::getter<Idx>(std::declval<TypeList<Ts...>>()))::type;
+
+        template <typename... Us>
+        FK_HOST_DEVICE_CNST TypeList<Ts..., Us...> operator>>(const TypeList<Us...> &) const;
     };
+
+    // The Accessor Alias
+    template <size_t Idx, typename List>
+    using TypeAt_t = typename decltype(detail::getter<Idx>(std::declval<List>()))::type;
 
     template <typename T>
     struct IsTypeList : std::false_type {};
@@ -64,41 +82,28 @@ namespace fk { // namespace fused kernel
     template <typename T>
     constexpr bool isTypeList = IsTypeList<T>::value;
 
-    /**
-     * @struct TypeList<TypeList<Args1...>, TypeList<Args2...>, TypeList<Args3...>, TypeList<Args4...>>
-     * @brief Struct to fuse 4 TypeList into a single one.
-     *
-     * The expansion results into a single struct that holds all the types.
-     */
-    template<typename... Args1, typename... Args2, typename... Args3, typename... Args4>
-    struct TypeList<TypeList<Args1...>, TypeList<Args2...>, TypeList<Args3...>, TypeList<Args4...>> {
-        using type = TypeList<Args1..., Args2..., Args3..., Args4...>;
+    // ------------------------------------------------------------------
+    // TypeListCat Implementation
+    // ------------------------------------------------------------------
+    template <typename... Lists>
+    struct TypeListCat {
+        using type = decltype((std::declval<Lists>() >> ...));
+    };
+    
+    template <typename... Lists>
+    using TypeListCat_t = typename TypeListCat<Lists...>::type;
+
+    // Primary template (default false)
+    template <typename T, typename List>
+    struct one_of {
+        static constexpr bool value = false;
     };
 
-    template<typename... Args1, typename... Args2, typename... Args3,
-             typename... Args4, typename... Args5, typename... Args6>
-    struct TypeList<TypeList<Args1...>, TypeList<Args2...>, TypeList<Args3...>,
-                    TypeList<Args4...>, TypeList<Args5...>, TypeList<Args6...>> {
-        using type = TypeList<Args1..., Args2..., Args3..., Args4..., Args5..., Args6...>;
-    };
-
-    template<typename... Types>
-    struct TypeListCat{};
-
-    template<typename... Args1, typename... Args2>
-    struct TypeListCat<TypeList<Args1...>, TypeList<Args2...>> {
-        using type = TypeList<Args1..., Args2...>;
-    };
-
-    template <typename TypeList1, typename TypeList2>
-    using TypeListCat_t = typename TypeListCat<TypeList1, TypeList2>::type;
-
-    template <typename... Args>
-    struct one_of {};
-
-    template <typename T, typename... U>
-    struct one_of<T, TypeList<U...>> {
-        static constexpr int value = std::disjunction_v<std::is_same<T,U>...>;
+    // Specialization for TypeList
+    // This will match any fk::TypeList<Us...>
+    template <typename T, typename... Us>
+    struct one_of<T, fk::TypeList<Us...>> {
+        static constexpr bool value = (std::is_same_v<T, Us> || ...);
     };
 
     template <typename T, typename TypeList_t>
@@ -109,7 +114,7 @@ namespace fk { // namespace fused kernel
 
     template <typename T, typename... U>
     struct all_of<T, TypeList<U...>> {
-        static constexpr bool value = std::conjunction_v<std::is_same<T, U>...>;
+        static constexpr bool value = (std::is_same_v<T, U> && ...);
     };
 
     template <typename T, typename TypeList_t>
@@ -170,10 +175,6 @@ namespace fk { // namespace fused kernel
      */
     template <typename T, typename TypeList_t>
     constexpr size_t TypeIndex_v = TypeIndex<T, TypeList_t>::value;
-
-    // Obtain the type found in the index Idx, in TypeList
-    template <int n, typename TypeList_t>
-    using TypeAt_t = std::conditional_t<(n>=0), typename TypeList_t::template at<static_cast<size_t>(n)>, typename TypeList_t::last>;
 
     template <typename... Types>
     using FirstType_t = TypeAt_t<0, TypeList<Types...>>;

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -15,18 +15,7 @@
 #ifndef FK_UTILS
 #define FK_UTILS
 
-#if defined(_MSC_VER)
-#define _MSC_VER_EXISTS 1
-#else
-#define _MSC_VER_EXISTS 0
-#endif
- 
-#if defined(__clang__) && defined(__CUDA__)
-// clang compiling CUDA code, device mode.º
-#define CLANG_HOST_DEVICE 1
-#else
-#define CLANG_HOST_DEVICE 0
-#endif
+#include <fused_kernel/core/utils/compiler_macros.h>
 
 #if !defined(NVRTC_COMPILER)
 #include <string>

--- a/include/fused_kernel/core/utils/vector_utils.h
+++ b/include/fused_kernel/core/utils/vector_utils.h
@@ -1,4 +1,4 @@
-/* Copyright 2023-2025 Oscar Amoros Huguet
+/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include <fused_kernel/core/utils/type_lists.h>
 #include <fused_kernel/core/utils/template_operations.h>
 #include <fused_kernel/core/data/vector_types.h>
-#include <fused_kernel/core/utils/static_get.h>
+#include <fused_kernel/core/utils/utils.h>
 
 namespace fk {
     template <typename BaseType, int Channels>
@@ -72,24 +72,34 @@ namespace fk {
     template <typename BaseType, int Channels>
     using VectorType_t = typename VectorType<BaseType, Channels>::type;
 
-    template <uint CHANNELS>
-    using VectorTypeList = TypeList<VectorType_t<bool, CHANNELS>, VectorType_t<uchar, CHANNELS>, VectorType_t<schar, CHANNELS>,
-                                    VectorType_t<ushort, CHANNELS>, VectorType_t<short, CHANNELS>,
-                                    VectorType_t<uint, CHANNELS>, VectorType_t<int, CHANNELS>,
-                                    VectorType_t<ulong, CHANNELS>, VectorType_t<long, CHANNELS>,
-                                    VectorType_t<ulonglong, CHANNELS>, VectorType_t<longlong, CHANNELS>,
-                                    VectorType_t<float, CHANNELS>, VectorType_t<double, CHANNELS>>;
+    template <size_t CN> using bool_ = VectorType_t<bool, CN>;
+    template <size_t CN> using uchar_ = VectorType_t<uchar, CN>;
+    template <size_t CN> using char_ = VectorType_t<schar, CN>;
+    template <size_t CN> using ushort_ = VectorType_t<ushort, CN>;
+    template <size_t CN> using short_ = VectorType_t<short, CN>;
+    template <size_t CN> using uint_ = VectorType_t<uint, CN>;
+    template <size_t CN> using int_ = VectorType_t<int, CN>;
+    template <size_t CN> using ulong_ = VectorType_t<ulong, CN>;
+    template <size_t CN> using long_ = VectorType_t<long, CN>;
+    template <size_t CN> using ulonglong_ = VectorType_t<ulonglong, CN>;
+    template <size_t CN> using longlong_ = VectorType_t<longlong, CN>;
+    template <size_t CN> using float_ = VectorType_t<float, CN>;
+    template <size_t CN> using double_ = VectorType_t<double, CN>;
+
+    template <uint CN>
+    using VectorTypeList = TypeList<bool_<CN>, uchar_<CN>, char_<CN>, ushort_<CN>, short_<CN>, uint_<CN>, int_<CN>,
+                                    ulong_<CN>, long_<CN>, ulonglong_<CN>, longlong_<CN>, float_<CN>, double_<CN>>;
 
     using FloatingTypes = TypeList<float, double>;
     using IntegralTypes = TypeList<uchar, char, schar, ushort, short, uint, int, ulong, long, ulonglong, longlong>;
     using IntegralBaseTypes = TypeList<uchar, schar, ushort, short, uint, int, ulong, long, ulonglong, longlong>;
-    using StandardTypes = TypeListCat_t<TypeListCat_t<TypeList<bool>, IntegralTypes>, FloatingTypes>;
-    using BaseTypes = TypeListCat_t<TypeListCat_t<TypeList<bool>, IntegralBaseTypes>, FloatingTypes>;
+    using StandardTypes = TypeListCat_t<TypeList<bool>, IntegralTypes, FloatingTypes>;
+    using BaseTypes = TypeListCat_t<TypeList<bool>, IntegralBaseTypes, FloatingTypes>;
     using VOne = TypeList<bool1, uchar1, char1, ushort1, short1, uint1, int1, ulong1, long1, ulonglong1, longlong1, float1, double1>;
     using VTwo = VectorTypeList<2>;
     using VThree = VectorTypeList<3>;
     using VFour = VectorTypeList<4>;
-    using VAll = typename TypeList<VOne, VTwo, VThree, VFour>::type;
+    using VAll = TypeListCat_t<VOne, VTwo, VThree, VFour>;
 
     template <typename T>
     constexpr bool validCUDAVec = one_of<T, VAll>::value;
@@ -105,7 +115,8 @@ namespace fk {
             return 2;
         } else if constexpr (one_of_v<T, VThree>) {
             return 3;
-        } else if constexpr (one_of_v<T, VFour>) {
+        } else {
+            static_assert(one_of_v<T, VFour>, "Type T must be a valid CUDA vector type (1, 2, 3, or 4 channels)");
             return 4;
         }
     }
@@ -158,11 +169,9 @@ namespace fk {
     template <typename T>
     using VBase = typename VectorTraits<T>::base;
 
-    template <size_t Idx>
-    template <typename VT>
-    FK_HOST_DEVICE_CNST auto static_get<Idx>::f(const VT& v)
-        -> std::enable_if_t<IsCudaVector<VT>::value,
-                            typename VectorTraits<VT>::base> {
+    template <size_t Idx, typename VT>
+    FK_HOST_DEVICE_CNST auto static_get(const VT& v) {
+        static_assert(IsCudaVector<VT>::value, "Invalid type for static_get");
         static_assert((Idx < cn<VT>), "Index out of bounds.");
         if constexpr (Idx == 0) {
             return v.x;
@@ -301,25 +310,26 @@ namespace fk {
     struct BothIntegrals : public std::false_type {};
 
     template <typename I1, typename I2>
-    struct BothIntegrals<I1, I2, std::enable_if_t<std::is_integral_v<fk::VBase<I1>>&& std::is_integral_v<fk::VBase<I2>>, void>> : public std::true_type {};
+    struct BothIntegrals<I1, I2, std::enable_if_t<std::is_integral_v<fk::VBase<I1>> && std::is_integral_v<fk::VBase<I2>>, void>> : public std::true_type {};
 
     template <typename I1, typename I2, typename = void>
     struct AreVVEqCN : public std::false_type {};
 
     template <typename I1, typename I2>
-    struct AreVVEqCN<I1, I2, std::enable_if_t<fk::validCUDAVec<I1>&& fk::validCUDAVec<I2> && (fk::cn<I1> == fk::cn<I2>), void>> : public std::true_type {};
+        struct AreVVEqCN<I1, I2, std::enable_if_t<fk::validCUDAVec<I1> && fk::validCUDAVec<I2>>>
+        : public std::bool_constant<(fk::cn<I1> == fk::cn<I2>)> {};
 
     template <typename I1, typename I2, typename = void>
     struct AreSV : public std::false_type {};
 
     template <typename I1, typename I2>
-    struct AreSV<I1, I2, std::enable_if_t<std::is_fundamental_v<I1>&& fk::validCUDAVec<I2>, void>> : public std::true_type {};
+    struct AreSV<I1, I2, std::enable_if_t<std::is_fundamental_v<I1> && fk::validCUDAVec<I2>, void>> : public std::true_type {};
 
     template <typename I1, typename I2, typename = void>
     struct AreVS : public std::false_type {};
 
     template <typename I1, typename I2>
-    struct AreVS<I1, I2, std::enable_if_t<fk::validCUDAVec<I1>&& std::is_fundamental_v<I2>, void>> : public std::true_type {};
+    struct AreVS<I1, I2, std::enable_if_t<fk::validCUDAVec<I1> && std::is_fundamental_v<I2>, void>> : public std::true_type {};
 
     template <typename I1, typename I2, typename = void>
     struct AreSS : public std::false_type {};

--- a/tests/algorithm/test_batchresize_build.h
+++ b/tests/algorithm/test_batchresize_build.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2023-2025 Oscar Amoros Huguet
+﻿/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/core/data/array.h>
 #include <array>

--- a/tests/algorithm/test_border_reader.h
+++ b/tests/algorithm/test_border_reader.h
@@ -1,4 +1,5 @@
 /* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/border_reader.h>
 
 int launch() {

--- a/tests/algorithm/test_crop.h
+++ b/tests/algorithm/test_crop.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2025 Oscar Amoros Huguet
+﻿/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #include <tests/main.h>
 
 #include <fused_kernel/algorithms/image_processing/crop.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/resize.h>
 
 using namespace fk;
@@ -27,9 +27,9 @@ int launch() {
 
     constexpr Rect aCrop(10, 12, 20, 30);
     constexpr auto cropOp = Crop<ReadIOp>::build(readIOp, aCrop);
-    static_assert(isReadBackType<std::decay_t<decltype(cropOp)>>, "Crop is not ReadBack and should be");
+    static_assert(opIs<ReadBackType, std::decay_t<decltype(cropOp)>>, "Crop is not ReadBack and should be");
     constexpr auto fusedCrop = readIOp.then(Crop<>::build(Rect(11, 9, 10, 10)));
-    static_assert(isReadBackType<decltype(fusedCrop)>, "The IOp should be a ReadBack type");
+    static_assert(opIs<ReadBackType, decltype(fusedCrop)>, "The IOp should be a ReadBack type");
 
     constexpr std::array<Rect, 2> rects{ aCrop, Rect(15,15, 50, 20)};
 

--- a/tests/algorithm/test_deinterlace.h
+++ b/tests/algorithm/test_deinterlace.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/deinterlace.h>
 
 int launch() {

--- a/tests/algorithm/test_warp.h
+++ b/tests/algorithm/test_warp.h
@@ -1,4 +1,5 @@
 /* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/warping.h>
 
 int launch() {

--- a/tests/buildAPI/batch_build_compilation_time.h
+++ b/tests/buildAPI/batch_build_compilation_time.h
@@ -1,0 +1,84 @@
+/* Copyright 2025-2026 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/image_processing/crop.h>
+#include <fused_kernel/algorithms/image_processing/resize.h>
+#include <fused_kernel/algorithms/image_processing/color_conversion.h>
+#include <fused_kernel/algorithms/image_processing/image.h>
+#include <fused_kernel/algorithms/image_processing/border_reader.h>
+#include <fused_kernel/fused_kernel.h>
+
+using namespace fk;
+
+void testCompareReferenceVSValueVSInstantiableDPP() {
+    Stream stream;
+
+    // We set all outputs to the same size
+    const Size outputSize(60, 60);
+
+    // We perform 5 crops on the image
+    constexpr int BATCH_10 = 10;
+    constexpr int BATCH = 100;
+
+    // We have a 4K source image
+    Image<PixelFormat::NV12> inputImage(3840, 2160);
+
+    // Intermediate RGB image after YUV to RGB conversion
+    Ptr2D<float3> rgbImg(3840, 2160);
+
+    // Crops can be of different sizes
+    constexpr std::array<Rect, BATCH_10> crops_10{Rect(0, 0, 34, 25),      Rect(40, 40, 70, 15),     Rect(100, 200, 60, 59),
+                                         Rect(300, 1000, 20, 23), Rect(3000, 2000, 12, 11), Rect(0, 0, 34, 25),
+                                         Rect(40, 40, 70, 15),    Rect(100, 200, 60, 59),   Rect(300, 1000, 20, 23),
+                                         Rect(3000, 2000, 12, 11) };
+    std::array<Rect, BATCH> crops{};
+    std::array<Ptr2D<float3>, BATCH> cropedPtrs;
+
+    for (int i = 0; i < BATCH_10; ++i) {
+        int j{ 0 };
+        for (auto&& elem : crops_10) {
+            const int idx = i * BATCH_10 + j;
+            crops[idx] = elem;
+            j++;
+        }
+    }
+
+    const float3 backgroundColor{ 0.f, 0.f, 0.f };
+
+    // Create the operation instances once, and use them multiple times
+    const auto readIOp = ReadYUV<PixelFormat::NV12>::build(inputImage);
+    const auto yuvToRGB = ConvertYUVToRGB<PixelFormat::NV12,
+        ColorRange::Full,
+        ColorPrimitives::bt2020,
+        false, float3>::build();
+    const auto borderReader = BorderReader<BorderType::REPLICATE>::build();
+    const auto cropIOp = Crop<>::build(crops);
+    const auto resizeIOp =
+        Resize<InterpolationType::INTER_LINEAR, AspectRatio::PRESERVE_AR>::build(outputSize, backgroundColor);
+
+    const auto fusedPipeline = readIOp & yuvToRGB & borderReader & cropIOp & resizeIOp;
+
+    stream.sync();
+}
+
+int launch() {
+    testCompareReferenceVSValueVSInstantiableDPP();
+
+    return 0;
+}

--- a/tests/cudabug/test_nvcc131_BugReproducer.h
+++ b/tests/cudabug/test_nvcc131_BugReproducer.h
@@ -1,0 +1,72 @@
+/* Copyright 2023-2025 Mediaproduccion S.L.U. (Oscar Amoros Huguet)
+   Copyright 2025 Albert Andaluz
+   
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. 
+   */
+
+/* NVCC Bug reproducer
+   Affects versions 12.4 until 13.1
+ 
+   This code does not compile starting on CUDA version 12.4.
+
+   We add comments in the code, indicating the different
+   modifications that make the code compile, to help with the
+   bug investigation
+*/
+
+#ifdef __NVCC__
+#define NVCC_VERSION_CALCULATED (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 + __CUDACC_VER_BUILD__)
+#define NVCC_VERSION_12_4_99 120499
+
+// Condition 1: we are compiling with MSVC + nvcc OR other compilers + nvcc versions lower than 12.4.99
+#if ( NVCC_VERSION_CALCULATED < NVCC_VERSION_12_4_99)
+#define WILL_COMPILE 1
+#else
+#define WILL_NOT_COMPILE 1
+#endif
+
+// Undefine helper macros to avoid polluting the global macro namespace
+#undef NVCC_VERSION_CALCULATED
+#undef NVCC_VERSION_12_4_99
+#else
+#define WILL_COMPILE 1
+#endif // __NVCC__
+
+#ifdef WILL_COMPILE
+template <bool results> constexpr bool and_v = results;
+
+template <bool results> constexpr bool and_v2 = results;
+
+struct MyInt {
+    int instance;
+    // Removing this constexpr constructor makes the code compile
+    constexpr MyInt(int val) : instance(val) {}
+};
+
+constexpr bool firstFunc() {
+    constexpr MyInt myint{1};
+    constexpr bool result1 = myint.instance == 1;
+
+    // Using and_v2 here and keeping and_v in line 67
+    // or the other way around, compiles
+    // Changing result1 to the literal true, compiles
+    return and_v<result1>;
+}
+
+constexpr bool secondFunc() { 
+    return and_v<true>; 
+}
+#endif
+int launch() {
+    return 0;
+}

--- a/tests/data/basic_test.h
+++ b/tests/data/basic_test.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2023-2025 Oscar Amoros Huguet
+﻿/* Copyright 2023-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,13 +19,11 @@
 #include <fused_kernel/core/data/ptr_nd.h>
 #include <fused_kernel/core/data/ptr_utils.h>
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/image_processing/saturate.h>
 #include <fused_kernel/fused_kernel.h>
-#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/core/utils/template_operations.h>
-#include <fused_kernel/algorithms/image_processing/saturate.h>
 #include <fused_kernel/core/execution_model/stream.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
 
@@ -36,7 +34,7 @@ bool testPtr_2D() {
     constexpr size_t width_crop = 300;
     constexpr size_t height_crop = 200;
 
-    fk::Point startPoint = {100, 200};
+    fk::Point startPoint = {100, 200, 0};
 
     fk::Stream stream;
 
@@ -100,26 +98,47 @@ int launch() {
     fk::Unary<fk::SaturateCast<uchar, uint>> cast = {};
     fk::Write<fk::PerThreadWrite<fk::ND::_2D, uint>> write { {output} };
 
-    auto fusedDF = fk::fuse(read, cast, fk::Binary<fk::Mul<uint>>{4});
-    static_assert(std::is_same_v<decltype(fusedDF.params.instance.params), fk::RawPtr<fk::ND::_2D, uchar>>, "Unexpected type for params");
+    auto fusedDF = fk::fuse(read, cast, fk::Binary<fk::Mul<uint>>{4u});
+    constexpr bool correct = std::is_same_v<std::decay_t<decltype(fusedDF.params)>,
+                       fk::OperationTuple_<void, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>,
+                                              fk::Unary<fk::SaturateCast<uchar, uint>>, fk::Binary<fk::Mul<uint>>>>;
+    static_assert(correct, "Unexpected type for fusedDF.params");
+    constexpr bool correct2 =
+        std::is_same_v<std::decay_t<decltype(fk::get_opt<0>(fusedDF.params))>, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>;
+    static_assert(correct2, "Unexpected type for get<0>(fusedDF.params)");
     //fusedDF.params.next.instance.params; // Should not compile
-    static_assert(std::is_same_v<decltype(fusedDF.params.next.next.instance.params), uint>, "Unexpected type for params");
+    auto params2 = fk::get_opt<2>(fusedDF.params).params;
+    static_assert(std::is_same_v<std::decay_t<decltype(params2)>, uint>, "Unexpected type for params");
 
     fk::executeOperations<fk::TransformDPP<>>(stream, fusedDF, write);
     stream.sync();
 
-    fk::OperationTuple<fk::PerThreadRead<fk::ND::_2D, uchar>, fk::SaturateCast<uchar, uint>, fk::PerThreadWrite<fk::ND::_2D, uint>> myTup{};
+    fk::OperationTuple<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>, fk::Unary<fk::SaturateCast<uchar, uint>>, fk::Write<fk::PerThreadWrite<fk::ND::_2D, uint>>> myTup{};
 
-    fk::get<2>(myTup);
-    constexpr bool test1 = std::is_same_v<fk::get_type_t<0, decltype(myTup)>, fk::PerThreadRead<fk::ND::_2D, uchar>>;
-    constexpr bool test2 = std::is_same_v<fk::get_type_t<1, decltype(myTup)>, fk::SaturateCast<uchar, uint>>;
-    constexpr bool test3 = std::is_same_v<fk::get_type_t<2, decltype(myTup)>, fk::PerThreadWrite<fk::ND::_2D, uint>>;
+    fk::get_opt<2>(myTup);
+    constexpr bool test1 = std::is_same_v<fk::TypeAt_t<0, typename decltype(myTup)::Operations>, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>;
+    constexpr bool test2 =
+        std::is_same_v<fk::TypeAt_t<1, typename decltype(myTup)::Operations>, fk::Unary<fk::SaturateCast<uchar, uint>>>;
+    constexpr bool test3 =
+        std::is_same_v<fk::TypeAt_t<2, typename decltype(myTup)::Operations>, fk::Write<fk::PerThreadWrite<fk::ND::_2D, uint>>>;
 
     if (test2Dpassed && fk::and_v<test1, test2, test3>) {
         std::cout << "cuda_transform executed!!" << std::endl;
         return 0;
     } else {
         std::cout << "cuda_transform failed!!" << std::endl;
+        if (!test2Dpassed) {
+            std::cout << "Specifically testPtr_2D failed!!" << std::endl;
+        }
+        if (!test1) {
+            std::cout << "Specifically test1 failed!!" << std::endl;
+        }
+        if (!test2) {
+            std::cout << "Specifically test2 failed!!" << std::endl;
+        }
+        if (!test3) {
+            std::cout << "Specifically test3 failed!!" << std::endl;
+        }
         return -1;
     }
 }

--- a/tests/data/test_ptr_nd.h
+++ b/tests/data/test_ptr_nd.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ int launch() {
     bool h_correct{ true };
     for (int y = 0; y < HEIGHT; y++) {
         for (int x = 0; x < WIDTH; x++) {
-            const Bool3 boolVect = *PtrAccessor<ND::_2D>::cr_point(Point(x, y), test0.ptrPinned()) == make_<uchar3>(1, 2, 3);
+            const Bool3 boolVect = *PtrAccessor<ND::_2D>::cr_point(Point{x, y, 0}, test0.ptrPinned()) == make_<uchar3>(1, 2, 3);
             const bool allTrue = boolVect;
             h_correct &= allTrue;
         }
@@ -182,7 +182,7 @@ int launch() {
     bool h_correct2{ true };
     for (int y = 0; y < HEIGHT; y++) {
         for (int x = 0; x < WIDTH; x++) {
-            const bool allTrue = test7.at(Point(x, y)) == make_<uchar3>(3, 6, 10);
+            const bool allTrue = test7.at(Point{x, y, 0}) == uchar3{3, 6, 10};
             h_correct2 &= allTrue;
         }
     }

--- a/tests/data/test_rect.h
+++ b/tests/data/test_rect.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 int launch() {
 
-    constexpr fk::Rect test(fk::Point(16, 32), fk::Size(32, 64));
+    constexpr fk::Rect test(fk::Point{16, 32, 0}, fk::Size(32, 64));
     static_assert(test.x == 16, "Something wrong");
     static_assert(test.y == 32, "Something wrong");
     static_assert(test.width == 32, "Something wrong");

--- a/tests/data/test_tuple.h
+++ b/tests/data/test_tuple.h
@@ -1,4 +1,5 @@
-﻿/* Copyright 2023-2024 Mediaproduccion S.L.U. (Oscar Amoros Huguet)
+﻿/* Copyright 2023-2024 Grup Mediapro S.L.U. (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,10 +19,26 @@
 
 #include <fused_kernel/core/execution_model/operation_model/operation_tuple.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#ifdef __NVCC__
+// Condition 1: we are compiling with MSVC + nvcc OR other compilers + nvcc versions lower than 12.4.99
+#if (NVCC_VERSION_CALCULATED < NVCC_VERSION_12_4_99)
+#define WILL_COMPILE 1
+#else
+#define WILL_NOT_COMPILE 1
+#endif
+
+// Undefine helper macros to avoid polluting the global macro namespace
+#undef NVCC_VERSION_CALCULATED
+#undef NVCC_VERSION_12_4_99
+#else
+#define WILL_COMPILE 1
+#endif // __NVCC__
+
+#ifdef WILL_COMPILE
 
 constexpr bool buildTuple() {
-    constexpr fk::Tuple<int, float, double, float3> test{1, 4.f, 5.0, {4.f, 3.f, 1.f}};
+    constexpr fk::Tuple<int, float, double, float3> test{1, 4.f, 5.0, float3{4.f, 3.f, 1.f}};
 
     constexpr bool result1 = fk::TupleUtil::get<0>(test) == 1;
     constexpr bool result2 = fk::TupleUtil::get<1>(test) == 4.f;
@@ -33,11 +50,11 @@ constexpr bool buildTuple() {
 }
 
 constexpr bool buildOperationTupleType() {
-    using Op1 = fk::PerThreadRead<fk::ND::_2D, uchar3>;
-    using Op2 = fk::VectorReorder<uchar3, 0, 1, 2>;
-    using Op3 = fk::PerThreadWrite<fk::ND::_2D, uchar3>;
+    using Op1 = typename fk::PerThreadRead<fk::ND::_2D, uchar3>::InstantiableType;
+    using Op2 = typename fk::VectorReorder<uchar3, 0, 1, 2>::InstantiableType;
+    using Op3 = typename fk::PerThreadWrite<fk::ND::_2D, uchar3>::InstantiableType;
 
-    using TupleType = fk::OperationTuple<Op1, Op2, Op3>;
+    using TupleType = typename fk::OperationTuple<Op1, Op2, Op3>::Operations;
 
     constexpr bool result1 = std::is_same_v<fk::get_type_t<0, TupleType>, Op1>;
     constexpr bool result2 = std::is_same_v<fk::get_type_t<1, TupleType>, Op2>;
@@ -52,7 +69,7 @@ constexpr bool tupleCat() {
     constexpr Tuple1 tuple1{ 1, 1.f };
     constexpr Tuple2 tuple2{ 1u, 1.0 };
 
-    constexpr auto myTuple = fk::cat(tuple1, tuple2);
+    constexpr auto myTuple = fk::tuple_cat(tuple1, tuple2);
 
     return fk::and_v<fk::get<0>(myTuple) == 1,
                      fk::get<1>(myTuple) == 1.f,
@@ -84,8 +101,10 @@ bool modifyTupleElement() {
            (fk::get<1>(myTuple) == 0.5f) &&
            (fk::get<2>(myTuple) == 3.0);
 }
+#endif
 
 int launch() {
+#ifdef WILL_COMPILE
     static_assert(buildTuple(), "Failed buildTuple test");
     static_assert(buildOperationTupleType(), "Failed buildOperationTupleType test");
     static_assert(tupleCat(), "Failed tupleCat test");
@@ -98,4 +117,9 @@ int launch() {
         std::cout << "test_tuple Failed!!" << std::endl;
         return -1;
     }
+#else
+    return 0;
+#endif
 }
+ 
+

--- a/tests/examples/compiler_explorer_example.h
+++ b/tests/examples/compiler_explorer_example.h
@@ -1,0 +1,52 @@
+/* Copyright 2025 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/fused_kernel.h>
+#include <fused_kernel/core/execution_model/execution_model.h>
+#include <fused_kernel/algorithms/algorithms.h>
+
+using namespace fk;
+
+void testLTS0013() {
+    // Define input and output data
+    Ptr2D<uchar4> input(1920, 1080);
+    std::array<Rect, 5> crops{ Rect(0, 0, 120, 40),
+                               Rect(100, 200, 60, 40),
+                               Rect(400, 20, 30, 50),
+                               Rect(1000, 800, 30, 30),
+                               Rect(40, 40, 40, 40)}; 
+    Tensor<uchar4> output(64, 64, 5);
+    Stream stream;
+
+    // Define and execute operations over the data
+    executeOperations<TransformDPP<>>(input, stream,
+                                      Crop<>::build(crops),
+                                      Resize<InterpolationType::INTER_LINEAR>::build(Size(64,64)),
+                                      Mul<float4>::build(make_set<float4>(1.f/255.f)),
+                                      Mul<float4>::build(make_set<float4>(0.33f)),
+                                      Add<float4>::build(make_set<float4>(0.5f)),
+                                      Mul<float4>::build(make_set<float4>(255.f)),
+                                      SaturateCast<float4, uchar4>::build(),
+                                      TensorWrite<uchar4>::build(output));
+
+    stream.sync();
+}
+
+int launch() {
+    testLTS0013();
+
+    return 0;
+}

--- a/tests/examples/inlining_and_LDL_STL.h
+++ b/tests/examples/inlining_and_LDL_STL.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #define __ONLY_CU__
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/utils/utils.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/image_processing/crop.h>
@@ -26,45 +26,29 @@
 using namespace fk;
 
 template <ParArch PA = defaultParArch> struct SimpleTransformDPPValue;
+template <ParArch PA = defaultParArch> struct SimpleTransformDPPValueLessCallDepth;
 template <ParArch PA = defaultParArch> struct SimpleTransformDPPReference;
+template <ParArch PA = defaultParArch> struct SimpleTransformDPPReferenceFoldExpr;
 
 struct SimpleTransformDPPBaseValue {
     friend struct SimpleTransformDPPValue<ParArch::GPU_NVIDIA>; // Allow TransformDPP to access private members
   private:
-    template <typename T, typename IOp, typename... IOpTypes>
-    FK_HOST_DEVICE_FUSE auto operate(const Point& thread, const T& i_data, const IOp& iOp,
-                                     const IOpTypes&... iOpInstances) {
-        static_assert(!isIncompleteReadBackType<IOp>, "Trying to execute an incomplete IOp");
-        if constexpr (IOp::template is<WriteType>) {
-            return i_data;
-            // MidWriteOperation with continuations, based on FusedOperation
-        } else if constexpr (IOp::template is<MidWriteType> && isMidWriteType<typename IOp::Operation>) {
-            return IOp::Operation::exec(thread, i_data, iOp);
-        } else if constexpr (IOp::template is<MidWriteType> && !isMidWriteType<typename IOp::Operation>) {
-            IOp::Operation::exec(thread, i_data, iOp);
-            return i_data;
-        } else {
-            return operate(thread, compute(i_data, iOp), iOpInstances...);
-        }
-    }
-
     template <typename ReadIOp, typename... IOps>
     FK_HOST_DEVICE_FUSE void execute_thread(const Point thread, const ReadIOp readDF, const IOps... iOps) {
         using ReadOperation = typename ReadIOp::Operation;
         using WriteOperation = typename LastType_t<IOps...>::Operation;
 
-        const auto writeDF = ppLast(iOps...);
+        const auto& writeDF = ppLast(iOps...);
 
-        const auto tempI = ReadIOp::Operation::exec(thread, readDF);
         if constexpr (sizeof...(iOps) > 1) {
-            const auto tempO = operate(thread, tempI, iOps...);
+            const auto tempO = ((thread | readDF) | ... | iOps).input;
             WriteOperation::exec(thread, tempO, writeDF);
         } else {
-            WriteOperation::exec(thread, tempI, writeDF);
+            WriteOperation::exec(thread, ReadIOp::Operation::exec(thread, readDF), writeDF);
         }
     }
 
-    template <typename FirstIOp> FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const FirstIOp& iOp) {
+    template <typename FirstIOp> FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const FirstIOp iOp) {
         return FirstIOp::Operation::getActiveThreads(iOp);
     }
 };
@@ -72,41 +56,47 @@ struct SimpleTransformDPPBaseValue {
 struct SimpleTransformDPPBaseReference {
     friend struct SimpleTransformDPPReference<ParArch::GPU_NVIDIA>; // Allow TransformDPP to access private members
   private:
-    template <typename T, typename IOp, typename... IOpTypes>
-    FK_HOST_DEVICE_FUSE auto operate(const Point& thread, const T& i_data, const IOp& iOp,
-                                     const IOpTypes&... iOpInstances) {
-        static_assert(!isIncompleteReadBackType<IOp>, "Trying to execute an incomplete IOp");
-        if constexpr (IOp::template is<WriteType>) {
-            return i_data;
-            // MidWriteOperation with continuations, based on FusedOperation
-        } else if constexpr (IOp::template is<MidWriteType> && isMidWriteType<typename IOp::Operation>) {
-            return IOp::Operation::exec(thread, i_data, iOp);
-        } else if constexpr (IOp::template is<MidWriteType> && !isMidWriteType<typename IOp::Operation>) {
-            IOp::Operation::exec(thread, i_data, iOp);
-            return i_data;
-        } else {
-            return operate(thread, compute(i_data, iOp), iOpInstances...);
-        }
-    }
-
     template <typename ReadIOp, typename... IOps>
-    FK_HOST_DEVICE_FUSE void execute_thread(const Point& thread, const ReadIOp& readDF, const IOps&... iOps) {
+    FK_HOST_DEVICE_FUSE void execute_thread(const Point thread, const ReadIOp& readDF, const IOps&... iOps) {
         using ReadOperation = typename ReadIOp::Operation;
         using WriteOperation = typename LastType_t<IOps...>::Operation;
 
-        const auto writeDF = ppLast(iOps...);
+        const auto& writeDF = ppLast(iOps...);
 
-        const auto tempI = ReadIOp::Operation::exec(thread, readDF);
         if constexpr (sizeof...(iOps) > 1) {
-            const auto tempO = operate(thread, tempI, iOps...);
+            const auto tempO = ((thread | readDF) | ... | iOps).input;
             WriteOperation::exec(thread, tempO, writeDF);
         } else {
-            WriteOperation::exec(thread, tempI, writeDF);
+            WriteOperation::exec(thread, ReadIOp::Operation::exec(thread, readDF), writeDF);
         }
     }
 
     template <typename FirstIOp>
     FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const FirstIOp& iOp) {
+        return FirstIOp::Operation::getActiveThreads(iOp);
+    }
+};
+
+struct SimpleTransformDPPBaseReferenceFoldExpr {
+    friend struct SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>; // Allow SimpleTransformDPPReferenceFoldExpr
+                                                                            // to access private members
+  private:
+    template <typename ReadIOp, typename... IOps>
+    FK_HOST_DEVICE_FUSE void execute_thread(const Point thread, const ReadIOp &readDF, const IOps &...iOps) {
+        using ReadOperation = typename ReadIOp::Operation;
+        using WriteOperation = typename LastType_t<IOps...>::Operation;
+
+        const auto& writeDF = ppLast(iOps...);
+
+        if constexpr (sizeof...(iOps) > 1) {
+            const auto tempO = ((thread | readDF) | ... | iOps);
+            WriteOperation::exec(thread, tempO.input, writeDF);
+        } else {
+            WriteOperation::exec(thread, ReadIOp::Operation::exec(thread, readDF), writeDF);
+        }
+    }
+
+    template <typename FirstIOp> FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const FirstIOp &iOp) {
         return FirstIOp::Operation::getActiveThreads(iOp);
     }
 };
@@ -129,7 +119,7 @@ struct SimpleTransformDPPValue<ParArch::GPU_NVIDIA> {
 
         const Point thread{x, y, z};
 
-        const ActiveThreads activeThreads = getActiveThreads(get<0>(iOps...));
+        const ActiveThreads activeThreads = getActiveThreads(get_arg<0>(iOps...));
 
         if (x < activeThreads.x && y < activeThreads.y) {
             Parent::execute_thread(thread, iOps...);
@@ -137,7 +127,13 @@ struct SimpleTransformDPPValue<ParArch::GPU_NVIDIA> {
     }
 };
 
-template <> struct SimpleTransformDPPReference<ParArch::GPU_NVIDIA> {
+template <>
+struct SimpleTransformDPPValueLessCallDepth<ParArch::GPU_NVIDIA> {
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+};
+
+template <>
+struct SimpleTransformDPPReference<ParArch::GPU_NVIDIA> {
   private:
     using Parent = SimpleTransformDPPBaseReference;
 
@@ -155,7 +151,34 @@ template <> struct SimpleTransformDPPReference<ParArch::GPU_NVIDIA> {
 
         const Point thread{x, y, z};
 
-        const ActiveThreads activeThreads = getActiveThreads(get<0>(iOps...));
+        const ActiveThreads activeThreads = getActiveThreads(get_arg<0>(iOps...));
+
+        if (x < activeThreads.x && y < activeThreads.y) {
+            Parent::execute_thread(thread, iOps...);
+        }
+    }
+};
+
+template <>
+struct SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA> {
+  private:
+    using Parent = SimpleTransformDPPBaseReferenceFoldExpr;
+
+  public:
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+    template <typename FirstIOp> FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const FirstIOp &iOp) {
+        return Parent::getActiveThreads(iOp);
+    }
+
+    template <typename... IOps>
+    FK_DEVICE_FUSE void exec(const IOps &...iOps) {
+        const int x = (blockDim.x * blockIdx.x) + threadIdx.x;
+        const int y = (blockDim.y * blockIdx.y) + threadIdx.y;
+        const int z = blockIdx.z;
+
+        const Point thread{x, y, z};
+
+        const ActiveThreads activeThreads = getActiveThreads(get_arg<0>(iOps...));
 
         if (x < activeThreads.x && y < activeThreads.y) {
             Parent::execute_thread(thread, iOps...);
@@ -177,19 +200,14 @@ struct InstantiableDPP {
 struct SimpleTransformDPPReferenceBuilder {
     template <typename... IOps>
     FK_HOST_FUSE auto build(const IOps&... iops) {
-        return InstantiableDPP<SimpleTransformDPPReference<ParArch::GPU_NVIDIA>, IOps...>{make_tuple(iops...)};
+        return InstantiableDPP<SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>, IOps...>{make_tuple(iops...)};
     }
 };
 
-template <typename IDPP, size_t... Idx>
-FK_DEVICE_CNST void exec_helper(const IDPP& idpp, const std::index_sequence<Idx...>&) {
-    IDPP::DPP::exec(fk::get<Idx>(idpp.ops)...);
-}
-
 template <typename IDPP>
 __global__ void launchInstantiableDPP_Kernel(const __grid_constant__ IDPP idpp) {
-    constexpr std::make_index_sequence<IDPP::OperationsTuple::size> seq{};
-    exec_helper(idpp, seq);
+    fk::apply([](auto &&...args) { return std::decay_t<IDPP>::DPP::exec(std::forward<decltype(args)>(args)...); },
+              idpp.ops);
 }
 
 template <typename... IOps>
@@ -197,9 +215,102 @@ __global__ void launchSimpleTransformDPPValue_Kernel(const __grid_constant__ IOp
     SimpleTransformDPPValue<ParArch::GPU_NVIDIA>::exec(iOps...);
 }
 
+template <size_t N, typename T> 
+FK_HOST_DEVICE_CNST T dummyCalls(const T something) { 
+    if constexpr (N == 0) {
+        return something;
+    } else {
+        return dummyCalls<N - 1, T>(something);
+    }
+}
+
+template <typename I, typename P, typename O, typename ChildImplementation, bool IS_FUSED = false>
+struct BinaryOperationValue {
+  private:
+    using SelfType = BinaryOperationValue<I, P, O, ChildImplementation, IS_FUSED>;
+
+  public:
+    FK_STATIC_STRUCT(BinaryOperationValue, SelfType)
+    using Child = ChildImplementation;
+    using InputType = I;
+    using OutputType = O;
+    using ParamsType = P;
+    using InstanceType = BinaryType;
+    using OperationDataType = OperationData<Child>;
+    using InstantiableType = Binary<Child>;
+    static constexpr bool IS_FUSED_OP = IS_FUSED;
+    static constexpr int N = 1;
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const OperationDataType opData) {
+        if constexpr (N == 0) {
+            return Child::exec(input, opData.params);
+        } else {
+            return Child::exec(input, dummyCalls<N - 1>(opData).params);
+        }
+    }
+    FK_HOST_FUSE InstantiableType build(const OperationDataType &opData) { return InstantiableType{opData}; }
+    FK_HOST_FUSE InstantiableType build(const ParamsType &params) { return InstantiableType{{params}}; }
+};
+
+template <typename I, typename P = I, typename O = I>
+struct DummyOp {
+  private:
+    using Self = DummyOp<I, P, O>;
+    using Parent = BinaryOperationValue<I, P, O, Self>;
+  public:
+    using InputType = typename Parent::InputType;
+    using OutputType = typename Parent::OutputType;
+    using ParamsType = typename Parent::ParamsType;
+    using InstanceType = typename Parent::InstanceType;
+    using OperationDataType = typename Parent::OperationDataType;
+    using InstantiableType = typename Parent::InstantiableType;
+    static constexpr bool IS_FUSED_OP = Parent::IS_FUSED_OP;
+
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const OperationDataType opData) {
+        return Parent::exec(input, opData);
+    }
+
+    static constexpr inline InstantiableType build(const OperationDataType &opData) { return Parent::build(opData); }
+    static constexpr inline InstantiableType build(const ParamsType &params) { return Parent::build(params); }
+    
+    FK_HOST_DEVICE_FUSE O exec(const I input, const P params) { 
+        return static_cast<O>(input + params);
+    }
+};
+
+template <typename ReadIOp, typename... IOps>
+__global__ void launchSimpleTransformDPPValueLessCallDepth_Kernel(const __grid_constant__ ReadIOp readIOp, const __grid_constant__ IOps... iOps) {
+    const int x = (blockDim.x * blockIdx.x) + threadIdx.x;
+    const int y = (blockDim.y * blockIdx.y) + threadIdx.y;
+    const int z = blockIdx.z;
+
+    const Point thread{x, y, z};
+
+    const ActiveThreads activeThreads = ReadIOp::Operation::getActiveThreads(readIOp);
+
+    if (x < activeThreads.x && y < activeThreads.y) {
+        using ReadOperation = typename ReadIOp::Operation;
+        using WriteOperation = typename LastType_t<IOps...>::Operation;
+
+        const auto writeIOp = ppLast(iOps...);
+        const auto readIOpTemp = dummyCalls<0>(readIOp);
+
+        if constexpr (sizeof...(iOps) > 1) {
+            const auto tempO = ((thread | readIOpTemp) | ... | iOps).input;
+            WriteOperation::exec(thread, tempO, writeIOp);
+        } else {
+            WriteOperation::exec(thread, (thread | readIOpTemp).input, writeIOp);
+        }
+    }
+}
+
 template <typename... IOps>
 __global__ void launchSimpleTransformDPPReference_Kernel(const __grid_constant__ IOps... iOps) {
     SimpleTransformDPPReference<ParArch::GPU_NVIDIA>::exec(iOps...);
+}
+
+template <typename... IOps>
+__global__ void launchSimpleTransformDPPReferenceFoldExpr_Kernel(const __grid_constant__ IOps... iOps) {
+    SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>::exec(iOps...);
 }
 
 template <>
@@ -241,7 +352,7 @@ struct Executor<SimpleTransformDPPValue<ParArch::GPU_NVIDIA>> {
     FK_HOST_FUSE void executeOperations_helper(Stream_<ParArch::GPU_NVIDIA> &stream_, const IOps &...iOps) {
         const cudaStream_t stream = stream_.getCUDAStream();
         
-        const auto readOp = get<0>(iOps...);
+        const auto readOp = get_arg<0>(iOps...);
 
         const ActiveThreads activeThreads = readOp.getActiveThreads();
 
@@ -262,6 +373,34 @@ struct Executor<SimpleTransformDPPValue<ParArch::GPU_NVIDIA>> {
 };
 
 template <>
+struct Executor<SimpleTransformDPPValueLessCallDepth<ParArch::GPU_NVIDIA>> {
+  private:
+    using Child = Executor<SimpleTransformDPPValueLessCallDepth<ParArch::GPU_NVIDIA>>;
+    using Parent = BaseExecutor<Child>;
+    template <typename... IOps>
+    FK_HOST_FUSE void executeOperations_helper(Stream_<ParArch::GPU_NVIDIA> &stream_, const IOps &...iOps) {
+        const cudaStream_t stream = stream_.getCUDAStream();
+
+        const auto& readOp = get_arg<0>(iOps...);
+
+        const ActiveThreads activeThreads = readOp.getActiveThreads();
+
+        const CtxDim3 ctx_block = getDefaultBlockSize(activeThreads.x, activeThreads.y);
+
+        const dim3 block{ctx_block.x, ctx_block.y, 1};
+        const dim3 grid{static_cast<uint>(ceil(activeThreads.x / static_cast<float>(block.x))),
+                        static_cast<uint>(ceil(activeThreads.y / static_cast<float>(block.y))), activeThreads.z};
+        launchSimpleTransformDPPValueLessCallDepth_Kernel<<<grid, block, 0, stream>>>(iOps...);
+        gpuErrchk(cudaGetLastError());
+    }
+
+  public:
+    FK_STATIC_STRUCT(Executor, Child)
+    FK_HOST_FUSE ParArch parArch() { return ParArch::GPU_NVIDIA; }
+    DECLARE_EXECUTOR_PARENT_IMPL
+};
+
+template <>
 struct Executor<SimpleTransformDPPReference<ParArch::GPU_NVIDIA>> {
   private:
     using Child = Executor<SimpleTransformDPPReference<ParArch::GPU_NVIDIA>>;
@@ -270,7 +409,7 @@ struct Executor<SimpleTransformDPPReference<ParArch::GPU_NVIDIA>> {
     FK_HOST_FUSE void executeOperations_helper(Stream_<ParArch::GPU_NVIDIA> &stream_, const IOps &...iOps) {
         const cudaStream_t stream = stream_.getCUDAStream();
 
-        const auto readOp = get<0>(iOps...);
+        const auto readOp = get_arg<0>(iOps...);
 
         const ActiveThreads activeThreads = readOp.getActiveThreads();
 
@@ -289,6 +428,34 @@ struct Executor<SimpleTransformDPPReference<ParArch::GPU_NVIDIA>> {
     DECLARE_EXECUTOR_PARENT_IMPL
 };
 
+template <>
+struct Executor<SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>> {
+  private:
+    using Child = Executor<SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>>;
+    using Parent = BaseExecutor<Child>;
+    template <typename... IOps>
+    FK_HOST_FUSE void executeOperations_helper(Stream_<ParArch::GPU_NVIDIA> &stream_, const IOps &...iOps) {
+        const cudaStream_t stream = stream_.getCUDAStream();
+
+        const auto readOp = get_arg<0>(iOps...);
+
+        const ActiveThreads activeThreads = readOp.getActiveThreads();
+
+        const CtxDim3 ctx_block = getDefaultBlockSize(activeThreads.x, activeThreads.y);
+
+        const dim3 block{ctx_block.x, ctx_block.y, 1};
+        const dim3 grid{static_cast<uint>(ceil(activeThreads.x / static_cast<float>(block.x))),
+                        static_cast<uint>(ceil(activeThreads.y / static_cast<float>(block.y))), activeThreads.z};
+        launchSimpleTransformDPPReferenceFoldExpr_Kernel<<<grid, block, 0, stream>>>(iOps...);
+        gpuErrchk(cudaGetLastError());
+    }
+
+  public:
+    FK_STATIC_STRUCT(Executor, Child)
+    FK_HOST_FUSE ParArch parArch() { return ParArch::GPU_NVIDIA; }
+    DECLARE_EXECUTOR_PARENT_IMPL
+};
+
 void testCompareReferenceVSValueVSInstantiableDPP() {
     Stream stream;
 
@@ -296,19 +463,24 @@ void testCompareReferenceVSValueVSInstantiableDPP() {
     const Size outputSize(60, 60);
 
     // We perform 5 crops on the image
-    constexpr int BATCH = 10;
+    constexpr int BATCH = 100;
 
     // We have a 4K source image
     Ptr2D<uchar3> inputImage(3840, 2160);
+    Ptr2D<float3> outputImage(3840, 2160);
 
     // We want a Tensor of contiguous memory for all images
     Tensor<float3> output(outputSize.width, outputSize.height, BATCH);
 
     // Crops can be of different sizes
-    std::array<Rect, BATCH> crops{Rect(0, 0, 34, 25),      Rect(40, 40, 70, 15),     Rect(100, 200, 60, 59),
+    std::array<Rect, 10> crops10{Rect(0, 0, 34, 25),      Rect(40, 40, 70, 15),     Rect(100, 200, 60, 59),
                                   Rect(300, 1000, 20, 23), Rect(3000, 2000, 12, 11), Rect(0, 0, 34, 25),
                                   Rect(40, 40, 70, 15),    Rect(100, 200, 60, 59),   Rect(300, 1000, 20, 23),
                                   Rect(3000, 2000, 12, 11)};
+    std::array<Rect, BATCH> crops{};
+    for (int i = 0; i < BATCH; ++i) {
+        crops[i] = crops10[i % 10];
+    }
 
     // initImageValues(inputImage);
     const float3 backgroundColor{0.f, 0.f, 0.f};
@@ -344,6 +516,23 @@ void testCompareReferenceVSValueVSInstantiableDPP() {
     // and passes that transform instance to the CUDA kernel.
     executeOperations<InstantiableSimpleTransformDPPReference>(
         stream, readIOp, cropIOp, resizeIOp, mulIOp, subIOp, divIOp, colorIOp, tensorWriteIOp);
+
+    // Fourth, test the fold expression solution to expand the IOp parameter pack
+    executeOperations<SimpleTransformDPPReferenceFoldExpr<>>(stream, readIOp, cropIOp, resizeIOp, mulIOp, subIOp,
+                                                                     divIOp, colorIOp, tensorWriteIOp);
+
+    executeOperations<TransformDPP<>>(stream, readIOp, cropIOp, resizeIOp, mulIOp, subIOp,
+                                              divIOp, colorIOp, tensorWriteIOp);
+
+    // Fifth, test (partial) pass by value, with less device function call depth
+    /* const auto dummyIOp = DummyOp<uchar3, float3, float3>::build(make_set<float3>(2.f));
+    using DummyOpType = typename std::decay_t<decltype(dummyIOp)>::Operation;
+    static_assert(std::is_same_v<typename DummyOpType::OutputType, float3>, "Not float3");
+    auto result = (Point{0, 0, 0} | readIOp.then(cropIOp) | dummyIOp);
+    using ResultType = decltype(result.input);
+    static_assert(std::is_same_v<ResultType, float3>, "Not float3");
+    executeOperations<SimpleTransformDPPValueLessCallDepth<>>(stream, readIOp.then(cropIOp), Cast<uchar3, float3>::build(), mulIOp,
+                                                              subIOp, divIOp, colorIOp, tensorWriteIOp); */
 
     stream.sync();
 }

--- a/tests/examples/readme_test_code.h
+++ b/tests/examples/readme_test_code.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/utils/utils.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/image_processing/crop.h>
@@ -28,7 +28,7 @@ int launch() {
     Stream stream;
 
     // We set all outputs to the same size
-    const Size outputSize(60, 60);
+    constexpr Size outputSize(60, 60);
     // We perform 5 crops on the image
     constexpr int BATCH = 5;
 
@@ -39,7 +39,7 @@ int launch() {
     Tensor<float3> output(outputSize.width, outputSize.height, BATCH);
 
     // Crops can be of different sizes
-    std::array<Rect, BATCH> crops{
+    constexpr std::array<Rect, BATCH> crops{
         Rect(0, 0, 34, 25),
         Rect(10, 10, 70, 15),
         Rect(20, 20, 60, 59),
@@ -48,11 +48,11 @@ int launch() {
     };
 
     //initImageValues(inputImage);
-    const float3 backgroundColor{ 0.f, 0.f, 0.f };
+    constexpr float3 backgroundColor{ 0.f, 0.f, 0.f };
 
-    const float3 mulValue = make_set<float3>(1.4f);
-    const float3 subValue = make_set<float3>(0.5f);
-    const float3 divValue = make_set<float3>(255.f);
+    constexpr float3 mulValue = make_set<float3>(1.4f);
+    constexpr float3 subValue = make_set<float3>(0.5f);
+    constexpr float3 divValue = make_set<float3>(255.f);
 
     // Create a fused operation that reads the input image,
     // crops it, resizes it, and applies arithmetic operations

--- a/tests/operation/test_filtered_index_sequence.h
+++ b/tests/operation/test_filtered_index_sequence.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-2025 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,14 +15,22 @@
 
 #include <tests/main.h>
 
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 
-template <typename Restriction, typename... ListTypes>
-constexpr bool allInstantiableOperationsComplieWith(const fk::TypeList<ListTypes...>& tl) {
-    return fk::and_v<(Restriction::template complies<typename ListTypes::InstanceType>())...>;
-}
+template <typename Restriction, typename T>
+struct CheckCompliance {
+    static constexpr bool value = Restriction::template complies<T>();
+};
+
+template <typename Restriction, typename TypeList_> 
+struct AllIOpsComply;
+
+template <typename Restriction, typename... Types>
+struct AllIOpsComply<Restriction, fk::TypeList<Types...>> {
+    static constexpr bool value = fk::and_v<(CheckCompliance<Restriction, typename Types::InstanceType>::value)...>;
+};
 
 int launch() {
     using ReadDummy = fk::PerThreadRead<fk::ND::_2D, int>;
@@ -36,17 +44,23 @@ int launch() {
                    fk::Binary<BinaryDummy>, fk::Ternary<TernaryDummy>,
                    fk::MidWrite<WriteDummy>, fk::Write<WriteDummy>>;
 
-    constexpr bool correctDFRestrict = allInstantiableOperationsComplieWith<fk::NotUnaryRestriction>(DFList{});
+    constexpr bool correctDFRestrict = AllIOpsComply<fk::NotIsUnaryRestriction, DFList>::value;
     static_assert(correctDFRestrict, "The list of operations does not comply with the restriction");
 
     using ListToCheck =
-        fk::TypeList<fk::ReadType, fk::BinaryType, fk::UnaryType, fk::TernaryType,
-                     fk::UnaryType, fk::MidWriteType, fk::BinaryType, fk::WriteType>;
+        fk::TypeList<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>,
+                     fk::Binary<fk::Add<float>>,
+                     fk::Unary<fk::Cast<float, int>>,
+                     fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>>,
+                     fk::Unary<fk::Cast<float, int>>,
+                     fk::MidWrite<fk::PerThreadWrite<fk::ND::_2D, uchar>>,
+                     fk::Binary<fk::Mul<float>>,
+                     fk::Write<fk::PerThreadWrite<fk::ND::_2D, uchar>>>;
 
-    using IndexList = fk::filtered_index_sequence_t<fk::NotUnaryRestriction, ListToCheck>;
-    using IntegerList = fk::filtered_integer_sequence_t<int, fk::NotUnaryRestriction, ListToCheck>;
+    using IndexList = fk::filtered_index_sequence_t<fk::NotIsUnaryRestriction, ListToCheck>;
+    using IntegerList = fk::filtered_integer_sequence_t<int, fk::NotIsUnaryRestriction, ListToCheck>;
 
-    constexpr IndexList indexList;
+    constexpr IndexList indexList{};
 
     static_assert(IndexList::size() == 6, "The index list does not have the expected size");
     constexpr size_t var = fk::get_index_f<0>(indexList);
@@ -66,10 +80,14 @@ int launch() {
     static_assert(fk::get_integer<int, 5, IntegerList> == 7, "Incorrect integer");
 
     using FirstUnary =
-        fk::TypeList<fk::UnaryType, fk::TernaryType,
-        fk::UnaryType, fk::MidWriteType, fk::BinaryType, fk::WriteType>;
+        fk::TypeList<fk::Unary<fk::Cast<float, int>>,
+        fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>>,
+        fk::Unary<fk::Cast<float, int>>,
+        fk::MidWrite<fk::PerThreadWrite<fk::ND::_2D, uchar>>,
+        fk::Binary<fk::Mul<float>>,
+        fk::Write<fk::PerThreadWrite<fk::ND::_2D, uchar>>>;
 
-    using IndexListFirstUnary = fk::filtered_index_sequence_t<fk::NotUnaryRestriction, FirstUnary>;
+    using IndexListFirstUnary = fk::filtered_index_sequence_t<fk::NotIsUnaryRestriction, FirstUnary>;
 
     static_assert(IndexListFirstUnary::size() == 4, "Incorrect sequence size");
     static_assert(fk::get_index<0, IndexListFirstUnary> == 1, "Incorrect index");
@@ -78,29 +96,34 @@ int launch() {
     static_assert(fk::get_index<3, IndexListFirstUnary> == 5, "Incorrect index");
 
     using FirstAndLastUnary =
-        fk::TypeList<fk::UnaryType, fk::TernaryType,
-        fk::UnaryType, fk::MidWriteType, fk::BinaryType, fk::UnaryType>;
+        fk::TypeList<fk::Unary<fk::Cast<float, int>>,
+        fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>>,
+        fk::Unary<fk::Cast<float, int>>>;
 
-    using IndexListFirstAndLastUnary = fk::filtered_index_sequence_t<fk::NotUnaryRestriction, FirstAndLastUnary>;
+    using IndexListFirstAndLastUnary = fk::filtered_index_sequence_t<fk::NotIsUnaryRestriction, FirstAndLastUnary>;
 
-    static_assert(IndexListFirstAndLastUnary::size() == 3, "Incorrect sequence size");
+    static_assert(IndexListFirstAndLastUnary::size() == 1, "Incorrect sequence size");
     static_assert(fk::get_index<0, IndexListFirstAndLastUnary> == 1, "Incorrect index");
-    static_assert(fk::get_index<1, IndexListFirstAndLastUnary> == 3, "Incorrect index");
-    static_assert(fk::get_index<2, IndexListFirstAndLastUnary> == 4, "Incorrect index");
 
-    using LastUnary = fk::TypeList<fk::TernaryType,
-        fk::UnaryType, fk::MidWriteType, fk::BinaryType, fk::UnaryType>;
+    using LastUnary = fk::TypeList<fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar>>>>,
+        fk::Unary<fk::Cast<float, int>>,
+        fk::MidWrite<fk::PerThreadWrite<fk::ND::_2D, uchar>>,
+        fk::Binary<fk::Mul<float>>,
+        fk::Unary<fk::Cast<float, int>>>;
 
-    using IndexListLastUnary = fk::filtered_index_sequence_t<fk::NotUnaryRestriction, LastUnary>;
+    using IndexListLastUnary = fk::filtered_index_sequence_t<fk::NotIsUnaryRestriction, LastUnary>;
 
     static_assert(IndexListLastUnary::size() == 3, "Incorrect sequence size");
     static_assert(fk::get_index<0, IndexListLastUnary> == 0, "Incorrect index");
     static_assert(fk::get_index<1, IndexListLastUnary> == 2, "Incorrect index");
     static_assert(fk::get_index<2, IndexListLastUnary> == 3, "Incorrect index");
 
-    using AllTypesUnary = fk::TypeList<fk::UnaryType, fk::UnaryType, fk::UnaryType, fk::UnaryType>;
+    using AllTypesUnary = fk::TypeList<fk::Unary<fk::Cast<float, int>>,
+                                       fk::Unary<fk::Cast<float, int>>,
+                                       fk::Unary<fk::Cast<float, int>>,
+                                       fk::Unary<fk::Cast<float, int>>>;
 
-    using IndexListAllUnary = fk::filtered_index_sequence_t<fk::NotUnaryRestriction, AllTypesUnary>;
+    using IndexListAllUnary = fk::filtered_index_sequence_t<fk::NotIsUnaryRestriction, AllTypesUnary>;
 
     static_assert(IndexListAllUnary::size() == 0, "Incorrect index");
 

--- a/tests/operation/test_fused_operation.h
+++ b/tests/operation/test_fused_operation.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-2025 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 #include <tests/main.h>
 
 #include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/image_processing.h>
 
 using namespace fk;
@@ -30,37 +30,38 @@ constexpr bool test_fuseDFResultingTypes() {
 
     using Test = decltype(PerThreadRead<ND::_2D, float>::num_elems_y(std::declval<Point>(), std::declval<typename PerThreadRead<ND::_2D, float>::OperationDataType>()));
 
-    static_assert(std::is_same_v<Test, uint>);
+    static_assert(std::is_same_v<std::decay_t<Test>, uint>);
 
     constexpr auto fused1 = fuse(readOp, addOp, castOp);
 
     constexpr auto read = Read<PerThreadRead<ND::_2D, float>>{ { fk::RawPtr<ND::_2D, float>{nullptr, {128, 4}} } };
     static_assert(std::is_same_v<std::decay_t<decltype(read)>, Read<PerThreadRead<ND::_2D, float>>>, "Unexpected type after fuseIOps");
 
-    constexpr auto readOp2 = PerThreadRead<ND::_2D, uchar3>::build(RawPtr<ND::_2D, uchar3>{nullptr, PtrDims<ND::_2D>(128,128)});
+    constexpr auto readOp2 = PerThreadRead<ND::_2D, uchar3>::build(RawPtr<ND::_2D, uchar3>{nullptr, PtrDims<ND::_2D>(128, 128)});
     static_assert(std::is_same_v<std::decay_t<decltype(readOp2)>, Read<PerThreadRead<ND::_2D, uchar3>>>, "Unexpected type after fuseIOps");
 
-    constexpr auto readYUV = ReadYUV<PixelFormat::NV12>::build({ {RawPtr<ND::_2D, uchar>{nullptr, PtrDims<ND::_2D>(128, 128+64)}, 128, 128} });
+    constexpr auto readYUV = ReadYUV<PixelFormat::NV12>::build({ {RawPtr<ND::_2D, uchar>{nullptr, PtrDims<ND::_2D>(128, 128 + 64)}, 128, 128} });
     constexpr auto readRGB = readYUV.then(ConvertYUVToRGB<PixelFormat::NV12, ColorRange::Full, ColorPrimitives::bt2020, false>::build());
 
     constexpr auto resizeRead = Resize<InterpolationType::INTER_LINEAR>::build(readRGB, Size(64, 64));
     constexpr auto resizeReadWithMul = resizeRead.then(Mul<float>::build(3.f));
 
     constexpr auto resizeReadWithDiv = resizeReadWithMul.then(Div<float>::build(4.3f));
-    static_assert(resizeReadWithDiv.params.next.next.instance.params == 4.3f, "Unexpected value after resizeRead");
+    static_assert(get_opt<2>(resizeReadWithDiv.params).params == 4.3f, "Unexpected value after resizeRead");
 
-    static_assert(std::is_same_v<typename decltype(fused1)::Operation,
-        fk::FusedOperation<fk::PerThreadRead<fk::ND::_2D, float>, fk::Add<float>, fk::Cast<float, int>>>, "Unexpected type after fuseIOps");
+    static_assert(std::is_same_v<typename std::decay_t<decltype(fused1)>::Operation,
+        fk::FusedOperation<fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>, fk::Binary<fk::Add<float>>, fk::Unary<fk::Cast<float, int>>>>, "Unexpected type after fuseIOps");
 
-    constexpr bool result1 = fk::is_fused_operation<fk::FusedOperation<fk::PerThreadRead<fk::ND::_2D, float>, fk::Add<float>, fk::Cast<float, int>>>::value;
+    constexpr bool result1 = fk::is_fused_operation<fk::FusedOperation<fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>, fk::Binary<fk::Add<float>>, fk::Unary<fk::Cast<float, int>>>>::value;
 
     constexpr bool result2 = fk::is_fused_operation<typename decltype(fused1)::Operation>::value;
 
     static_assert(result1 && result2, "is_fused_operation does not work properly");
 
     constexpr auto fused2 = fk::fuse(readOp, addOp, writeOp);
-    static_assert(std::is_same_v<typename decltype(fused2)::Operation,
-        fk::FusedOperation<fk::PerThreadRead<fk::ND::_2D, float>, fk::Add<float>, fk::PerThreadWrite<fk::ND::_2D, float>>>, "Unexpected type after fuseIOps");
+    static_assert(std::is_same_v<typename std::decay_t<decltype(fused2)>::Operation,
+        fk::FusedOperation<fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>, fk::Binary<fk::Add<float>>, fk::Write<fk::PerThreadWrite<fk::ND::_2D, float>>>>,
+        "Unexpected type after fuseIOps");
 
     return result1 && result2;
 }
@@ -77,58 +78,295 @@ constexpr bool test_fuseFusedOperations() {
 }
 
 int launch() {
-    constexpr auto opTuple1 = fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>>();
+    constexpr auto opTuple1 = fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType>::build());
 
-    using OpTuple1Type = decltype(opTuple1);
+    using OpTuple1Type = std::decay_t<decltype(opTuple1)>;
 
     static_assert(OpTuple1Type::size == 1, "Wrong operation tuple size");
-    static_assert(fk::isUnaryType<typename OpTuple1Type::Operation>, "Wrong Operation Type");
 
-    constexpr auto opTuple2 =
-        fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>, fk::Add<int>>
-        (fk::OperationData<fk::Add<int>>{3});
+    constexpr auto opTuple2 = fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType> ::build(), fk::Add<int>::build(3));
 
     using OpTuple2Type = decltype(opTuple2);
 
     constexpr auto df2 = fk::Add<int, int, int, fk::UnaryType>::build().then(fk::Add<int >::build(3));
-    static_assert(df2.params.next.instance.params == 3, "");
+    static_assert(get_opt<1>(df2.params).params == 3, "");
 
-    constexpr auto result1 = decltype(df2)::Operation::exec(fk::Tuple<int, int>{4, 4}, df2);
+    constexpr auto result1 = std::decay_t<decltype(fk::get_opt<0>(df2.params))>::Operation::exec(fk::Tuple<int, int>{4, 4});
 
-    static_assert(result1 == 11, "Wrong result1");
+    static_assert(result1 == 8, "Wrong result1");
 
     static_assert(OpTuple2Type::size == 2, "Wrong operation tuple size");
-    static_assert(fk::isBinaryType<typename OpTuple2Type::Next::Operation>, "Wrong Operation Type");
-    static_assert(opTuple2.next.instance.params == 3, "Wrong value");
+    static_assert(fk::opIs<BinaryType, TypeAt_t<1, typename OpTuple2Type::Operations>>, "Wrong Operation Type");
+    static_assert(get_opt<1>(opTuple2).params == 3, "Wrong value");
 
-    constexpr auto opTuple3 = fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>,
-    fk::Cast<int, float>, fk::Cast<float, int>>();
+    constexpr auto opTuple3 = fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType>::build(),
+    fk::Cast<int, float>::build(), fk::Cast<float, int>::build());
 
     using OpTuple3Type = decltype(opTuple3);
 
     constexpr auto df3 = fk::Add<int, int, int, fk::UnaryType>::build().then(fk::Cast<int, float>::build()).then(fk::Cast<float, int>::build());
 
-    constexpr auto result3 = decltype(df3)::Operation::exec(fk::Tuple<int, int>{5,20});
+    constexpr auto result3 = TypeAt_t<0, typename decltype(df3)::Operation::Operations>::Operation::exec(fk::Tuple<int, int>{5,20});
     static_assert(result3 == 25, "Wrong result3");
 
     static_assert(OpTuple3Type::size == 3, "Wrong operation tuple size");
     //opTuple3.next; //must not compile
-    static_assert(fk::isUnaryType<typename OpTuple3Type::Operation>, "Wrong Operation Type");
+    static_assert(fk::opIs<UnaryType, TypeAt_t<0, typename OpTuple3Type::Operations>>, "Wrong Operation Type");
 
     static_assert(test_fuseDFResultingTypes(), "Something wrong with the types generated by fusedDF");
     static_assert(test_fuseFusedOperations(), "Something wrong while fusing a FusedOperation with another operation");
 
     using SomeFusedOp =
-    fk::FusedOperation_<void,
-        fk::Resize<fk::InterpolationType::INTER_LINEAR,
-                   fk::AspectRatio::PRESERVE_AR,
-                   fk::ReadBackInstantiableOperation<fk::Crop<fk::ReadInstantiableOperation<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>,
-        fk::Mul<float3, float3, float3>,
-        fk::Sub<float3, float3, float3>,
-        fk::Div<float3, float3, float3>,
-        fk::VectorReorder<float3, 2, 1, 0>>;
+    fk::FusedOperation<
+        fk::ReadBack<fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
+                  fk::Ternary<fk::InterpolateComplete<
+                      fk::InterpolationType::INTER_LINEAR,
+                   fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>>,
+        fk::Binary<fk::Mul<float3, float3, float3>>,
+        fk::Binary<fk::Sub<float3, float3, float3>>,
+        fk::Binary<fk::Div<float3, float3, float3>>,
+        fk::Unary<fk::VectorReorder<float3, 2, 1, 0>>>;
 
     static_assert(isCompleteOperation<SomeFusedOp>, "Something wrong with the compiler?");
+
+    // ===========================================================================
+    // COMPREHENSIVE TESTS FOR DEEPLY NESTED FUSED OPERATIONS
+    // Testing all specializations with various nesting depths as requested in PR feedback
+    // ===========================================================================
+    // Note: OpenType requires MidWriteType operations which are specialized internal operations.
+    // OpenType is tested implicitly through the fold expression implementation tests below.
+
+    // Test 1: ClosedType FusedOperation (Read + operations + Write)
+    // This combines ReadType at the start and WriteType at the end
+    {
+        using ClosedFusedOp = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename ClosedFusedOp::InstanceType, fk::ClosedType>,
+            "ClosedType FusedOperation not correctly identified");
+    }
+
+    // Test 2: WriteType FusedOperation (operations + Write, no Read at start)
+    {
+        using WriteFusedOp = fk::FusedOperation<
+            fk::Binary<fk::Add<float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename WriteFusedOp::InstanceType, fk::WriteType>,
+            "WriteType FusedOperation not correctly identified");
+    }
+
+    // Test 3: ReadType FusedOperation (Read + operations, no Write at end)
+    {
+        using ReadFusedOp = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Unary<fk::Cast<float, int>>
+        >;
+        static_assert(std::is_same_v<typename ReadFusedOp::InstanceType, fk::ReadType>,
+            "ReadType FusedOperation not correctly identified");
+    }
+
+    // Test 4: UnaryType FusedOperation (all operations are Unary)
+    {
+        using UnaryChainOp = fk::FusedOperation<
+            fk::Unary<fk::Cast<int, float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Unary<fk::Cast<double, int>>
+        >;
+        static_assert(std::is_same_v<typename UnaryChainOp::InstanceType, fk::UnaryType>,
+            "UnaryType FusedOperation not correctly identified");
+    }
+
+    // Test 5: BinaryType FusedOperation (compute operations, no Read/Write/MidWrite)
+    {
+        using BinaryChainOp = fk::FusedOperation<
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>
+        >;
+        static_assert(std::is_same_v<typename BinaryChainOp::InstanceType, fk::BinaryType>,
+            "BinaryType FusedOperation not correctly identified");
+    }
+
+    // Test 6: Deeply nested ReadType (5+ levels)
+    {
+        using DeeplyNestedRead = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Unary<fk::Cast<float, int>>
+        >;
+        static_assert(std::is_same_v<typename DeeplyNestedRead::InstanceType, fk::ReadType>,
+            "Deeply nested ReadType FusedOperation failed");
+    }
+
+    // Test 7: Deeply nested ClosedType (5+ levels)
+    {
+        using DeeplyNestedClosed = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename DeeplyNestedClosed::InstanceType, fk::ClosedType>,
+            "Deeply nested ClosedType FusedOperation failed");
+    }
+
+    // Test 8: Deeply nested UnaryType (5+ levels)
+    {
+        using DeeplyNestedUnary = fk::FusedOperation<
+            fk::Unary<fk::Cast<int, float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Unary<fk::Cast<double, float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Unary<fk::Cast<double, int>>
+        >;
+        static_assert(std::is_same_v<typename DeeplyNestedUnary::InstanceType, fk::UnaryType>,
+            "Deeply nested UnaryType FusedOperation failed");
+    }
+
+    // Test 9: Deeply nested BinaryType (5+ levels)
+    {
+        using DeeplyNestedBinary = fk::FusedOperation<
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Binary<fk::Add<float>>
+        >;
+        static_assert(std::is_same_v<typename DeeplyNestedBinary::InstanceType, fk::BinaryType>,
+            "Deeply nested BinaryType FusedOperation failed");
+    }
+
+    // Test 10: Deeply nested WriteType (5+ levels)
+    {
+        using DeeplyNestedWrite = fk::FusedOperation<
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename DeeplyNestedWrite::InstanceType, fk::WriteType>,
+            "Deeply nested WriteType FusedOperation failed");
+    }
+
+    // Test 11: Very deeply nested ClosedType (10+ levels) - stress test
+    {
+        using VeryDeeplyNestedClosed = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Binary<fk::Div<double>>,
+            fk::Unary<fk::Cast<double, float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename VeryDeeplyNestedClosed::InstanceType, fk::ClosedType>,
+            "Very deeply nested ClosedType FusedOperation failed");
+    }
+
+    // Test 12: Mixed compute types (Binary and Unary) in deep chain
+    {
+        using MixedComputeChain = fk::FusedOperation<
+            fk::Binary<fk::Add<int>>,
+            fk::Unary<fk::Cast<int, float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Binary<fk::Div<double>>,
+            fk::Unary<fk::Cast<double, int>>
+        >;
+        static_assert(std::is_same_v<typename MixedComputeChain::InstanceType, fk::BinaryType>,
+            "Mixed compute chain should be BinaryType when not all are Unary");
+    }
+
+    // Test 13: Verify complex existing SomeFusedOp is still valid
+    // This ensures backward compatibility with existing complex operations
+    static_assert(std::is_same_v<typename SomeFusedOp::InstanceType, fk::ReadType>,
+        "Complex SomeFusedOp should be ReadType (starts with ReadBack, no Write at end)");
+
+    // Test 14: Verify operation fusion with .then() for deep chains
+    {
+        constexpr auto chain1 = fk::Add<int, int, int, fk::UnaryType>::build()
+            .then(fk::Cast<int, float>::build())
+            .then(fk::Cast<float, double>::build())
+            .then(fk::Cast<double, float>::build())
+            .then(fk::Cast<float, int>::build());
+        
+        using ChainType = std::decay_t<decltype(chain1)>;
+        static_assert(ChainType::Operation::Operations::size == 5,
+            "Deep .then() chain should have 5 operations");
+    }
+
+    // Test 15: Verify FusedOperation can be fused again (nesting FusedOperations)
+    {
+        constexpr auto inner = fk::fuse(
+            fk::Add<int, int, int, fk::UnaryType>::build(),
+            fk::Cast<int, float>::build()
+        );
+        [[maybe_unused]] constexpr auto outer = fk::fuse(
+            inner,
+            fk::Cast<float, int>::build()
+        );
+        // This should compile without errors
+    }
+
+    // Test 16: Edge case - Single operation wrapped in FusedOperation
+    {
+        using SingleOpFused = fk::FusedOperation<fk::Unary<fk::Cast<int, float>>>;
+        static_assert(std::is_same_v<typename SingleOpFused::InstanceType, fk::UnaryType>,
+            "Single Unary operation should be UnaryType");
+    }
+
+    // Test 17: Edge case - Two operations (minimum for meaningful fusion)
+    {
+        using TwoOpFused = fk::FusedOperation<
+            fk::Binary<fk::Add<float>>,
+            fk::Unary<fk::Cast<float, int>>
+        >;
+        static_assert(std::is_same_v<typename TwoOpFused::InstanceType, fk::BinaryType>,
+            "Two mixed compute ops should be BinaryType");
+    }
+
+    // Test 18: Maximum stress test - 15+ operations deeply nested
+    {
+        using MaxStressTest = fk::FusedOperation<
+            fk::Read<fk::PerThreadRead<fk::ND::_2D, float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Binary<fk::Div<float>>,
+            fk::Binary<fk::Add<float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Binary<fk::Sub<float>>,
+            fk::Unary<fk::Cast<float, double>>,
+            fk::Binary<fk::Div<double>>,
+            fk::Binary<fk::Add<double>>,
+            fk::Unary<fk::Cast<double, float>>,
+            fk::Binary<fk::Mul<float>>,
+            fk::Unary<fk::Cast<float, int>>,
+            fk::Binary<fk::Add<int>>,
+            fk::Write<fk::PerThreadWrite<fk::ND::_2D, int>>
+        >;
+        static_assert(std::is_same_v<typename MaxStressTest::InstanceType, fk::ClosedType>,
+            "Maximum stress test (15+ ops) ClosedType FusedOperation failed");
+    }
 
     return 0;
 }

--- a/tests/operation/test_instantiable_operations.h
+++ b/tests/operation/test_instantiable_operations.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-2025 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/basic_ops/cast.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/core/utils/type_lists.h>
 #include <fused_kernel/algorithms/basic_ops/set.h>
@@ -69,9 +69,9 @@ constexpr inline bool test_read_then_batch() {
     static_assert(std::is_same_v<ResultingType_, ResultingType2>);
     static_assert(fusedBatchIOp.params.usedPlanes == 2);
     static_assert(fusedBatchIOp.params.default_value == 3.f);
-    static_assert(isReadType<ResultingType2>);
-    static_assert(isReadBackType<typename ResultingType2::Operation::Operation>);
-    static_assert(isTernaryType<typename ResultingType2::Operation::Operation::BackIOp>);
+    static_assert(opIs<ReadType, ResultingType2>);
+    static_assert(opIs<ReadBackType, typename ResultingType2::Operation::Operation>);
+    static_assert(opIs<TernaryType, typename ResultingType2::Operation::Operation::BackIOp>);
 
     return true;
 }
@@ -126,7 +126,7 @@ constexpr inline bool test_read_then_readback() {
     constexpr auto readIOp = RPerThrFloat::build(input);
 
     constexpr auto fusedOp = readIOp.then(Resize<InterpolationType::INTER_LINEAR, AspectRatio::PRESERVE_AR>::build(Size(16,32), 0.5f));
-    static_assert(isReadBackType<decltype(fusedOp)>, "The IOp should be a ReadBack type");
+    static_assert(opIs<ReadBackType, decltype(fusedOp)>, "The IOp should be a ReadBack type");
 
     return true;
 }
@@ -186,21 +186,21 @@ int launch() {
     static_assert(is_fused_operation<typename ResType::Operation>::value);
     using ResOperationTuple = typename ResType::Operation::ParamsType;
     constexpr bool noIntermediateFusedOperation =
-        and_v<!is_fused_operation<ResOperationTuple::Operation>::value,
-        !is_fused_operation<ResOperationTuple::Next::Operation>::value,
-        !is_fused_operation<ResOperationTuple::Next::Next::Operation>::value,
-        !is_fused_operation<ResOperationTuple::Next::Next::Next::Operation>::value,
-        !is_fused_operation<ResOperationTuple::Next::Next::Next::Next::Operation>::value>;
+        and_v<!is_fused_operation<TypeAt_t<0, typename ResOperationTuple::Operations>>::value,
+              !is_fused_operation<TypeAt_t<1, typename ResOperationTuple::Operations>>::value,
+              !is_fused_operation<TypeAt_t<2, typename ResOperationTuple::Operations>>::value,
+              !is_fused_operation<TypeAt_t<3, typename ResOperationTuple::Operations>>::value,
+              !is_fused_operation<TypeAt_t<4, typename ResOperationTuple::Operations>>::value>;
     static_assert(noIntermediateFusedOperation);
 
     // All Unary
-    constexpr auto func = Instantiable<UFloatInt>{}.then(Instantiable<UIntFloat>{}).then(Instantiable<UFloatInt>{});
+    constexpr auto func = UFloatInt::build().then(UIntFloat::build()).then(UFloatInt::build());
 
     using Operations = decltype(func)::Operation::Operations;
     static_assert(Operations::size == 3);
-    static_assert(std::is_same_v<TypeAt_t<0,Operations>, UFloatInt>);
-    static_assert(std::is_same_v<TypeAt_t<1, Operations>, UIntFloat>);
-    static_assert(std::is_same_v<TypeAt_t<2, Operations>, UFloatInt>);
+    static_assert(std::is_same_v<TypeAt_t<0,Operations>, Unary<UFloatInt>>);
+    static_assert(std::is_same_v<TypeAt_t<1, Operations>, Unary<UIntFloat>>);
+    static_assert(std::is_same_v<TypeAt_t<2, Operations>, Unary<UFloatInt>>);
     static_assert(decltype(func)::Operation::exec(5.5f) == 5);
 
     constexpr auto op = BAddInt::build(45);
@@ -215,15 +215,15 @@ int launch() {
 
     constexpr auto someReadOp =
         PerThreadRead<ND::_2D, uchar3>::build(input).then(Cast<uchar3, float3>::build()).then(Resize<InterpolationType::INTER_LINEAR>::build(dstSize));
-    static_assert(isReadBackType<decltype(someReadOp)>, "Unexpected Operation Type for someReadOp");
-    static_assert(std::is_same_v<decltype(someReadOp.backIOp.backIOp.params), OperationTuple<PerThreadRead<ND::_2D, uchar3>, Cast<uchar3, float3>>>, "Unexpected type for params");
+    static_assert(opIs<ReadBackType, decltype(someReadOp)>, "Unexpected Operation Type for someReadOp");
+    static_assert(std::is_same_v<decltype(someReadOp.backIOp.backIOp.params), OperationTuple<Read<PerThreadRead<ND::_2D, uchar3>>, Unary<Cast<uchar3, float3>>>>, "Unexpected type for params");
 
     constexpr bool correct =
-        std::is_same_v<OperationTuple<PerThreadRead<ND::_2D, uchar3>, Cast<uchar3, float3>>, decltype(someReadOp.backIOp.backIOp.params)>;
+        std::is_same_v<OperationTuple<Read<PerThreadRead<ND::_2D, uchar3>>, Unary<Cast<uchar3, float3>>>, decltype(someReadOp.backIOp.backIOp.params)>;
     static_assert(correct, "Unexpected resulting type");
 
     constexpr auto finalOp = someReadOp.then(Mul<float3>::build(make_<float3>(3.f, 1.f, 32.f)));
-    static_assert(!isReadBackType<std::decay_t<decltype(finalOp)>>, "Unexpected type for finalOp");
+    static_assert(!opIs<ReadBackType, std::decay_t<decltype(finalOp)>>, "Unexpected type for finalOp");
 
     constexpr auto inputAlt = ReadSet<uchar3>::build({ { { 0,0,0 }, {128,128,1} } });
 

--- a/tests/operation/test_operation_fuser.h
+++ b/tests/operation/test_operation_fuser.h
@@ -1,4 +1,5 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,10 +21,11 @@
 using namespace fk;
 
 using ComplexType =
-Read<FusedOperation_<void,
-    Resize<InterpolationType::INTER_LINEAR, AspectRatio::PRESERVE_AR,
-    ReadBack<Crop<Read<PerThreadRead<ND::_2D, uchar3>>>>>,
-    Mul<float3, float3, float3>>>;
+Read<FusedOperation<
+    ReadBack<ResizeComplete<AspectRatio::PRESERVE_AR,
+                    Ternary<InterpolateComplete<
+                        InterpolationType::INTER_LINEAR, ReadBack<Crop<Read<PerThreadRead<ND::_2D, uchar3>>>>>>>>,
+             Binary<Mul<float3, float3, float3>>>>;
 
 // Operation types
 // Read
@@ -45,36 +47,17 @@ using WPerThrFloat = PerThreadWrite<ND::_2D, float>;
 // MidWrite
 using MWPerThrFloat = FusedOperation<WPerThrFloat, BAddFloat>;
 
-
 constexpr bool test_InstantiableFusedOperationToOperationTuple() {
-    constexpr bool mustFalse = isAllUnaryFusedOperation<MWPerThrFloat>;
-    static_assert(!mustFalse, "MWPerThrFloat is not an all Unary FusedOperation");
-    constexpr bool mustTrue = isAllUnaryFusedOperation<FusedOperation<UIntFloat>>;
-    static_assert(mustTrue, "FusedOperation<UIntFloat> is an all Unary FusedOperation");
-    constexpr bool mustTrue2 = isAllUnaryFusedOperation<FusedOperation<UIntFloat, UFloatInt>>;
-    static_assert(mustTrue2, "FusedOperation<UIntFloat, UFloatInt> is an all Unary FusedOperation");
 
-    constexpr bool mustTrue3 = isNotAllUnaryFusedOperation<MWPerThrFloat>;
-    static_assert(mustTrue3, "MWPerThrFloat is not an all Unary FusedOperation");
-    constexpr bool mustFalse2 = isNotAllUnaryFusedOperation<FusedOperation<UIntFloat>>;
-    static_assert(!mustFalse2, "FusedOperation<UIntFloat> is an all Unary FusedOperation");
-    constexpr bool mustFalse3 = isNotAllUnaryFusedOperation<FusedOperation<UIntFloat, UFloatInt>>;
-    static_assert(!mustFalse3, "FusedOperation<UIntFloat, UFloatInt> is an all Unary FusedOperation");
-    constexpr auto fusedOp0 = Binary<FusedOperation<Add<float>>>{};
-    [[maybe_unused]] constexpr auto operationTuple = InstantiableFusedOperationToOperationTuple<Binary<FusedOperation<Add<float>>>>::value(fusedOp0);
-    constexpr auto fusedOp = MWPerThrFloat::build(OperationData<MWPerThrFloat>{});
-    using FusedOpType = std::decay_t<decltype(fusedOp)>;
-    [[maybe_unused]] constexpr auto operationTuple2 = InstantiableFusedOperationToOperationTuple<FusedOpType>::value(fusedOp);
+    constexpr auto fusedOp = FusedOperation<>::build(ComplexType{}, Add<float3>::build(make_set<float3>(2.f)));
+
+    constexpr auto opTuple = fusedOp.params;
+
+    static_assert(opTuple.size == 3, "Wrong OperationTuple size");
 
     return true;
 }
 
 int launch() {
-#if defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSC_VER < 1920)
     return test_InstantiableFusedOperationToOperationTuple() ? 0 : -1;
-#else
-    constexpr ComplexType complexVar{};
-    [[maybe_unused]] constexpr auto opTuple = InstantiableFusedOperationToOperationTuple<ComplexType>::value(complexVar);
-    return test_InstantiableFusedOperationToOperationTuple() ? 0 : -1;
-#endif
 }

--- a/tests/operation/test_operation_tuple.h
+++ b/tests/operation/test_operation_tuple.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-2025 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,84 +18,122 @@
 #include <fused_kernel/core/data/ptr_nd.h>
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/core/execution_model/stream.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/basic_ops/cast.h>
 #include <fused_kernel/algorithms/image_processing/saturate.h>
 
 bool test_OTInitialization() {
-    fk::Stream stream;
-    
     constexpr uint X = 64;
     constexpr uint Y = 64;
 
     const fk::Ptr2D<uchar> input(X, Y);
-    using Op = fk::PerThreadRead<fk::ND::_2D, uchar>;
-    const fk::Read<Op> read{ {input} };
+    using IOp = typename fk::PerThreadRead<fk::ND::_2D, uchar>::InstantiableType;
+    const IOp read{ {input} };
 
-    [[maybe_unused]] const fk::OperationTuple<Op> testing{ {read.params} };
+    [[maybe_unused]] const fk::OperationTuple<IOp> testing{ {read} };
 
-    const auto test2 = fk::iOpsToOperationTuple(read);
+    const auto test2 = fk::make_new_operation_tuple(read);
     //const fk::Read<fk::FusedOperation<Op>> test3 = fk::fuse(read); //Should not compile
 
     using Op2 = fk::SaturateCast<uchar, uint>;
     constexpr fk::Unary<Op2> cast = {};
 
-    const auto ot1 = fk::iOpsToOperationTuple(read);
-    constexpr auto ot2 = fk::iOpsToOperationTuple(cast);
+    const auto ot1 = fk::make_new_operation_tuple(read);
+    constexpr auto ot2 = fk::make_new_operation_tuple(cast);
 
-    const auto test4 = fk::make_operation_tuple_<Op, Op2>(ot1.instance);
-    const auto test5 = fk::make_operation_tuple_<Op, Op2>(fk::get<0>(ot1));
+    const auto test4 = fk::make_new_operation_tuple(fk::get_opt<0>(ot1));
 
     constexpr auto filtered1 =
-        fk::filtered_integer_sequence_t<int, fk::NotUnaryRestriction, fk::TypeList<typename Op::InstanceType>>{};
+        fk::filtered_integer_sequence_t<int, fk::NotIsUnaryRestriction, fk::TypeList<typename IOp::InstanceType>>{};
     static_assert(filtered1.size() == 1, "Wrong filtered integer sequence size");
 
-    const fk::OperationTuple<Op, decltype(ot2)::Operation> test6 = fk::cat(ot1, ot2);
+    const auto test6 = fk::cat(ot1, ot2);
 
-    const auto test7 = fk::iOpsToOperationTuple(read, cast);
+    const auto test7 = fk::make_new_operation_tuple(read, cast);
 
     const auto test8 = fk::fuse(read, cast);
 
-    const auto test9 = fk::Instantiable<fk::FusedOperation<typename decltype(read)::Operation,
-                                                                   typename decltype(cast)::Operation>>
-    { fk::iOpsToOperationTuple(read, cast) };
+    const auto test9 = fk::Instantiable<fk::FusedOperation<std::decay_t<decltype(read)>,
+                                                           std::decay_t<decltype(cast)>>>
+    { fk::make_new_operation_tuple(read, cast) };
+
+    return true;
+}
+
+bool testNewOperationTuple() {
+    using namespace fk;
+
+    constexpr auto op1 = Div<uchar>::build(1u);
+    constexpr auto op2 = SaturateCast<uchar, uint>::build();
+    constexpr auto op3 = Mul<uint>::build(5u);
+    constexpr auto op4 = Cast<uint, float>::build();
+    constexpr auto op5 = Add<float>::build(0.5f);
+    constexpr auto op6 = Div<float>::build(0.6f);
+    constexpr auto op7 = Mul<float>::build(0.8f);
+
+    // Some unary
+    constexpr auto opTuple1 = make_new_operation_tuple(op1, op2, op3);
+    constexpr auto gotOp1 = get_opt<0>(opTuple1);
+    constexpr auto gotOp2 = get_opt<1>(opTuple1);
+    constexpr auto gotOp3 = get_opt<2>(opTuple1);
+
+    static_assert(opTuple1.instances.size == 2, "Wrong Tuple size in OperationTuple");
+    static_assert(gotOp1.params == 1u, "Wrong value in op1");
+    static_assert(opIs<UnaryType, std::decay_t<decltype(gotOp2)>>, "Op2 must be Unary");
+    static_assert(gotOp3.params == 5u, "Wrong value in op3");
+
+    // All unary
+    constexpr auto opTuple2 = make_new_operation_tuple(op2, op4);
+    constexpr auto gotT2Op2 = get_opt<0>(opTuple2);
+    constexpr auto gotT2Op4 = get_opt<1>(opTuple2);
+
+    static_assert(opIs<UnaryType, std::decay_t<decltype(gotT2Op2)>>, "Op2 must be Unary");
+    static_assert(opIs<UnaryType, std::decay_t<decltype(gotT2Op4)>>, "Op4 must be Unary");
+
+    // None unary
+    constexpr auto opTuple3 = make_new_operation_tuple(op5, op6, op7);
+    constexpr auto gotT3Op5 = get_opt<0>(opTuple3);
+    constexpr auto gotT3Op6 = get_opt<1>(opTuple3);
+    constexpr auto gotT3Op7 = get_opt<2>(opTuple3);
+
+    static_assert(gotT3Op5.params == 0.5f, "Wrong value in op5");
+    static_assert(gotT3Op6.params == 0.6f, "Wrong value in op6");
+    static_assert(gotT3Op7.params == 0.8f, "Wrong value in op7");
 
     return true;
 }
 
 int launch() {
-    constexpr auto opTuple1 = fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>>();
+    constexpr auto opTuple1 = fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType>::build());
 
-    using OpTuple1Type = decltype(opTuple1);
+    using OpTuple1Type = std::decay_t<decltype(opTuple1)>;
 
     static_assert(OpTuple1Type::size == 1, "Wrong operation tuple size");
-    static_assert(fk::isUnaryType<typename OpTuple1Type::Operation>, "Wrong Operation Type");
+    static_assert(fk::opIs<fk::UnaryType, fk::TypeAt_t<0, typename OpTuple1Type::Operations>>, "Wrong Operation Type");
 
     constexpr fk::OperationData<fk::Add<int>> data{ 3 };
     static_assert(data.params == 3, "Wrong value");
 
     constexpr auto opTuple2 =
-        fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>, fk::Add<int>>
-        (fk::OperationData<fk::Add<int>>{3});
+        fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType>::build(), fk::Add<int>::build(3));
 
     using OpTuple2Type = decltype(opTuple2);
 
     static_assert(OpTuple2Type::size == 2, "Wrong operation tuple size");
-    static_assert(fk::isBinaryType<typename OpTuple2Type::Next::Operation>, "Wrong Operation Type");
-    static_assert(opTuple2.next.instance.params == 3, "Wrong value");
+    static_assert(fk::opIs<fk::BinaryType, fk::TypeAt_t<1, typename OpTuple2Type::Operations>>, "Wrong Operation Type");
+    static_assert(fk::get_opt<1>(opTuple2).params == 3, "Wrong value");
 
-    constexpr auto opTuple3 = fk::make_operation_tuple_<fk::Add<int, int, int, fk::UnaryType>,
-    fk::Cast<int, float>, fk::Cast<float, int>>();
+    constexpr auto opTuple3 = fk::make_new_operation_tuple(fk::Add<int, int, int, fk::UnaryType>::build(),
+    fk::Cast<int, float>::build(), fk::Cast<float, int>::build());
 
     using OpTuple3Type = decltype(opTuple3);
 
     static_assert(OpTuple3Type::size == 3, "Wrong operation tuple size");
     //opTuple3.next; must not compile
-    static_assert(fk::isUnaryType<typename OpTuple3Type::Operation>, "Wrong Operation Type");
-    static_assert(opTuple2.next.instance.params == 3, "Wrong value");
-
-    if (!test_OTInitialization()) {
+    static_assert(fk::opIs<fk::UnaryType, fk::TypeAt_t<0, typename OpTuple3Type::Operations>>, "Wrong Operation Type");
+   
+    if (!test_OTInitialization() || !testNewOperationTuple()) {
         return -1;
     }
 

--- a/tests/operation/test_operation_types.h
+++ b/tests/operation/test_operation_types.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024 Oscar Amoros Huguet
+﻿/* Copyright 2024-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 #include <fused_kernel/algorithms/basic_ops/cast.h>
 #include <fused_kernel/algorithms/image_processing/resize.h>
 #include <fused_kernel/algorithms/image_processing/crop.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 
 // Operation types
 // Read
@@ -38,7 +38,7 @@ using TInterpFloat = fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR
 // Write
 using WPerThrFloat = fk::PerThreadWrite<fk::ND::_2D, float>;
 // MidWrite
-using MWPerThrFloat = fk::FusedOperation<WPerThrFloat, BAddFloat>;
+using FusedPerThrFloat = fk::FusedOperation<fk::MidWrite<WPerThrFloat>, fk::Binary<BAddFloat>>;
 
 // Test combination type lists
 template <typename... Types>
@@ -54,36 +54,36 @@ template <typename T, typename TL>
 using ITF = fk::InsertTypeFront_t<T, TL>;
 
 // No Read
-using NoRead = ITB<ITB<ITB<TLC<TLC<TL<RBResize>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>, MWPerThrFloat>;
+using NoRead = ITB<ITB<ITB<TLC<TLC<TL<RBResize>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>, FusedPerThrFloat>;
 // No ReadBack
-using NoReadBack = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>, MWPerThrFloat>;
+using NoReadBack = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>, FusedPerThrFloat>;
 // No Unary
-using NoUnary = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Binaries>, TInterpFloat>, WPerThrFloat>, MWPerThrFloat>;
+using NoUnary = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Binaries>, TInterpFloat>, WPerThrFloat>, FusedPerThrFloat>;
 // No Binary
-using NoBinary = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, TInterpFloat>, WPerThrFloat>, MWPerThrFloat>;
+using NoBinary = ITB<ITB<ITB<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, TInterpFloat>, WPerThrFloat>, FusedPerThrFloat>;
 // No Ternary
-using NoTernary = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, WPerThrFloat>, MWPerThrFloat>;
+using NoTernary = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, WPerThrFloat>, FusedPerThrFloat>;
 // No Write
-using NoWrite = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, TInterpFloat>, MWPerThrFloat>;
+using NoWrite = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, TInterpFloat>, FusedPerThrFloat>;
 // No Midwrite
-using NoMidWrite = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>;
+using NoFused = ITB<ITB<TLC<TLC<TLC<TL<RPerThrFloat>, TL<RBResize>>, Unaries>, Binaries>, TInterpFloat>, WPerThrFloat>;
 // No AnyWrite
-using NoAnyWrite = ITB<TLC<TLC<ITB<TL<RPerThrFloat>, RBResize>, Unaries>, Binaries>, TInterpFloat>;
+using NoAnyWrite = ITB<ITB<TLC<TLC<ITB<TL<RPerThrFloat>, RBResize>, Unaries>, Binaries>, TInterpFloat>, FusedPerThrFloat>;
 // All Compute
 using AllCompute = ITB<TLC<Unaries, Binaries>, TInterpFloat>;
 
 template <typename TypeList>
-struct IsReadType;
+struct ContainsReadType;
 template <typename... Types>
-struct IsReadType<fk::TypeList<Types...>> {
-    static constexpr bool value = fk::or_v<fk::isReadType<Types>...>;
+struct ContainsReadType<fk::TypeList<Types...>> {
+    static constexpr bool value = fk::or_v<fk::opIs<fk::ReadType, Types>...>;
 };
 
 template <typename TypeList>
-struct IsReadBackType;
+struct ContainsReadBackType;
 template <typename... Types>
-struct IsReadBackType<fk::TypeList<Types...>> {
-    static constexpr bool value = fk::or_v<fk::isReadBackType<Types>...>;
+struct ContainsReadBackType<fk::TypeList<Types...>> {
+    static constexpr bool value = fk::or_v<fk::opIs<fk::ReadBackType, Types>...>;
 };
 
 template <typename TypeList>
@@ -91,6 +91,14 @@ struct NoneAnyWriteType;
 template <typename... Types>
 struct NoneAnyWriteType<fk::TypeList<Types...>> {
     static constexpr bool value = fk::noneAnyWriteType<Types...>;
+};
+
+template <typename TypeList>
+struct NoneFusedType;
+
+template <typename... Types>
+struct NoneFusedType<fk::TypeList<Types...>> {
+    static constexpr bool value = !fk::or_v<fk::opIs<fk::OpenType, Types>...>;
 };
 
 template <typename TypeList_t>
@@ -109,16 +117,15 @@ constexpr bool test_allUnaryTypes() {
     constexpr bool mustFalse4 = Test_allUnaryTypes<NoAnyWrite>::value;
     constexpr bool mustFalse5 = Test_allUnaryTypes<NoBinary>::value;
     using ComplexType =
-    fk::Read<fk::FusedOperation_<void,
-                                 fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
-                                            fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>,
-                                 fk::Mul<float3, float3, float3>>>;
+    fk::Read<fk::FusedOperation<typename fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
+                                fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>::InstantiableType,
+                                typename fk::Mul<float3, float3, float3>::InstantiableType>>;
     constexpr bool mustFalse6 = fk::allUnaryTypes<ComplexType>;
 
-    using ComplexType2 = fk::Read<fk::FusedOperation_<void,
-                                                      fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
-        fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>,
-                                                          fk::Mul<float3, float3, float3>>>;
+    using ComplexType2 =
+        fk::Read<fk::FusedOperation<typename fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
+                                    fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>::InstantiableType,
+                                    typename fk::Mul<float3, float3, float3>::InstantiableType>>;
     constexpr bool mustFalse7 = Test_allUnaryTypes<fk::TypeList<ComplexType2>>::value;
 
     return mustTrue && !fk::or_v<mustFalse1, mustFalse2, mustFalse3, mustFalse4, mustFalse5, mustFalse6, mustFalse7>;
@@ -141,15 +148,14 @@ constexpr bool test_notAllUnaryTypes() {
     constexpr bool mustTrue5 = Test_notAllUnaryTypes<NoBinary>::value;
 
     using ComplexType =
-        fk::Read<fk::FusedOperation_<void,
-        fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
-        fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>,
-        fk::Mul<float3, float3, float3>>>;
+        fk::Read<fk::FusedOperation<typename fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
+                                    fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>::InstantiableType,
+                                    typename fk::Mul<float3, float3, float3>::InstantiableType>>;
     constexpr bool mustTrue6 = fk::notAllUnaryTypes<ComplexType>;
 
-    using ComplexType2 = fk::Read<fk::FusedOperation_<void,
-        fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR, fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>,
-        fk::Mul<float3, float3, float3>>>;
+    using ComplexType2 = fk::Read<fk::FusedOperation<typename fk::ResizeComplete<fk::AspectRatio::PRESERVE_AR,
+                                                     fk::Ternary<fk::InterpolateComplete<fk::InterpolationType::INTER_LINEAR, fk::ReadBack<fk::Crop<fk::Read<fk::PerThreadRead<fk::ND::_2D, uchar3>>>>>>>::InstantiableType,
+                                                     typename fk::Mul<float3, float3, float3>::InstantiableType>>;
     constexpr bool mustTrue7 = Test_notAllUnaryTypes<fk::TypeList<ComplexType2>>::value;
 
     return !mustFalse && fk::and_v<mustTrue1, mustTrue2, mustTrue3, mustTrue4, mustTrue5, mustTrue6, mustTrue7>;
@@ -157,20 +163,18 @@ constexpr bool test_notAllUnaryTypes() {
 
 int launch() {
     // isReadType
-    constexpr bool noneRead = !IsReadType<NoRead>::value;
-    constexpr bool isRead = fk::isReadType<RPerThrFloat>;
+    constexpr bool noneRead = !ContainsReadType<NoRead>::value;
+    constexpr bool isRead = fk::opIs<fk::ReadType, RPerThrFloat>;
     static_assert(noneRead && isRead, "Something wrong with isReadType");
 
     // isReadBackType
-    constexpr bool noneReadBack = !IsReadBackType<NoReadBack>::value;
-    constexpr bool isReadBack = fk::isReadBackType<RBResize>;
+    constexpr bool noneReadBack = !ContainsReadBackType<NoReadBack>::value;
+    constexpr bool isReadBack = fk::opIs<fk::ReadBackType, RBResize>;
     static_assert(noneReadBack && isReadBack, "Something wrong with isReadType");
 
     // noneAnyWriteType
-    constexpr bool noneAnyWriteType_v = NoneAnyWriteType<NoAnyWrite>::value;
-    constexpr bool oneIsMidWrite = !NoneAnyWriteType<NoWrite>::value;
-    constexpr bool oneIsWrite = !NoneAnyWriteType<NoMidWrite>::value;
-    static_assert(fk::and_v<noneAnyWriteType_v, oneIsMidWrite, oneIsWrite>, "Something wrong with isReadType");
+    constexpr bool noneAnyWriteType_ = NoneAnyWriteType<NoAnyWrite>::value;
+    static_assert(fk::and_v<noneAnyWriteType_>, "Something wrong with isReadType");
 
     // allUnaryTypes
     constexpr bool allUnaryTypes_v = test_allUnaryTypes();

--- a/tests/operation_test_utils.h
+++ b/tests/operation_test_utils.h
@@ -1,4 +1,4 @@
-﻿/* Copyright 2025 Oscar Amoros Huguet
+﻿/* Copyright 2025-2026 Oscar Amoros Huguet
    Copyright 2025 Albert Andaluz
    Copyright 2025 Grup Mediapro S.L.U
 
@@ -101,7 +101,7 @@ constexpr inline bool equalInstances(const T& instance1, const T& instance2) {
         const auto i1 = fk::toArray(instance1);
         const auto i2 = fk::toArray(instance2);
         constexpr size_t N = static_cast<size_t>(fk::cn<T>);
-        const fk::Array<bool, N> equalArray = fk::transformArray(fk::makeIndexArray<N>(),
+        const fk::ArrayVector<bool, N> equalArray = fk::transformArray(fk::makeIndexArray<N>(),
             [&] (const size_t& idx) constexpr {
                 return equalValues(i1[idx], i2[idx]);
             }
@@ -298,7 +298,7 @@ namespace test_case_builder::detail {
         fk::Ptr1D<I> inputPtr(N);
         fk::Ptr1D<O> outputPtr(N);
         for (size_t i = 0; i < N; ++i) {
-            inputPtr.at(fk::Point(i)) = inputElems[i];
+            inputPtr.at(fk::Point{static_cast<int>(i), 0, 0}) = inputElems[i];
         }
         std::cout << "Running test for " << "\033[1;33m" <<testName << "\033[1;33m" << ": ";
         inputPtr.upload(stream);
@@ -323,7 +323,7 @@ namespace test_case_builder::detail {
             fk::transformArray(inputElems, [](const BuildParams& input) {
                 const auto iROp = Operation::build(input);
                 using ROp = typename std::decay_t<decltype(iROp)>::Operation;
-                const fk::Point point(0, 0, 0);
+                const fk::Point point{0, 0, 0};
                 const uint num_elems_x = ROp::num_elems_x(point, iROp);
                 if constexpr (D == fk::ND::_1D) {
                     return fk::Ptr<D, OutputType>(num_elems_x);
@@ -360,7 +360,7 @@ namespace test_case_builder::detail {
 }
 
 template <typename Operation>
-struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::value &&
+struct TestCaseBuilder<Operation, std::enable_if_t<fk::OpIs<fk::UnaryType, Operation>::value &&
                                     std::is_fundamental_v<typename Operation::InputType> &&
                                     std::is_fundamental_v<typename Operation::OutputType>, void>> {
     template <size_t N>
@@ -372,7 +372,7 @@ struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::v
             const auto outputPtr = test_case_builder::detail::launchUnary<Operation>(testName, inputElems);
             bool result{ true };
             for (size_t i = 0; i < N; ++i) {
-                const auto generated = outputPtr.at(fk::Point(i));
+                const auto generated = outputPtr.at(fk::Point{static_cast<int>(i),0,0});
                 static_assert(std::is_same_v<std::decay_t<decltype(generated)>, std::decay_t<decltype(expectedElems[i])>>, "Output and Expected types are not the same");
                 const auto resultV = generated == expectedElems[i];
                 if (!resultV) {
@@ -395,7 +395,7 @@ struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::v
 };
 
 template <typename Operation>
-struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::value &&
+struct TestCaseBuilder<Operation, std::enable_if_t<fk::OpIs<fk::UnaryType, Operation>::value &&
                                     (fk::validCUDAVec<typename Operation::InputType> ||
                                      fk::validCUDAVec<typename Operation::OutputType>), void>> {
     template <size_t N>
@@ -407,7 +407,7 @@ struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::v
             const auto outputPtr = test_case_builder::detail::launchUnary<Operation>(testName, inputElems);
             bool result{ true };
             for (size_t i = 0; i < N; ++i) {
-                const auto generated = outputPtr.at(fk::Point(i));
+                const auto generated = outputPtr.at(fk::Point{static_cast<int>(i), 0, 0});
                 static_assert(std::is_same_v<std::decay_t<decltype(generated)>, std::decay_t<decltype(expectedElems[i])>>, "Output and Expected types are not the same");
                 const auto resultV = generated == expectedElems[i];
                 const auto arrayGenerated = fk::toArray(generated);
@@ -441,7 +441,7 @@ struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsUnaryType<Operation>::v
 };
 
 template <typename Operation>
-struct TestCaseBuilder<Operation, std::enable_if_t<fk::IsReadType<Operation>::value || fk::IsReadBackType<Operation>::value, void>> {
+struct TestCaseBuilder<Operation, std::enable_if_t<fk::OpIs<fk::ReadType, Operation>::value || fk::OpIs<fk::ReadBackType, Operation>::value, void>> {
     template <fk::ND D, size_t N, typename BuildParams>
     static inline void addTest(std::map<std::string, std::function<bool()>>& testCases,
                                fk::Stream& stream,

--- a/utests/algorithm/image_processing/utest_saturate/utest_saturate_common.h
+++ b/utests/algorithm/image_processing/utest_saturate/utest_saturate_common.h
@@ -24,8 +24,8 @@ constexpr T halfPositiveRange() {
 }
 
 template <typename OutputType, typename InputType>
-constexpr OutputType expectedPositiveValue(const InputType &input) {
-    if (cxp::cmp_greater::f(fk::get<0>(input), fk::maxValue<fk::VBase<OutputType>>)) {
+constexpr OutputType expectedPositiveValue(const InputType input) {
+    if (cxp::cmp_greater::f(input, fk::maxValue<fk::VBase<OutputType>>)) {
         return fk::maxValue<OutputType>;
     } else {
         return fk::Cast<InputType, OutputType>::exec(input);

--- a/utests/core/execution_model/utest_executors.h
+++ b/utests/core/execution_model/utest_executors.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Oscar Amoros Huguet
+/* Copyright 2025-2026 Oscar Amoros Huguet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,15 +15,22 @@
 #include <tests/main.h>
 
 #include <fused_kernel/algorithms/algorithms.h>
-#include <fused_kernel/core/execution_model/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/execution_model/executors.h>
 #include <iostream>
 
 using namespace fk;
 
+struct TestBackFuser : public BackFuser {
+    template <typename... IOps>
+    FK_HOST_FUSE size_t test_idxFirstNonBack() {
+        return BackFuser::idxFirstNonBack<IOps...>();
+    }
+};
+
 template <typename... IOps>
 constexpr size_t testIdxFirstNonBack(const IOps&...) {
-    return Back::idxFirstNonBack<IOps...>();
+    return TestBackFuser::template test_idxFirstNonBack<IOps...>();
 }
 
 bool testBack() {
@@ -58,23 +65,23 @@ bool testBack() {
         // Test idxFirstNonBack
         constexpr size_t idx1 = testIdxFirstNonBack(readOp, castU3F3, mulOpF3, writeF3);
         static_assert(idx1 == 0, "idx1 should be 0");
-        constexpr auto fusedIOp1 = Back::fuse(readOp, castU3F3, mulOpF3, writeF3);
+        constexpr auto fusedIOp1 = get<0>(BackFuser::fuse_back(readOp, castU3F3, mulOpF3, writeF3));
         static_assert(std::is_same_v<decltype(fusedIOp1), decltype(readOp)>, "Returned operation must be readOp");
 
         constexpr size_t idx2 = testIdxFirstNonBack(readOp, cropOp, castU3F3, writeF3);
         static_assert(idx2 == 2, "idx2 should be 2");
-        constexpr auto fusedIOp2 = Back::fuse(readOp, cropOp, castU3F3, writeF3);
+        constexpr auto fusedIOp2 = get<0>(BackFuser::fuse_back(readOp, cropOp, castU3F3, writeF3));
         static_assert(std::is_same_v<ReadBack<Crop<std::decay_t<decltype(readOp)>>>, std::decay_t<decltype(fusedIOp2)>>,
             "fusedIOps must have type ReadBack<Crop<PerThreadRead<ND::_2D, uchar3>>>");
 
         constexpr size_t idx3 = testIdxFirstNonBack(readOp, cropOp, mulOpU3, resizeOp, mulOpF3, vecReduceF3, writeF);
         static_assert(idx3 == 4, "idx3 should be 4");
-        constexpr auto fusedIOp3 = Back::fuse(readOp, cropOp, mulOpU3, resizeOp, mulOpF3, vecReduceF3, writeF);
+        constexpr auto fusedIOp3 = get<0>(BackFuser::fuse_back(readOp, cropOp, mulOpU3, resizeOp, mulOpF3, vecReduceF3, writeF));
         using GenerateFuseBack = std::decay_t<decltype(fusedIOp3)>;
         static_assert(std::is_same_v<typename GenerateFuseBack::Operation::InstanceType, ReadBackType>);
         static_assert(std::is_same_v<typename GenerateFuseBack::Operation::BackIOp::Operation::InstanceType, TernaryType>, "Expecting a ternary operation");
         static_assert(GenerateFuseBack::Operation::BackIOp::Operation::BackIOp::Operation::IS_FUSED_OP, "Expecting a fused operation");
-        using FusedBackType = ReadBack<ResizeComplete<AspectRatio::IGNORE_AR, Ternary<InterpolateComplete<InterpolationType::INTER_LINEAR, Read<FusedOperation<Crop<Read<PerThreadRead<ND::_2D, uchar3>>>, Mul<uchar3>>>>>>>;
+        using FusedBackType = ReadBack<ResizeComplete<AspectRatio::IGNORE_AR, Ternary<InterpolateComplete<InterpolationType::INTER_LINEAR, Read<FusedOperation<ReadBack<Crop<Read<PerThreadRead<ND::_2D, uchar3>>>>, Binary<Mul<uchar3>>>>>>>>;
         static_assert(std::is_same_v<std::decay_t<decltype(fusedIOp3)>, FusedBackType>, "Expecting ReadBack<ResizeComplete<AspectRatio::IGNORE_AR, Ternary<InterpolateComplete<InterpolationType::INTER_LINEAR, Read<FusedOperation<Crop<Read<PerThreadRead<ND::_2D, uchar3>>>, Mul<uchar3>>>>>>>");
     }
 


### PR DESCRIPTION
* LTS-C++17: (157 commits) Made all values that reside in registers, to be passed as const value, instead of const reference, to be more consistent with the reality of the variables and values. If nvcc where very strict, or there where no inlining in one function, it would trigger local memory usage. Simplified get wrapper and get_opt implementations Making get_opt generic like get Added missing include and fixing comment typos Removed unnecessary cast Using correct macro in OpenType Instantiable Operation further simplifying operation_types file Removing unnecesary code and adapting some benchmarks to new Point aggregate Making make and cat for OperationTuple host only functions. They should be used only on CPU. Fixing comments and removing unnecesary decltype(auto) Making OperationTuple an aggregate Removing unnecessary decltype(auto) Making some changes to avoid confusion with the two types of operator| in InstantiableOperations Added operator[] implementations with index passed as size_t Removing unnecesary decltype(auto), and adding a comment. Reducing function call depth in all operations exec and build functions, by moving their definition to the macros. Fixing bugs in memory operations Removing unnecesary decltyp(auto) Cleaning unnecessary decltype(auto) usage Revert .gitignore changes - remove CodeQL entries ...

# Conflicts:
#	.github/workflows/cmake-linux-amd64.yml
#	.github/workflows/cmake-linux-arm64.yml
#	.github/workflows/cmake-windows-amd64.yml
#	CMakeLists.txt
#	README.md
#	cmake/libs/cuda/target_generation.cmake
#	include/fused_kernel/core/execution_model/data_parallel_patterns.h #	include/fused_kernel/core/execution_model/operation_model/iop_fuser.h #	include/fused_kernel/core/utils/utils.h
#	lib/export/FKLConfigVersion.cmake
#	tests/examples/inlining_and_LDL_STL.h
#	tests/examples/readme_test_code.h