### PR TITLE
Add cuda 13.2 to arm64 via jetson using the forward compatibility for jetpack 6.x

### DIFF
--- a/.github/workflows/cmake-linux-amd64.yml
+++ b/.github/workflows/cmake-linux-amd64.yml
@@ -37,7 +37,7 @@ jobs:
         id: strings
         run: |
           echo "build-output-dir=${{github.workspace}}/build" >> "$GITHUB_OUTPUT"        
-          echo "PATH=/home/cudeiro/cmake-4.2.1-linux-x86_64/bin/:$PATH" >> "$GITHUB_ENV"
+          echo "PATH=$HOME/cmake-4.2.1-linux-x86_64/bin/:$PATH" >> "$GITHUB_ENV"
           echo "CUDACXX=/usr/local/cuda-${{matrix.cuda_toolkit}}/bin/nvcc" >> "$GITHUB_ENV"
           echo "CC=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
           echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"

--- a/.github/workflows/cmake-linux-arm64.yml
+++ b/.github/workflows/cmake-linux-arm64.yml
@@ -19,16 +19,16 @@ jobs:
         include:
           - host_compiler: "g++-11"
             cuda_toolkit: "12.9"
-            cuda_ldpath: "$LD_LIBRARY_PATH"
+            cuda_ldpath: "cuda-12.9"
           - host_compiler: "clang++-21"
             cuda_toolkit: "12.9"
-            cuda_ldpath: "$LD_LIBRARY_PATH"
+            cuda_ldpath: "cuda-12.9"
           - host_compiler: "g++-11"
             cuda_toolkit: "13.2"
-            cuda_ldpath: "$HOME/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+            cuda_ldpath: "cuda-13.2/compat_orin" 
           - host_compiler: "clang++-21"
             cuda_toolkit: "13.2"  
-            cuda_ldpath: "$HOME/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+            cuda_ldpath: "cuda-13.2/compat_orin" 
  
     steps:
       - uses: actions/checkout@v4
@@ -40,13 +40,9 @@ jobs:
           echo "PATH=$HOME/cmake-4.2.1-linux-aarch64/bin/:$PATH" >> "$GITHUB_ENV"
           echo "CUDACXX=/usr/local/cuda-${{matrix.cuda_toolkit}}/bin/nvcc" >> "$GITHUB_ENV"
           echo "CC=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
-          echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
-          if [ -n "${{ matrix.cuda_ldpath }}" ]; then
-            echo "LD_LIBRARY_PATH=${{ matrix.cuda_ldpath }}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          else
-            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          fi
-
+          echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"          
+          echo "LD_LIBRARY_PATH=/usr/local/${{matrix.cuda_ldpath}}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          
       - name: Configure CMake
         run: |
 

--- a/.github/workflows/cmake-linux-arm64.yml
+++ b/.github/workflows/cmake-linux-arm64.yml
@@ -41,7 +41,11 @@ jobs:
           echo "CUDACXX=/usr/local/cuda-${{matrix.cuda_toolkit}}/bin/nvcc" >> "$GITHUB_ENV"
           echo "CC=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
           echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=${{matrix.cuda_ldpath}}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          if [ -n "${{ matrix.cuda_ldpath }}" ]; then
+            echo "LD_LIBRARY_PATH=${{ matrix.cuda_ldpath }}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          else
+            echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          fi
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/cmake-linux-arm64.yml
+++ b/.github/workflows/cmake-linux-arm64.yml
@@ -19,9 +19,17 @@ jobs:
         include:
           - host_compiler: "g++-11"
             cuda_toolkit: "12.9"
+            cuda_ldpath: ""
           - host_compiler: "clang++-21"
             cuda_toolkit: "12.9"
-        #
+            cuda_ldpath: ""
+          - host_compiler: "g++-11"
+            cuda_toolkit: "13.2"
+            cuda_ldpath: "/home/cudeiro/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+          - host_compiler: "clang++-21"
+            cuda_toolkit: "13.2"  
+            cuda_ldpath: "/home/cudeiro/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+ 
     steps:
       - uses: actions/checkout@v4
       - name: Set reusable strings
@@ -33,6 +41,7 @@ jobs:
           echo "CUDACXX=/usr/local/cuda-${{matrix.cuda_toolkit}}/bin/nvcc" >> "$GITHUB_ENV"
           echo "CC=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
           echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=${{matrix.cuda_ldpath}}:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/cmake-linux-arm64.yml
+++ b/.github/workflows/cmake-linux-arm64.yml
@@ -19,16 +19,16 @@ jobs:
         include:
           - host_compiler: "g++-11"
             cuda_toolkit: "12.9"
-            cuda_ldpath: ""
+            cuda_ldpath: "$LD_LIBRARY_PATH"
           - host_compiler: "clang++-21"
             cuda_toolkit: "12.9"
-            cuda_ldpath: ""
+            cuda_ldpath: "$LD_LIBRARY_PATH"
           - host_compiler: "g++-11"
             cuda_toolkit: "13.2"
-            cuda_ldpath: "/home/cudeiro/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+            cuda_ldpath: "$HOME/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
           - host_compiler: "clang++-21"
             cuda_toolkit: "13.2"  
-            cuda_ldpath: "/home/cudeiro/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
+            cuda_ldpath: "$HOME/cuda-compat-orin/extracted/usr/local/cuda-13.2/compat_orin" 
  
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         id: strings
         run: |
           echo "build-output-dir=${{github.workspace}}/build" >> "$GITHUB_OUTPUT"      
-          echo "PATH=/home/cudeiro/cmake-4.2.1-linux-aarch64/bin/:$PATH" >> "$GITHUB_ENV"
+          echo "PATH=$HOME/cmake-4.2.1-linux-aarch64/bin/:$PATH" >> "$GITHUB_ENV"
           echo "CUDACXX=/usr/local/cuda-${{matrix.cuda_toolkit}}/bin/nvcc" >> "$GITHUB_ENV"
           echo "CC=${{matrix.host_compiler}}" >> "$GITHUB_ENV"
           echo "CXX=${{matrix.host_compiler}}" >> "$GITHUB_ENV"


### PR DESCRIPTION
added cuda 13.2 to jetson agx orin (ARM64) using the compatiblity guide for jetpack 6.x as in  
​ 
[(Test) Run public wheels CUDA 13.2 Jetson Orin Family](https://forums.developer.nvidia.com/t/test-run-public-wheels-cuda-13-2-jetson-orin-family/364497)