### PR TITLE
Fix ColorConversion FusedOperation aliases and DivergentBatchTransformDPP Executor (fixes #244, #245)

### DIFF
--- a/include/fused_kernel/algorithms/image_processing/color_conversion.h
+++ b/include/fused_kernel/algorithms/image_processing/color_conversion.h
@@ -569,14 +569,15 @@ namespace fk {
     // Will work for ColorConversionCodes::COLOR_RGB2BGRA too
     template <typename I, typename O, ColorDepth CD>
     struct ColorConversionType<ColorConversionCodes::COLOR_BGR2RGBA, I, O, CD> {
-        using type = FusedOperation<VectorReorder<I, 2, 1, 0>, AddOpaqueAlpha<I, CD>>;
+        // FusedOperation expects IOps (with ::Operation); wrap raw Unary Ops
+        using type = FusedOperation<Unary<VectorReorder<I, 2, 1, 0>>, Unary<AddOpaqueAlpha<I, CD>>>;
     };
 
     // Will work for COLOR_RGBA2BGR too
     template <typename I, typename O, ColorDepth CD>
     struct ColorConversionType<ColorConversionCodes::COLOR_BGRA2RGB, I, O, CD> {
-        using type = FusedOperation<VectorReorder<I, 2, 1, 0, 3>,
-                           Discard<I, VectorType_t<VBase<I>, 3>>>;
+        using type = FusedOperation<Unary<VectorReorder<I, 2, 1, 0, 3>>,
+                           Unary<Discard<I, VectorType_t<VBase<I>, 3>>>>;
     };
 
     // Will work for ColorConversionCodes::COLOR_RGB2BGR too
@@ -598,7 +599,7 @@ namespace fk {
 
     template <typename I, typename O, ColorDepth CD>
     struct ColorConversionType<ColorConversionCodes::COLOR_BGR2GRAY, I, O, CD> {
-        using type = FusedOperation<VectorReorder<I, 2, 1, 0>, RGB2Gray<I, O>>;
+        using type = FusedOperation<Unary<VectorReorder<I, 2, 1, 0>>, Unary<RGB2Gray<I, O>>>;
     };
 
     template <typename I, typename O, ColorDepth CD>
@@ -608,7 +609,7 @@ namespace fk {
 
     template <typename I, typename O, ColorDepth CD>
     struct ColorConversionType<ColorConversionCodes::COLOR_BGRA2GRAY, I, O, CD> {
-        using type = FusedOperation<VectorReorder<I, 2, 1, 0, 3>, RGB2Gray<I, O>>;
+        using type = FusedOperation<Unary<VectorReorder<I, 2, 1, 0, 3>>, Unary<RGB2Gray<I, O>>>;
     };
 
     template <ColorConversionCodes code, typename I, typename O, ColorDepth CD = ColorDepth::p8bit>

--- a/include/fused_kernel/core/execution_model/executors.h
+++ b/include/fused_kernel/core/execution_model/executors.h
@@ -324,7 +324,13 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
 
         template <typename... IOps>
         FK_HOST_FUSE auto fuseBackSequence(const IOpSequence<IOps...>& iOpSeq) {
-            return buildOperationSequence_tup(apply(BackFuser::fuse_back<IOps...>, iOpSeq.iOps));
+            // NOTE: do not pass explicit template arguments to fuse_back here.
+            // With explicit args its IOps&&... parameters become rvalue
+            // references, which cannot bind to the const lvalues stored in
+            // the sequence tuple. Let the compiler deduce (forwarding refs).
+            return buildOperationSequence_tup(apply(
+                [](const auto&... iOps) { return BackFuser::fuse_back(iOps...); },
+                iOpSeq.iOps));
         }
 
         template <typename... IOpSequenceTypes>

--- a/utests/algorithm/image_processing/utest_color_conversion.h
+++ b/utests/algorithm/image_processing/utest_color_conversion.h
@@ -137,6 +137,48 @@ void testBGR2Gray() {
     TestCaseBuilder<BGR2GrayTest>::addTest(testCases, inputVals, expectedVals);
 }
 
+// Tests for the ColorConversion aliases that expand to FusedOperation
+// (regression test for the raw-Op vs IOp template arguments bug):
+// COLOR_BGR2GRAY, COLOR_BGRA2GRAY, COLOR_BGR2RGBA, COLOR_BGRA2RGB
+void testFusedColorConversionAliases() {
+    // COLOR_BGR2GRAY: reorder(2,1,0) then RGB2Gray
+    // input is BGR -> luma = 0.299*R(z) + 0.587*G(y) + 0.114*B(x)
+    std::array<uchar3, 2> inBGR = {
+        uchar3{50, 100, 150},
+        uchar3{75, 125, 200}
+    };
+    std::array<uchar, 2> expGray = {
+        static_cast<uchar>(std::nearbyint(150 * 0.299f + 100 * 0.587f + 50 * 0.114f)),
+        static_cast<uchar>(std::nearbyint(200 * 0.299f + 125 * 0.587f + 75 * 0.114f))
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2GRAY, uchar3, uchar>>::
+        addTest(testCases, inBGR, expGray);
+
+    // COLOR_BGRA2GRAY: reorder(2,1,0,3) then RGB2Gray (alpha discarded by formula)
+    std::array<uchar4, 2> inBGRA = {
+        uchar4{50, 100, 150, 255},
+        uchar4{75, 125, 200, 128}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2GRAY, uchar4, uchar>>::
+        addTest(testCases, inBGRA, expGray);
+
+    // COLOR_BGR2RGBA: reorder(2,1,0) then AddOpaqueAlpha
+    std::array<uchar4, 2> expRGBA = {
+        uchar4{150, 100, 50, 255},
+        uchar4{200, 125, 75, 255}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2RGBA, uchar3, uchar4>>::
+        addTest(testCases, inBGR, expRGBA);
+
+    // COLOR_BGRA2RGB: reorder(2,1,0,3) then Discard -> 3 channels
+    std::array<uchar3, 2> expRGB = {
+        uchar3{150, 100, 50},
+        uchar3{200, 125, 75}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2RGB, uchar4, uchar3>>::
+        addTest(testCases, inBGRA, expRGB);
+}
+
 void testAddOpaqueAlphaStruct() {
     // Test AddOpaqueAlpha struct with 8-bit depth
     using AddOpaqueAlphaTest = fk::AddOpaqueAlpha<uchar3, fk::ColorDepth::p8bit>;
@@ -343,6 +385,7 @@ testColorConversionOperations();
 // Test additional structs
 testStaticAddAlpha();
 testBGR2Gray();
+testFusedColorConversionAliases();
 testAddOpaqueAlphaStruct();
 testDenormalizePixel();
 testNormalizePixel();


### PR DESCRIPTION
## Summary

Fixes two compile-time bugs found while building a Python front-end on top of FKL, both with minimal reproducers in the linked issues:

- Fixes #244 — `ColorConversion` aliases (`COLOR_BGR2GRAY`, `COLOR_BGRA2GRAY`, `COLOR_BGR2RGBA`, `COLOR_BGRA2RGB`) expanded to `FusedOperation<RawOp...>` with raw Operation types, but `FusedOperation_` expects IOps (types with `::Operation`). Any instantiation failed with `name followed by "::" must be a class or namespace name`. Fixed by wrapping the Ops as `Unary<...>`.
- Fixes #245 — `Executor<DivergentBatchTransformDPP>::fuseBackSequence` called `fuse_back<IOps...>` with explicit template arguments, fixing its `IOps&&...` parameters as rvalue references that cannot bind to the const lvalues in the sequence tuple (`qualifiers dropped in binding reference`). Fixed by deducing through a lambda so the forwarding references work as intended.

## Tests

- New `testFusedColorConversionAliases()` in `utest_color_conversion.h` covering the four affected codes against per-channel expected values (BT.601 luma for the GRAY ones).
- Runtime verification on RTX PRO 6000 Blackwell (sm_120, CUDA 13.3):
  - `COLOR_BGR2GRAY` produces correct BT.601 luma vs CPU reference.
  - Divergent Executor reproducer from #245 compiles and produces plane0 = x*2 / plane1 = x+100 correctly.
- Full in-tree suite: **66/66 test binaries pass** (`utests/` + `tests/`) on CUDA 13.3 / sm_120 / Ubuntu (nvcc).

## Notes

- No API changes; both fixes are internal to the existing templates.
- The `Unary<...>` wrapping changes the alias' resolved type name (it now names IOps), but any code that previously compiled against these four aliases could not exist, since they never compiled.
