### PR TITLE
Attention DPPs: FlashAttention-2 + FlashDecode (IOp prologues, tensor cores, fp8/int8 KV cache)

### DIFF
--- a/include/fused_kernel/algorithms/attention/flash_attention.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention.h
@@ -355,4 +355,102 @@ inline void quantizeKVCacheHost(const T* dense, int8_t* q8, float* scales,
 
 } // namespace fk
 
+// ============================ FP8 KV CACHE ==================================
+// fp8 e4m3 per-token-scaled KV cache (the FA4-sm12x / PR #2634 recipe,
+// expressed as a prologue Read IOp). Same 2x-vs-bf16 memory saving as int8
+// but the e4m3 grid is non-uniform (more precision near 0), which suits
+// attention tails. Storage: data fp8 e4m3, one fp32 scale per token
+// (scale = max|row| / 448, e4m3 max normal = 448).
+#if __has_include(<cuda_fp8.h>)
+#include <cuda_fp8.h>
+#define FK_HAS_FP8 1
+
+namespace fk {
+
+struct Fp8TokenDequantReadParams {
+    RawPtr<ND::_3D, int8_t> data;   // raw e4m3 bytes (int8_t storage)
+    const float* scales;            // one fp32 scale per token
+};
+
+struct Fp8TokenDequantRead {
+private:
+    using Parent = ReadOperation<int8_t, Fp8TokenDequantReadParams, float,
+                                 TF::DISABLED, Fp8TokenDequantRead>;
+    using SelfType = Fp8TokenDequantRead;
+public:
+    FK_STATIC_STRUCT(Fp8TokenDequantRead, SelfType)
+    DECLARE_READ_PARENT
+
+    // NOTE: plain static (not FK_HOST_DEVICE_FUSE): fp8 conversion ops are
+    // not constexpr (same trap as __shared__ in cooperative DPP exec).
+    static __host__ __device__ __forceinline__
+    float exec(const Point thread, const ParamsType& params) {
+        const int8_t raw = *PtrAccessor<ND::_3D>::cr_point(thread, params.data);
+        const int seq = static_cast<int>(params.data.dims.height);
+        const float sc = params.scales[(long)thread.z * seq + thread.y];
+#if defined(__CUDA_ARCH__)
+        const __nv_fp8_e4m3* f8 = reinterpret_cast<const __nv_fp8_e4m3*>(&raw);
+        return static_cast<float>(*f8) * sc;
+#else
+        __nv_fp8_e4m3 f8;
+        f8.__x = static_cast<__nv_fp8_storage_t>(raw);
+        return static_cast<float>(f8) * sc;
+#endif
+    }
+
+    FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.width;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.height;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.planes;
+    }
+    FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.pitch;
+    }
+    FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
+        return { num_elems_x(Point{0,0,0}, opData),
+                 num_elems_y(Point{0,0,0}, opData),
+                 num_elems_z(Point{0,0,0}, opData) };
+    }
+};
+
+// fp8-per-token compressed K or V cache as a dequantizing Read IOp.
+inline auto makeFp8KVRead(const void* data, const float* scales,
+                          const int batchHeads, const int seq,
+                          const int headDim) {
+    const RawPtr<ND::_3D, int8_t> ptr{
+        const_cast<int8_t*>(static_cast<const int8_t*>(data)),
+        PtrDims<ND::_3D>(static_cast<uint>(headDim), static_cast<uint>(seq),
+                         static_cast<uint>(batchHeads), 1,
+                         static_cast<uint>(headDim)) };
+    return Fp8TokenDequantRead::build(Fp8TokenDequantReadParams{ ptr, scales });
+}
+
+// host-side reference packing: scale[t] = max|row|/448 (e4m3 max normal).
+template <typename T>
+inline void quantizeKVCacheFp8Host(const T* dense, void* f8out, float* scales,
+                                   const int tokens, const int headDim) {
+    int8_t* out = static_cast<int8_t*>(f8out);
+    for (int t = 0; t < tokens; ++t) {
+        float mx = 0.f;
+        for (int d = 0; d < headDim; ++d) {
+            mx = std::max(mx, std::abs(attnToF32(dense[(long)t * headDim + d])));
+        }
+        const float sc = mx > 0.f ? mx / 448.f : 1.f;
+        scales[t] = sc;
+        for (int d = 0; d < headDim; ++d) {
+            const float x = attnToF32(dense[(long)t * headDim + d]) / sc;
+            const __nv_fp8_e4m3 f8(x);
+            out[(long)t * headDim + d] = static_cast<int8_t>(f8.__x);
+        }
+    }
+}
+
+} // namespace fk
+
+#endif // __has_include(<cuda_fp8.h>)
+
 #endif // FK_ATTENTION_FLASH_ATTENTION_H

--- a/include/fused_kernel/algorithms/attention/flash_attention.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention.h
@@ -16,45 +16,57 @@
 #define FK_ATTENTION_FLASH_ATTENTION_H
 
 /* FlashAttentionDPP: FlashAttention-2 forward as ONE cooperative DPP
- * (one kernel), with two FKL-only superpowers that handmade FA kernels
+ * (one kernel), with FKL-only superpowers that handmade FA kernels
  * (flash-attention repo and friends) cannot offer:
  *
- *  1. EPILOGUE FUSION: any FKL compute IOp chain (Mul, Add, Cast,
+ *  1. PROLOGUE FUSION (the fa-5090 insight, generalized): the DPP does
+ *     NOT read raw pointers. Q, K and V are each a Read or ReadBack IOp
+ *     (PerThreadRead, Int8TokenDequantRead, or any read.then(compute...)
+ *     fusion) and the algorithm reads EVERY data element through that
+ *     IOp. Whatever preprocessing the prologue encodes (dequantization,
+ *     scaling, RoPE-style maps, casts...) happens in-register at load
+ *     time - one global read, no preprocessing kernel, no DRAM round-trip.
+ *
+ *  2. EPILOGUE FUSION: any FKL compute IOp chain (Mul, Add, Cast,
  *     Saturate, ... composed with .then()) is applied IN-REGISTER to the
  *     attention output before the single global write. out = (o/l) | chain.
- *     With handmade kernels that is always a second kernel + a DRAM
- *     round-trip; here it is zero extra cost and type-checked by FKL.
  *
- *  2. COMPRESSED KV CACHE (KVLayout::INT8_PER_TOKEN): K and V live in
- *     global memory as int8 with one fp32 scale per token:
+ *  3. COMPRESSED KV CACHE (Int8TokenDequantRead / KVLayout::INT8_PER_TOKEN):
+ *     K and V live in global memory as int8 with one fp32 scale per token:
  *       k_int8[t][d] = round(k[t][d]/kScale[t]), kScale[t] = max|k[t]|/127
  *     -> 4x smaller cache vs fp32 (2x vs fp16) + 2 floats/token.
- *     Dequantization is a fused prologue: it happens in-register inside
- *     the q.k dot product and the p*v accumulation. The compressed cache
- *     is NEVER inflated in global memory.
+ *     Dequantization is just the K/V prologue Read IOp: it happens
+ *     in-register inside the q.k dot product and the p*v accumulation.
+ *     The compressed cache is NEVER inflated in global memory.
  *
  * Algorithm (Dao, FlashAttention-2): never materialize S = QK^T. Each
  * query row keeps a running (m, l, o); every KV position updates them with
  * the online-softmax rescaling trick. One pass over KV, O(seq) memory,
  * exact (fp32 accumulation).
  *
- * Mapping (SM 12x friendly — no TMEM/tcgen05, per the fa-5090 analysis,
+ * Mapping (SM 12x friendly - no TMEM/tcgen05, per the fa-5090 analysis,
  * correctness-first SIMT baseline before mma.sync tiling):
  *   grid.y = batch*heads; grid.x = ceil(seq_q / WARPS_PER_BLOCK)
  *   1 warp per query row; q and o live in registers spread across lanes
  *   (HEAD_DIM/32 each); dot products warp-reduce via __shfl_xor_sync;
- *   K/V tiles staged cooperatively in shared memory.
+ *   K/V tiles staged cooperatively in shared memory THROUGH the prologue
+ *   IOps (tiles hold post-prologue fp32, so the prologue runs exactly
+ *   once per element).
+ *
+ * Element addressing convention for the prologue IOps (3D):
+ *   thread.x = position inside the head (0..HEAD_DIM-1)
+ *   thread.y = token index in the sequence
+ *   thread.z = batch*head plane
  */
 
 #include <fused_kernel/algorithms/attention/softmax.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 
 namespace fk {
 
 enum class KVLayout { DENSE, INT8_PER_TOKEN };
 
-#if defined(__NVCC__) || CLANG_HOST_DEVICE
-
-// Identity epilogue: applied when no IOp chain is given.
+// Identity IOp: applied when no epilogue chain is given.
 struct AttentionIdentityEpilogue {
     FK_HOST_DEVICE_CNST friend float operator|(const float v,
                                                const AttentionIdentityEpilogue&) {
@@ -62,61 +74,137 @@ struct AttentionIdentityEpilogue {
     }
 };
 
-template <typename T, int HEAD_DIM, KVLayout KVL = KVLayout::DENSE,
+/* Int8TokenDequantRead: Read IOp for the compressed KV cache.
+ * data  : (batch*heads, seq, head_dim) int8, C-contiguous
+ * scales: one float per token, laid out (batch*heads * seq)
+ * exec(thread) returns float(data[z][y][x]) * scales[z*seq + y].
+ * Usable standalone in any FKL pipeline, and as the K/V prologue of
+ * FlashAttentionDPP. Compose further preprocessing with .then(...). */
+struct Int8TokenDequantReadParams {
+    RawPtr<ND::_3D, int8_t> data;
+    const float* scales;
+};
+
+struct Int8TokenDequantRead {
+private:
+    using Parent = ReadOperation<int8_t, Int8TokenDequantReadParams, float,
+                                 TF::DISABLED, Int8TokenDequantRead>;
+    using SelfType = Int8TokenDequantRead;
+public:
+    FK_STATIC_STRUCT(Int8TokenDequantRead, SelfType)
+    DECLARE_READ_PARENT
+
+    FK_HOST_DEVICE_FUSE float exec(const Point thread, const ParamsType& params) {
+        const int8_t q = *PtrAccessor<ND::_3D>::cr_point(thread, params.data);
+        const int seq = static_cast<int>(params.data.dims.height);
+        const float sc = params.scales[(long)thread.z * seq + thread.y];
+        return static_cast<float>(q) * sc;
+    }
+
+    FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.width;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.height;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.planes;
+    }
+    FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
+        return opData.params.data.dims.pitch;
+    }
+    FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
+        return { num_elems_x(Point{0,0,0}, opData),
+                 num_elems_y(Point{0,0,0}, opData),
+                 num_elems_z(Point{0,0,0}, opData) };
+    }
+};
+
+// ---- prologue builders ----------------------------------------------------
+// Wrap a raw (batch*heads, seq, head_dim) C-contiguous pointer as the
+// canonical attention Read IOp. Fuse extra preprocessing with .then(...).
+template <typename T>
+inline auto makeAttentionRead(const T* data, const int batchHeads,
+                              const int seq, const int headDim) {
+    const RawPtr<ND::_3D, T> ptr{
+        const_cast<T*>(data),
+        PtrDims<ND::_3D>(static_cast<uint>(headDim), static_cast<uint>(seq),
+                         static_cast<uint>(batchHeads), 1,
+                         static_cast<uint>(headDim * sizeof(T))) };
+    return PerThreadRead<ND::_3D, T>::build(ptr);
+}
+
+// int8-per-token compressed K or V cache as a dequantizing Read IOp.
+inline auto makeInt8KVRead(const int8_t* data, const float* scales,
+                           const int batchHeads, const int seq,
+                           const int headDim) {
+    const RawPtr<ND::_3D, int8_t> ptr{
+        const_cast<int8_t*>(data),
+        PtrDims<ND::_3D>(static_cast<uint>(headDim), static_cast<uint>(seq),
+                         static_cast<uint>(batchHeads), 1,
+                         static_cast<uint>(headDim)) };
+    return Int8TokenDequantRead::build(Int8TokenDequantReadParams{ ptr, scales });
+}
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+
+/* The DPP. QIOp/KIOp/VIOp are INSTANTIABLE Read or ReadBack IOps (possibly
+ * fused with compute continuations): the algorithm reads each element of
+ * Q, K and V exclusively through IOp::Operation::exec(thread, iop). */
+template <typename OT, int HEAD_DIM,
+          typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue,
-          int BLOCK_N = (sizeof(T) == 2 ? 64 : 32), int WARPS_PER_BLOCK = 4>
+          int BLOCK_N = 32, int WARPS_PER_BLOCK = 4>
 struct FlashAttentionDPP {
 private:
-    using SelfType = FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
+    using SelfType = FlashAttentionDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
+                                       EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
 public:
     FK_STATIC_STRUCT(FlashAttentionDPP, SelfType)
 
     static_assert(HEAD_DIM % 32 == 0, "HEAD_DIM must be a multiple of 32");
+    static_assert(isAnyReadType<QIOp>, "Q prologue must be a Read or ReadBack IOp");
+    static_assert(isAnyReadType<KIOp>, "K prologue must be a Read or ReadBack IOp");
+    static_assert(isAnyReadType<VIOp>, "V prologue must be a Read or ReadBack IOp");
     static constexpr int ELEMS_PER_LANE = HEAD_DIM / 32;
     static constexpr int THREADS = WARPS_PER_BLOCK * 32;
-    static constexpr bool QUANT = (KVL == KVLayout::INT8_PER_TOKEN);
-
-    // dense: KVT = T. int8: KVT = int8_t + per-token scales.
-    using KVT = std::conditional_t<QUANT, int8_t, T>;
 
     struct Params {
-        const T* q;            // (batch*heads, seq_q, HEAD_DIM)
-        const KVT* k;          // (batch*heads, seq_k, HEAD_DIM) [int8 if QUANT]
-        const KVT* v;
-        const float* kScale;   // (batch*heads, seq_k) per-token scales (QUANT)
-        const float* vScale;
-        T* o;                  // (batch*heads, seq_q, HEAD_DIM)
+        QIOp q;                  // prologue Read/ReadBack IOp for Q
+        KIOp k;                  // prologue Read/ReadBack IOp for K
+        VIOp v;                  // prologue Read/ReadBack IOp for V
+        OT* o;                   // (batch*heads, seq_q, HEAD_DIM) output
         int seq_q;
         int seq_k;
-        float scale;           // logit scale, usually rsqrt(HEAD_DIM)
+        float scale;             // logit scale, usually rsqrt(HEAD_DIM)
         bool causal;
-        EpilogueIOp epilogue;  // fused FKL IOp chain applied before the write
+        EpilogueIOp epilogue;    // fused IOp chain on the output (pre-write)
     };
 
+    template <typename IOp>
+    FK_DEVICE_FUSE float readElem(const IOp& iop, const int x, const int y, const int z) {
+        // ALL data elements enter the algorithm through this single point:
+        // the prologue IOp's exec. Fused continuations run here, in-register.
+        return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
+    }
+
     FK_COOP_DEVICE_FUSE exec(const Params& p) {
-        __shared__ KVT kTile[BLOCK_N][HEAD_DIM];
-        __shared__ KVT vTile[BLOCK_N][HEAD_DIM];
-        __shared__ float kScaleTile[BLOCK_N];
-        __shared__ float vScaleTile[BLOCK_N];
+        // Tiles hold POST-prologue fp32: the prologue runs once per element.
+        __shared__ float kTile[BLOCK_N][HEAD_DIM];
+        __shared__ float vTile[BLOCK_N][HEAD_DIM];
 
         const int lane = threadIdx.x & 31;
         const int warp = threadIdx.x >> 5;
         const int qIdx = blockIdx.x * WARPS_PER_BLOCK + warp;
-        const long bh = blockIdx.y;
+        const int bh = blockIdx.y;
         const bool active = qIdx < p.seq_q;
-
-        const T* qBase = p.q + bh * (long)p.seq_q * HEAD_DIM;
-        const KVT* kBase = p.k + bh * (long)p.seq_k * HEAD_DIM;
-        const KVT* vBase = p.v + bh * (long)p.seq_k * HEAD_DIM;
-        T* oBase = p.o + bh * (long)p.seq_q * HEAD_DIM;
-        const float* kS = QUANT ? p.kScale + bh * (long)p.seq_k : nullptr;
-        const float* vS = QUANT ? p.vScale + bh * (long)p.seq_k : nullptr;
 
         float qReg[ELEMS_PER_LANE];
         float oAcc[ELEMS_PER_LANE];
         #pragma unroll
         for (int e = 0; e < ELEMS_PER_LANE; ++e) {
-            qReg[e] = active ? attnToF32(qBase[(long)qIdx * HEAD_DIM + lane + 32 * e]) : 0.f;
+            // Q PROLOGUE: read through the IOp, in-register, at load time.
+            qReg[e] = active ? readElem(p.q, lane + 32 * e, qIdx, bh) : 0.f;
             oAcc[e] = 0.f;
         }
         float m = -FLT_MAX;
@@ -129,17 +217,13 @@ public:
             const int tileLen = ::min(BLOCK_N, kvEnd - tile);
 
             __syncthreads();
+            // K/V PROLOGUES: cooperative staging reads every element of the
+            // tile through the K and V IOps (dequant & friends fuse here).
             for (int idx = threadIdx.x; idx < tileLen * HEAD_DIM; idx += THREADS) {
                 const int r = idx / HEAD_DIM;
                 const int c = idx % HEAD_DIM;
-                kTile[r][c] = kBase[(long)(tile + r) * HEAD_DIM + c];
-                vTile[r][c] = vBase[(long)(tile + r) * HEAD_DIM + c];
-            }
-            if constexpr (QUANT) {
-                for (int r = threadIdx.x; r < tileLen; r += THREADS) {
-                    kScaleTile[r] = kS[tile + r];
-                    vScaleTile[r] = vS[tile + r];
-                }
+                kTile[r][c] = readElem(p.k, c, tile + r, bh);
+                vTile[r][c] = readElem(p.v, c, tile + r, bh);
             }
             __syncthreads();
 
@@ -149,17 +233,11 @@ public:
                 const int kvIdx = tile + j;
                 if (p.causal && kvIdx > qIdx) { break; }
 
-                // s = q . k_j (dequantize in-register if compressed)
+                // s = q . k_j
                 float partial = 0.f;
                 #pragma unroll
                 for (int e = 0; e < ELEMS_PER_LANE; ++e) {
-                    float kv;
-                    if constexpr (QUANT) {
-                        kv = static_cast<float>(kTile[j][lane + 32 * e]) * kScaleTile[j];
-                    } else {
-                        kv = attnToF32(kTile[j][lane + 32 * e]);
-                    }
-                    partial += qReg[e] * kv;
+                    partial += qReg[e] * kTile[j][lane + 32 * e];
                 }
                 #pragma unroll
                 for (int offset = 16; offset > 0; offset >>= 1) {
@@ -173,13 +251,7 @@ public:
                 l = l * corr + pj;
                 #pragma unroll
                 for (int e = 0; e < ELEMS_PER_LANE; ++e) {
-                    float vv;
-                    if constexpr (QUANT) {
-                        vv = static_cast<float>(vTile[j][lane + 32 * e]) * vScaleTile[j];
-                    } else {
-                        vv = attnToF32(vTile[j][lane + 32 * e]);
-                    }
-                    oAcc[e] = oAcc[e] * corr + pj * vv;
+                    oAcc[e] = oAcc[e] * corr + pj * vTile[j][lane + 32 * e];
                 }
                 m = mNew;
             }
@@ -187,48 +259,75 @@ public:
 
         if (active) {
             const float invL = l > 0.f ? 1.f / l : 0.f;
+            const long oRow = ((long)bh * p.seq_q + qIdx) * HEAD_DIM;
             #pragma unroll
             for (int e = 0; e < ELEMS_PER_LANE; ++e) {
                 // EPILOGUE FUSION: the FKL IOp chain runs in-register on the
-                // normalized output, then ONE global write. This is the
-                // "fuse more than handmade FA" hook: any Mul/Add/Cast/
-                // Saturate/... composition rides inside the same kernel.
+                // normalized output, then ONE global write.
                 const float r = (oAcc[e] * invL) | p.epilogue;
-                oBase[(long)qIdx * HEAD_DIM + lane + 32 * e] = attnFromF32<T>(r);
+                p.o[oRow + lane + 32 * e] = attnFromF32<OT>(r);
             }
         }
     }
 };
 
-template <typename T, int HEAD_DIM, KVLayout KVL, typename EpilogueIOp,
-          int BLOCK_N, int WARPS_PER_BLOCK>
+template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
+          typename EpilogueIOp, int BLOCK_N, int WARPS_PER_BLOCK>
 __global__ void launchFlashAttentionDPP_Kernel(
-        const __grid_constant__ typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::Params params) {
-    FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::exec(params);
+        const __grid_constant__ typename FlashAttentionDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::Params params) {
+    FlashAttentionDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::exec(params);
 }
 
+/* IOp-first API: pass Q/K/V as Read/ReadBack IOps (the prologues). */
+template <int HEAD_DIM, int BLOCK_N = 32, int WARPS_PER_BLOCK = 4,
+          typename OT = float, typename QIOp, typename KIOp, typename VIOp,
+          typename EpilogueIOp = AttentionIdentityEpilogue>
+inline void executeFlashAttention(
+        const QIOp& q, const KIOp& k, const VIOp& v, OT* o,
+        const int batchHeads, const int seqQ, const int seqK,
+        const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
+        const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {}) {
+    using DPP = FlashAttentionDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
+                                  EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
+    const float scale = scaleOverride > 0.f ? scaleOverride
+                                            : rsqrtf(static_cast<float>(HEAD_DIM));
+    const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal, epilogue };
+    const dim3 grid((seqQ + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, batchHeads, 1);
+    const dim3 block(DPP::THREADS, 1, 1);
+    launchFlashAttentionDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>
+        <<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+/* Pointer convenience API (kept for compatibility): builds the canonical
+ * prologue Read IOps and forwards. KVLayout::INT8_PER_TOKEN selects the
+ * Int8TokenDequantRead prologue for K and V. */
 template <typename T, int HEAD_DIM, KVLayout KVL = KVLayout::DENSE,
-          int BLOCK_N = (sizeof(T) == 2 ? 64 : 32), int WARPS_PER_BLOCK = 4,
+          int BLOCK_N = 32, int WARPS_PER_BLOCK = 4,
           typename EpilogueIOp = AttentionIdentityEpilogue>
 inline void executeFlashAttention(
         const T* q,
-        const typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::KVT* k,
-        const typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::KVT* v,
+        const std::conditional_t<KVL == KVLayout::INT8_PER_TOKEN, int8_t, T>* k,
+        const std::conditional_t<KVL == KVLayout::INT8_PER_TOKEN, int8_t, T>* v,
         T* o, const int batchHeads, const int seqQ, const int seqK,
         const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
         const float* kScale = nullptr, const float* vScale = nullptr,
         const float scaleOverride = -1.f,
         const EpilogueIOp& epilogue = {}) {
-    using DPP = FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
-    const float scale = scaleOverride > 0.f ? scaleOverride
-                                            : rsqrtf(static_cast<float>(HEAD_DIM));
-    const typename DPP::Params params{ q, k, v, kScale, vScale, o,
-                                       seqQ, seqK, scale, causal, epilogue };
-    const dim3 grid((seqQ + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, batchHeads, 1);
-    const dim3 block(DPP::THREADS, 1, 1);
-    launchFlashAttentionDPP_Kernel<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>
-        <<<grid, block, 0, stream.getCUDAStream()>>>(params);
-    gpuErrchk(cudaGetLastError());
+    const auto qIOp = makeAttentionRead(q, batchHeads, seqQ, HEAD_DIM);
+    if constexpr (KVL == KVLayout::INT8_PER_TOKEN) {
+        const auto kIOp = makeInt8KVRead(k, kScale, batchHeads, seqK, HEAD_DIM);
+        const auto vIOp = makeInt8KVRead(v, vScale, batchHeads, seqK, HEAD_DIM);
+        executeFlashAttention<HEAD_DIM, BLOCK_N, WARPS_PER_BLOCK>(
+            qIOp, kIOp, vIOp, o, batchHeads, seqQ, seqK, causal, stream,
+            scaleOverride, epilogue);
+    } else {
+        const auto kIOp = makeAttentionRead(k, batchHeads, seqK, HEAD_DIM);
+        const auto vIOp = makeAttentionRead(v, batchHeads, seqK, HEAD_DIM);
+        executeFlashAttention<HEAD_DIM, BLOCK_N, WARPS_PER_BLOCK>(
+            qIOp, kIOp, vIOp, o, batchHeads, seqQ, seqK, causal, stream,
+            scaleOverride, epilogue);
+    }
 }
 
 #endif // defined(__NVCC__) || CLANG_HOST_DEVICE

--- a/include/fused_kernel/algorithms/attention/flash_attention.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention.h
@@ -1,0 +1,259 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_ATTENTION_FLASH_ATTENTION_H
+#define FK_ATTENTION_FLASH_ATTENTION_H
+
+/* FlashAttentionDPP: FlashAttention-2 forward as ONE cooperative DPP
+ * (one kernel), with two FKL-only superpowers that handmade FA kernels
+ * (flash-attention repo and friends) cannot offer:
+ *
+ *  1. EPILOGUE FUSION: any FKL compute IOp chain (Mul, Add, Cast,
+ *     Saturate, ... composed with .then()) is applied IN-REGISTER to the
+ *     attention output before the single global write. out = (o/l) | chain.
+ *     With handmade kernels that is always a second kernel + a DRAM
+ *     round-trip; here it is zero extra cost and type-checked by FKL.
+ *
+ *  2. COMPRESSED KV CACHE (KVLayout::INT8_PER_TOKEN): K and V live in
+ *     global memory as int8 with one fp32 scale per token:
+ *       k_int8[t][d] = round(k[t][d]/kScale[t]), kScale[t] = max|k[t]|/127
+ *     -> 4x smaller cache vs fp32 (2x vs fp16) + 2 floats/token.
+ *     Dequantization is a fused prologue: it happens in-register inside
+ *     the q.k dot product and the p*v accumulation. The compressed cache
+ *     is NEVER inflated in global memory.
+ *
+ * Algorithm (Dao, FlashAttention-2): never materialize S = QK^T. Each
+ * query row keeps a running (m, l, o); every KV position updates them with
+ * the online-softmax rescaling trick. One pass over KV, O(seq) memory,
+ * exact (fp32 accumulation).
+ *
+ * Mapping (SM 12x friendly — no TMEM/tcgen05, per the fa-5090 analysis,
+ * correctness-first SIMT baseline before mma.sync tiling):
+ *   grid.y = batch*heads; grid.x = ceil(seq_q / WARPS_PER_BLOCK)
+ *   1 warp per query row; q and o live in registers spread across lanes
+ *   (HEAD_DIM/32 each); dot products warp-reduce via __shfl_xor_sync;
+ *   K/V tiles staged cooperatively in shared memory.
+ */
+
+#include <fused_kernel/algorithms/attention/softmax.h>
+
+namespace fk {
+
+enum class KVLayout { DENSE, INT8_PER_TOKEN };
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+
+// Identity epilogue: applied when no IOp chain is given.
+struct AttentionIdentityEpilogue {
+    FK_HOST_DEVICE_CNST friend float operator|(const float v,
+                                               const AttentionIdentityEpilogue&) {
+        return v;
+    }
+};
+
+template <typename T, int HEAD_DIM, KVLayout KVL = KVLayout::DENSE,
+          typename EpilogueIOp = AttentionIdentityEpilogue,
+          int BLOCK_N = (sizeof(T) == 2 ? 64 : 32), int WARPS_PER_BLOCK = 4>
+struct FlashAttentionDPP {
+private:
+    using SelfType = FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
+public:
+    FK_STATIC_STRUCT(FlashAttentionDPP, SelfType)
+
+    static_assert(HEAD_DIM % 32 == 0, "HEAD_DIM must be a multiple of 32");
+    static constexpr int ELEMS_PER_LANE = HEAD_DIM / 32;
+    static constexpr int THREADS = WARPS_PER_BLOCK * 32;
+    static constexpr bool QUANT = (KVL == KVLayout::INT8_PER_TOKEN);
+
+    // dense: KVT = T. int8: KVT = int8_t + per-token scales.
+    using KVT = std::conditional_t<QUANT, int8_t, T>;
+
+    struct Params {
+        const T* q;            // (batch*heads, seq_q, HEAD_DIM)
+        const KVT* k;          // (batch*heads, seq_k, HEAD_DIM) [int8 if QUANT]
+        const KVT* v;
+        const float* kScale;   // (batch*heads, seq_k) per-token scales (QUANT)
+        const float* vScale;
+        T* o;                  // (batch*heads, seq_q, HEAD_DIM)
+        int seq_q;
+        int seq_k;
+        float scale;           // logit scale, usually rsqrt(HEAD_DIM)
+        bool causal;
+        EpilogueIOp epilogue;  // fused FKL IOp chain applied before the write
+    };
+
+    FK_COOP_DEVICE_FUSE exec(const Params& p) {
+        __shared__ KVT kTile[BLOCK_N][HEAD_DIM];
+        __shared__ KVT vTile[BLOCK_N][HEAD_DIM];
+        __shared__ float kScaleTile[BLOCK_N];
+        __shared__ float vScaleTile[BLOCK_N];
+
+        const int lane = threadIdx.x & 31;
+        const int warp = threadIdx.x >> 5;
+        const int qIdx = blockIdx.x * WARPS_PER_BLOCK + warp;
+        const long bh = blockIdx.y;
+        const bool active = qIdx < p.seq_q;
+
+        const T* qBase = p.q + bh * (long)p.seq_q * HEAD_DIM;
+        const KVT* kBase = p.k + bh * (long)p.seq_k * HEAD_DIM;
+        const KVT* vBase = p.v + bh * (long)p.seq_k * HEAD_DIM;
+        T* oBase = p.o + bh * (long)p.seq_q * HEAD_DIM;
+        const float* kS = QUANT ? p.kScale + bh * (long)p.seq_k : nullptr;
+        const float* vS = QUANT ? p.vScale + bh * (long)p.seq_k : nullptr;
+
+        float qReg[ELEMS_PER_LANE];
+        float oAcc[ELEMS_PER_LANE];
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; ++e) {
+            qReg[e] = active ? attnToF32(qBase[(long)qIdx * HEAD_DIM + lane + 32 * e]) : 0.f;
+            oAcc[e] = 0.f;
+        }
+        float m = -FLT_MAX;
+        float l = 0.f;
+
+        const int blockMaxQ = blockIdx.x * WARPS_PER_BLOCK + WARPS_PER_BLOCK - 1;
+        const int kvEnd = p.causal ? ::min(p.seq_k, blockMaxQ + 1) : p.seq_k;
+
+        for (int tile = 0; tile < kvEnd; tile += BLOCK_N) {
+            const int tileLen = ::min(BLOCK_N, kvEnd - tile);
+
+            __syncthreads();
+            for (int idx = threadIdx.x; idx < tileLen * HEAD_DIM; idx += THREADS) {
+                const int r = idx / HEAD_DIM;
+                const int c = idx % HEAD_DIM;
+                kTile[r][c] = kBase[(long)(tile + r) * HEAD_DIM + c];
+                vTile[r][c] = vBase[(long)(tile + r) * HEAD_DIM + c];
+            }
+            if constexpr (QUANT) {
+                for (int r = threadIdx.x; r < tileLen; r += THREADS) {
+                    kScaleTile[r] = kS[tile + r];
+                    vScaleTile[r] = vS[tile + r];
+                }
+            }
+            __syncthreads();
+
+            if (!active) { continue; }
+
+            for (int j = 0; j < tileLen; ++j) {
+                const int kvIdx = tile + j;
+                if (p.causal && kvIdx > qIdx) { break; }
+
+                // s = q . k_j (dequantize in-register if compressed)
+                float partial = 0.f;
+                #pragma unroll
+                for (int e = 0; e < ELEMS_PER_LANE; ++e) {
+                    float kv;
+                    if constexpr (QUANT) {
+                        kv = static_cast<float>(kTile[j][lane + 32 * e]) * kScaleTile[j];
+                    } else {
+                        kv = attnToF32(kTile[j][lane + 32 * e]);
+                    }
+                    partial += qReg[e] * kv;
+                }
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1) {
+                    partial += __shfl_xor_sync(0xffffffffu, partial, offset);
+                }
+                const float s = partial * p.scale;
+
+                const float mNew = fmaxf(m, s);
+                const float corr = expf(m - mNew);
+                const float pj = expf(s - mNew);
+                l = l * corr + pj;
+                #pragma unroll
+                for (int e = 0; e < ELEMS_PER_LANE; ++e) {
+                    float vv;
+                    if constexpr (QUANT) {
+                        vv = static_cast<float>(vTile[j][lane + 32 * e]) * vScaleTile[j];
+                    } else {
+                        vv = attnToF32(vTile[j][lane + 32 * e]);
+                    }
+                    oAcc[e] = oAcc[e] * corr + pj * vv;
+                }
+                m = mNew;
+            }
+        }
+
+        if (active) {
+            const float invL = l > 0.f ? 1.f / l : 0.f;
+            #pragma unroll
+            for (int e = 0; e < ELEMS_PER_LANE; ++e) {
+                // EPILOGUE FUSION: the FKL IOp chain runs in-register on the
+                // normalized output, then ONE global write. This is the
+                // "fuse more than handmade FA" hook: any Mul/Add/Cast/
+                // Saturate/... composition rides inside the same kernel.
+                const float r = (oAcc[e] * invL) | p.epilogue;
+                oBase[(long)qIdx * HEAD_DIM + lane + 32 * e] = attnFromF32<T>(r);
+            }
+        }
+    }
+};
+
+template <typename T, int HEAD_DIM, KVLayout KVL, typename EpilogueIOp,
+          int BLOCK_N, int WARPS_PER_BLOCK>
+__global__ void launchFlashAttentionDPP_Kernel(
+        const __grid_constant__ typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::Params params) {
+    FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::exec(params);
+}
+
+template <typename T, int HEAD_DIM, KVLayout KVL = KVLayout::DENSE,
+          int BLOCK_N = (sizeof(T) == 2 ? 64 : 32), int WARPS_PER_BLOCK = 4,
+          typename EpilogueIOp = AttentionIdentityEpilogue>
+inline void executeFlashAttention(
+        const T* q,
+        const typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::KVT* k,
+        const typename FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>::KVT* v,
+        T* o, const int batchHeads, const int seqQ, const int seqK,
+        const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
+        const float* kScale = nullptr, const float* vScale = nullptr,
+        const float scaleOverride = -1.f,
+        const EpilogueIOp& epilogue = {}) {
+    using DPP = FlashAttentionDPP<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>;
+    const float scale = scaleOverride > 0.f ? scaleOverride
+                                            : rsqrtf(static_cast<float>(HEAD_DIM));
+    const typename DPP::Params params{ q, k, v, kScale, vScale, o,
+                                       seqQ, seqK, scale, causal, epilogue };
+    const dim3 grid((seqQ + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, batchHeads, 1);
+    const dim3 block(DPP::THREADS, 1, 1);
+    launchFlashAttentionDPP_Kernel<T, HEAD_DIM, KVL, EpilogueIOp, BLOCK_N, WARPS_PER_BLOCK>
+        <<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+#endif // defined(__NVCC__) || CLANG_HOST_DEVICE
+
+// ---- host-side KV cache compression helper (reference packing) -----------
+// Per-token symmetric int8: scale[t] = max|row|/127; q(x) = round(x/scale).
+// Usable from tests and from frameworks that own the cache; the kernel
+// dequantizes in-register (the cache is never inflated in global memory).
+template <typename T>
+inline void quantizeKVCacheHost(const T* dense, int8_t* q8, float* scales,
+                                const int tokens, const int headDim) {
+    for (int t = 0; t < tokens; ++t) {
+        float mx = 0.f;
+        for (int d = 0; d < headDim; ++d) {
+            mx = std::max(mx, std::abs(attnToF32(dense[(long)t * headDim + d])));
+        }
+        const float sc = mx > 0.f ? mx / 127.f : 1.f;
+        scales[t] = sc;
+        for (int d = 0; d < headDim; ++d) {
+            const float x = attnToF32(dense[(long)t * headDim + d]) / sc;
+            q8[(long)t * headDim + d] = static_cast<int8_t>(std::nearbyint(x));
+        }
+    }
+}
+
+} // namespace fk
+
+#endif // FK_ATTENTION_FLASH_ATTENTION_H

--- a/include/fused_kernel/algorithms/attention/flash_attention.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention.h
@@ -245,9 +245,9 @@ public:
                 }
                 const float s = partial * p.scale;
 
-                const float mNew = fmaxf(m, s);
-                const float corr = expf(m - mNew);
-                const float pj = expf(s - mNew);
+                const float mNew = attnMaxF(m, s);
+                const float corr = attnExpF(m - mNew);
+                const float pj = attnExpF(s - mNew);
                 l = l * corr + pj;
                 #pragma unroll
                 for (int e = 0; e < ELEMS_PER_LANE; ++e) {

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -110,6 +110,49 @@ constexpr bool isFp8KVRead = false;
 template <typename IOp>
 constexpr bool isInt8KVRead = std::is_same_v<typename IOp::Operation, Int8TokenDequantRead>;
 
+// ---- FLEX ATTENTION: score mods (FlexAttention-style score_mod) ------------
+// A score mod is a tiny device functor applied to each attention score
+// AFTER scaling and bounds/causal masking, BEFORE the online softmax:
+//     s' = mod(s, q_idx, kv_idx)
+// Return -FLT_MAX to mask a position (mask_mod semantics). Composable with
+// everything else (prologues, epilogues, compressed KV, block sparsity).
+struct NoScoreMod {
+    __device__ __forceinline__ float operator()(const float s, const int,
+                                                const int) const { return s; }
+};
+struct ALiBiScoreMod {              // s - slope * (q - k)
+    float slope;
+    __device__ __forceinline__ float operator()(const float s, const int q,
+                                                const int k) const {
+        return s - slope * static_cast<float>(q - k);
+    }
+};
+struct SoftCapScoreMod {            // Gemma-2 style logit soft capping
+    float cap;
+    __device__ __forceinline__ float operator()(const float s, const int,
+                                                const int) const {
+        return cap * tanhf(s / cap);
+    }
+};
+struct SlidingWindowMask {          // mask_mod: keep only last `window` keys
+    int window;
+    __device__ __forceinline__ float operator()(const float s, const int q,
+                                                const int k) const {
+        return (q - k) >= window ? -FLT_MAX : s;
+    }
+};
+
+/* BLOCK-SPARSE ATTENTION: a (bh, nQBlocks, nKVBlocks) uint8 mask at
+ * (maskBQ x maskBKV) granularity. Inactive KV tiles are SKIPPED ENTIRELY —
+ * no global reads, no mma, no softmax (both bandwidth and compute scale
+ * with the sparsity). nullptr = dense. Requirements (checked at launch):
+ * maskBQ % BLOCK_Q == 0 and maskBKV % BLOCK_KV == 0. */
+struct BlockSparsity {
+    const unsigned char* mask = nullptr;   // nullptr = dense
+    int nQBlocks = 0, nKVBlocks = 0;
+    int maskBQ = 128, maskBKV = 128;
+};
+
 namespace attention_mma_detail {
 
 __device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
@@ -171,11 +214,15 @@ template <typename OT, int HEAD_DIM,
           typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue,
           int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32,
-          int NUM_WARPS = 4>
+          int NUM_WARPS = 4, typename ScoreModOp = NoScoreMod>
 struct FlashAttentionMmaDPP {
 private:
     using SelfType = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
-                                          EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+                                          EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS,
+                                          ScoreModOp>;
+public:
+    static constexpr bool HAS_SCORE_MOD = !std::is_same_v<ScoreModOp, NoScoreMod>;
+private:
 public:
     FK_STATIC_STRUCT(FlashAttentionMmaDPP, SelfType)
 
@@ -223,6 +270,8 @@ public:
         float scale;
         bool causal;
         EpilogueIOp epilogue;
+        ScoreModOp scoreMod;     // flex-attention score_mod / mask_mod
+        BlockSparsity sparse;    // block-sparse tile skipping (nullptr = dense)
     };
 
     FK_DEVICE_FUSE uint32_t swz(const uint32_t byteOff) {
@@ -435,17 +484,24 @@ public:
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
                 float* r = sReg[mq][mkv];
-                if constexpr (NO_MASK) {
+                const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
+                if constexpr (NO_MASK && !HAS_SCORE_MOD) {
                     #pragma unroll
                     for (int e = 0; e < 4; ++e) r[e] *= p.scale;
                 } else {
-                    const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
                     #pragma unroll
                     for (int e = 0; e < 4; ++e) {
                         const int col = colBase + (e & 1);
                         const int row = (e < 2) ? rowA : rowB;
-                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
-                        r[e] = dead ? -FLT_MAX : r[e] * p.scale;
+                        bool dead;
+                        if constexpr (NO_MASK) { dead = false; }
+                        else { dead = (col >= p.seq_k) || (p.causal && col > row); }
+                        float s = r[e] * p.scale;
+                        if constexpr (HAS_SCORE_MOD) {
+                            // flex score_mod / mask_mod: AFTER scaling
+                            if (!dead) s = p.scoreMod(s, row, col);
+                        }
+                        r[e] = dead ? -FLT_MAX : s;
                     }
                 }
             }
@@ -481,7 +537,7 @@ public:
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
                 float* r = sReg[mq][mkv];
-                if constexpr (NO_MASK) {
+                if constexpr (NO_MASK && !HAS_SCORE_MOD) {
                     r[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
                     r[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
                     r[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);
@@ -637,6 +693,16 @@ public:
             if (p.causal && offKV + BLOCK_KV - 1 > firstRowOfBlock) return true;
             return false;
         };
+        // BLOCK SPARSITY: inactive KV tiles skip loads AND math entirely.
+        // commit/wait groups still run (possibly empty) to keep counting sane.
+        const auto tileActive = [&](const int offKV) -> bool {
+            if (offKV >= kvEnd) return false;
+            if (p.sparse.mask == nullptr) return true;
+            const int qb = qBlockBase / p.sparse.maskBQ;
+            const int kb = offKV / p.sparse.maskBKV;
+            return p.sparse.mask[((long)bh * p.sparse.nQBlocks + qb)
+                                 * p.sparse.nKVBlocks + kb] != 0;
+        };
 
         if constexpr (RAW_KV) {
             // ============= cp.async schedule (fa-5090 v5 staggering) =========
@@ -648,50 +714,60 @@ public:
             const uint32_t vBufOff = 2 * KV_BUF_B;  // single V buffer
 
             // prefetch K0
-            cpasyncTile<KV_GROUPS>(smemBase + kBuf(0), kPlane, 0, p.seq_k);
+            if (tileActive(0)) {
+                cpasyncTile<KV_GROUPS>(smemBase + kBuf(0), kPlane, 0, p.seq_k);
+            }
             cp_async_commit();
 
             for (int kv = 0; kv < numIter; ++kv) {
                 const int offKV = kv * BLOCK_KV;
+                const bool act = tileActive(offKV);
 
                 // V uses a single buffer: previous PV must be done.
                 __syncthreads();
-                cpasyncTile<KV_GROUPS>(smemBase + vBufOff, vPlane, offKV, p.seq_k);
+                if (act) {
+                    cpasyncTile<KV_GROUPS>(smemBase + vBufOff, vPlane, offKV, p.seq_k);
+                }
                 cp_async_commit();
 
                 // wait K[kv] (1 group outstanding: V[kv])
                 cp_async_wait<1>();
                 __syncthreads();
 
-                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-
                 float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
-                sMma(qReg, kReg, sReg);
+                if (act) {
+                    uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                    loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                    sMma(qReg, kReg, sReg);
+                }
 
-                // prefetch K[kv+1] (overlaps softmax + PV)
-                if (kv + 1 < numIter) {
+                // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
+                if (kv + 1 < numIter && tileActive(offKV + BLOCK_KV)) {
                     cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
                                            offKV + BLOCK_KV, p.seq_k);
                 }
                 cp_async_commit();
 
                 uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
-                if (tileNeedsMask(offKV)) {
-                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                       qBlockBase, warpId, laneId);
-                } else {
-                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                      qBlockBase, warpId, laneId);
+                if (act) {
+                    if (tileNeedsMask(offKV)) {
+                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                           qBlockBase, warpId, laneId);
+                    } else {
+                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                          qBlockBase, warpId, laneId);
+                    }
                 }
 
                 // wait V[kv] (1 group outstanding: K[kv+1])
                 cp_async_wait<1>();
                 __syncthreads();
 
-                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
-                loadVFrags(smemBase + vBufOff, vThread, vReg);
-                pvMma(pReg, vReg, oAcc);
+                if (act) {
+                    uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                    loadVFrags(smemBase + vBufOff, vThread, vReg);
+                    pvMma(pReg, vReg, oAcc);
+                }
             }
         } else if constexpr (QUANT_KV) {
             // ====== quantized cp.async schedule: stream RAW BYTES (2x less
@@ -715,52 +791,66 @@ public:
             const uint32_t vStage = stageBase + 2 * (KV_BUF_B / 2);
 
             // prefetch K0 bytes
-            cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(0), kPlane, 0, p.seq_k);
+            if (tileActive(0)) {
+                cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(0), kPlane, 0, p.seq_k);
+            }
             cp_async_commit();
 
             for (int kv = 0; kv < numIter; ++kv) {
                 const int offKV = kv * BLOCK_KV;
+                const bool act = tileActive(offKV);
 
                 __syncthreads();
-                cpasyncQuantTile<KV_GROUPS>(smemBase + vStage, vPlane, offKV, p.seq_k);
+                if (act) {
+                    cpasyncQuantTile<KV_GROUPS>(smemBase + vStage, vPlane, offKV, p.seq_k);
+                }
                 cp_async_commit();
 
                 cp_async_wait<1>();   // K bytes ready
                 __syncthreads();
-                dequantTile<KV_GROUPS, IS_FP8>(smemBytes, kStage(kv), kBuf(kv),
-                                               kScales, offKV, p.seq_k);
+                if (act) {
+                    dequantTile<KV_GROUPS, IS_FP8>(smemBytes, kStage(kv), kBuf(kv),
+                                                   kScales, offKV, p.seq_k);
+                }
                 __syncthreads();
 
-                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-
                 float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
-                sMma(qReg, kReg, sReg);
+                if (act) {
+                    uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                    loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                    sMma(qReg, kReg, sReg);
+                }
 
-                if (kv + 1 < numIter) {
+                if (kv + 1 < numIter && tileActive(offKV + BLOCK_KV)) {
                     cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(kv + 1), kPlane,
                                                 offKV + BLOCK_KV, p.seq_k);
                 }
                 cp_async_commit();
 
                 uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
-                if (tileNeedsMask(offKV)) {
-                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                       qBlockBase, warpId, laneId);
-                } else {
-                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                      qBlockBase, warpId, laneId);
+                if (act) {
+                    if (tileNeedsMask(offKV)) {
+                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                           qBlockBase, warpId, laneId);
+                    } else {
+                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                          qBlockBase, warpId, laneId);
+                    }
                 }
 
                 cp_async_wait<1>();   // V bytes ready
                 __syncthreads();
-                dequantTile<KV_GROUPS, IS_FP8>(smemBytes, vStage, vBufOff,
-                                               vScales, offKV, p.seq_k);
+                if (act) {
+                    dequantTile<KV_GROUPS, IS_FP8>(smemBytes, vStage, vBufOff,
+                                                   vScales, offKV, p.seq_k);
+                }
                 __syncthreads();
 
-                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
-                loadVFrags(smemBase + vBufOff, vThread, vReg);
-                pvMma(pReg, vReg, oAcc);
+                if (act) {
+                    uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                    loadVFrags(smemBase + vBufOff, vThread, vReg);
+                    pvMma(pReg, vReg, oAcc);
+                }
             }
         } else {
             // ============== register-prefetch schedule (fused prologues) =====
@@ -776,32 +866,35 @@ public:
 
             for (int kv = 0; kv < numIter; ++kv) {
                 const int offKV = kv * BLOCK_KV;
-                const bool havePrefetch = (kv + 1) < numIter;
-                if (havePrefetch) {
+                const bool act = tileActive(offKV);
+                const bool nextAct = (kv + 1) < numIter && tileActive(offKV + BLOCK_KV);
+                if (nextAct) {
                     prefetchTile<KV_GROUPS>(p.k, offKV + BLOCK_KV, p.seq_k, bh, kPre);
                     prefetchTile<KV_GROUPS>(p.v, offKV + BLOCK_KV, p.seq_k, bh, vPre);
                 }
 
-                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                if (act) {
+                    uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                    loadKFrags(smemBase + kBuf(kv), kThread, kReg);
 
-                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
-                sMma(qReg, kReg, sReg);
+                    float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                    sMma(qReg, kReg, sReg);
 
-                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
-                if (tileNeedsMask(offKV)) {
-                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                       qBlockBase, warpId, laneId);
-                } else {
-                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
-                                      qBlockBase, warpId, laneId);
+                    uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+                    if (tileNeedsMask(offKV)) {
+                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                           qBlockBase, warpId, laneId);
+                    } else {
+                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                          qBlockBase, warpId, laneId);
+                    }
+
+                    uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                    loadVFrags(smemBase + vBuf(kv), vThread, vReg);
+                    pvMma(pReg, vReg, oAcc);
                 }
 
-                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
-                loadVFrags(smemBase + vBuf(kv), vThread, vReg);
-                pvMma(pReg, vReg, oAcc);
-
-                if (havePrefetch) {
+                if (nextAct) {
                     storeTile<KV_GROUPS>(smemBytes, kBuf(kv + 1), kPre);
                     storeTile<KV_GROUPS>(smemBytes, vBuf(kv + 1), vPre);
                 }
@@ -814,13 +907,14 @@ public:
 };
 
 template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
-          typename EpilogueIOp, int BLOCK_Q, int BLOCK_KV, int NUM_WARPS>
+          typename EpilogueIOp, int BLOCK_Q, int BLOCK_KV, int NUM_WARPS,
+          typename ScoreModOp>
 __global__ void launchFlashAttentionMmaDPP_Kernel(
         const __grid_constant__ typename FlashAttentionMmaDPP<
             OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
-            BLOCK_Q, BLOCK_KV, NUM_WARPS>::Params params) {
+            BLOCK_Q, BLOCK_KV, NUM_WARPS, ScoreModOp>::Params params) {
     FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
-                         BLOCK_Q, BLOCK_KV, NUM_WARPS>::exec(params);
+                         BLOCK_Q, BLOCK_KV, NUM_WARPS, ScoreModOp>::exec(params);
 }
 
 /* IOp-first API. The DPP auto-selects cp.async streaming (raw bf16
@@ -830,27 +924,39 @@ __global__ void launchFlashAttentionMmaDPP_Kernel(
  * fused-prologue path prefers BQ128/BKV32 (register headroom). */
 template <int HEAD_DIM, int BLOCK_Q = 0, int BLOCK_KV = 0, int NUM_WARPS = 4,
           typename OT = float, typename QIOp, typename KIOp, typename VIOp,
-          typename EpilogueIOp = AttentionIdentityEpilogue>
+          typename EpilogueIOp = AttentionIdentityEpilogue,
+          typename ScoreModOp = NoScoreMod>
 inline void executeFlashAttentionMma(
         const QIOp& q, const KIOp& k, const VIOp& v, OT* o,
         const int batchHeads, const int seqQ, const int seqK,
         const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
-        const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {}) {
+        const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {},
+        const ScoreModOp& scoreMod = {}, const BlockSparsity& sparse = {}) {
     constexpr bool RAW = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
     constexpr int BQ = BLOCK_Q > 0 ? BLOCK_Q
                                    : (RAW ? 64 : (HEAD_DIM <= 64 ? 128 : 64));
     constexpr int BKV = BLOCK_KV > 0 ? BLOCK_KV
                                      : (RAW ? (HEAD_DIM <= 64 ? 64 : 32) : 32);
     using DPP = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
-                                     EpilogueIOp, BQ, BKV, NUM_WARPS>;
+                                     EpilogueIOp, BQ, BKV, NUM_WARPS, ScoreModOp>;
     const float scale = scaleOverride > 0.f ? scaleOverride
                                             : rsqrtf(static_cast<float>(HEAD_DIM));
-    const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal, epilogue };
+    if (sparse.mask != nullptr) {
+        // block-sparse mask granularity must contain whole kernel tiles
+        if (sparse.maskBQ % BQ != 0 || sparse.maskBKV % BKV != 0) {
+            throw std::invalid_argument(
+                "BlockSparsity: maskBQ/maskBKV must be multiples of the kernel "
+                "tiles (BQ=" + std::to_string(BQ) + ", BKV=" + std::to_string(BKV) + ")");
+        }
+    }
+    const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal,
+                                       epilogue, scoreMod, sparse };
     const dim3 grid((seqQ + BQ - 1) / BQ, batchHeads, 1);
     const dim3 block(DPP::THREADS, 1, 1);
     const int smemBytes = DPP::SMEM_BYTES;
     auto* kernel = launchFlashAttentionMmaDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp,
-                                                     EpilogueIOp, BQ, BKV, NUM_WARPS>;
+                                                     EpilogueIOp, BQ, BKV, NUM_WARPS,
+                                                     ScoreModOp>;
     if (smemBytes > 48000) {
         gpuErrchk(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
                                        smemBytes));

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -237,6 +237,15 @@ __device__ __forceinline__ float fastExp(const float x) {
 #endif
 }
 
+// pack two fp32 into one bf16x2 register (uint32_t) — used by the in-place
+// S/P union pack in softmaxTile.
+__device__ __forceinline__ uint32_t packBf162(const float lo, const float hi) {
+    const __nv_bfloat162 h = __float22bfloat162_rn({ lo, hi });
+    uint32_t r;
+    memcpy(&r, &h, sizeof(r));
+    return r;
+}
+
 } // namespace attention_mma_detail
 
 template <typename OT, int HEAD_DIM,
@@ -494,12 +503,25 @@ public:
         }
     }
 
+    /* Fused S/P register tile. The fp32 scores (s) and the packed bf16x2
+     * probabilities (p) used to live in SEPARATE arrays (32 + 16 regs at
+     * BKV=64), but their live ranges only overlap inside softmaxTile, and
+     * the pack is strictly in-place-safe: iteration mkv writes p bytes
+     * [8*mkv, 8*mkv+8) while s reads touch [16*mkv, 16*mkv+16) — the write
+     * head never catches the read head (only mkv==0 overlaps, and there the
+     * statement order consumes s[0..1] before overwriting them). Overlaying
+     * p on the first half of s saves BLOCK_KV/4 regs/thread (16 at BKV=64):
+     * 138 -> target ~122. */
+    union SPTile {
+        float    s[BLOCK_KV / MMA_N][4];   // QK^T scores / exp(s - m), fp32
+        uint32_t p[BLOCK_KV / MMA_K][4];   // packed bf16x2 P (first half of s)
+    };
+
     /* mask + online softmax + P pack for one KV tile (shared by both
        schedules). noMask: compile-out the bounds/causal branch for interior
        tiles (the common case at long seq). */
     template <bool NO_MASK>
-    FK_DEVICE_FUSE void softmaxTile(float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4],
-                                    uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+    FK_DEVICE_FUSE void softmaxTile(SPTile (&sp)[WARP_Q / MMA_M],
                                     float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
                                     float (&rowMax)[WARP_Q / MMA_M][2],
                                     float (&rowSum)[WARP_Q / MMA_M][2],
@@ -513,7 +535,7 @@ public:
 
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                float* r = sReg[mq][mkv];
+                float* r = sp[mq].s[mkv];
                 const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
                 if constexpr (NO_MASK && !HAS_SCORE_MOD) {
                     #pragma unroll
@@ -539,7 +561,7 @@ public:
             float mNew[2] = { -FLT_MAX, -FLT_MAX };
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                const float* r = sReg[mq][mkv];
+                const float* r = sp[mq].s[mkv];
                 mNew[0] = fmaxf(mNew[0], fmaxf(r[0], r[1]));
                 mNew[1] = fmaxf(mNew[1], fmaxf(r[2], r[3]));
             }
@@ -566,24 +588,34 @@ public:
             float lNew[2] = {};
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                float* r = sReg[mq][mkv];
+                // Read scores BEFORE packing: iteration mkv packs into union
+                // bytes [8*mkv, 8*mkv+8) while reading s bytes
+                // [16*mkv, 16*mkv+16) — the pack write head never reaches
+                // unread scores (s[mkv'] for mkv' > mkv starts at byte
+                // 16*mkv+16 > 8*mkv+8). exp values live only in `e` locals;
+                // s is dead after this loop, so nothing is written back.
+                const float* r = sp[mq].s[mkv];
+                float e[4];
                 if constexpr (NO_MASK && !HAS_SCORE_MOD) {
-                    r[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
-                    r[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
-                    r[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);
-                    r[3] = attention_mma_detail::fastExp(r[3] - mNew[1]);
+                    e[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
+                    e[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
+                    e[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);
+                    e[3] = attention_mma_detail::fastExp(r[3] - mNew[1]);
                 } else {
-                    r[0] = (r[0] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[0] - mNew[0]);
-                    r[1] = (r[1] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[1] - mNew[0]);
-                    r[2] = (r[2] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[2] - mNew[1]);
-                    r[3] = (r[3] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[3] - mNew[1]);
+                    e[0] = (r[0] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[0] - mNew[0]);
+                    e[1] = (r[1] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[1] - mNew[0]);
+                    e[2] = (r[2] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[2] - mNew[1]);
+                    e[3] = (r[3] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[3] - mNew[1]);
                 }
-                lNew[0] += r[0] + r[1];
-                lNew[1] += r[2] + r[3];
+                lNew[0] += e[0] + e[1];
+                lNew[1] += e[2] + e[3];
 
-                __nv_bfloat162* pp = reinterpret_cast<__nv_bfloat162*>(pReg[mq][mkv / 2]);
-                pp[(mkv % 2) * 2]     = __float22bfloat162_rn({ r[0], r[1] });
-                pp[(mkv % 2) * 2 + 1] = __float22bfloat162_rn({ r[2], r[3] });
+                // Store through the union member (NOT a reinterpret_cast'ed
+                // pointer): reads (.s) and writes (.p) share the same union
+                // lvalue base, so the compiler cannot reorder the pack store
+                // ahead of the score loads via type-based alias analysis.
+                sp[mq].p[mkv / 2][(mkv % 2) * 2]     = attention_mma_detail::packBf162(e[0], e[1]);
+                sp[mq].p[mkv / 2][(mkv % 2) * 2 + 1] = attention_mma_detail::packBf162(e[2], e[3]);
             }
             #pragma unroll
             for (int half = 0; half < 2; ++half) {
@@ -596,7 +628,7 @@ public:
 
     FK_DEVICE_FUSE void sMma(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
                              const uint32_t (&kReg)[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2],
-                             float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4]) {
+                             SPTile (&sp)[WARP_Q / MMA_M]) {
         using namespace attention_mma_detail;
         #pragma unroll
         for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
@@ -604,7 +636,7 @@ public:
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv)
                 #pragma unroll
                 for (int md = 0; md < HEAD_DIM / MMA_K; ++md)
-                    mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sReg[mq][mkv]);
+                    mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sp[mq].s[mkv]);
     }
 
     /* REGISTER-PRESSURE-FUSED QK^T: stream K fragments from smem with
@@ -614,7 +646,7 @@ public:
      * (+V below, +3 smem bufs) unlocks the 4th block. */
     FK_DEVICE_FUSE void sMmaStream(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
                                    const uint32_t base, const uint32_t kThread,
-                                   float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4]) {
+                                   SPTile (&sp)[WARP_Q / MMA_M]) {
         using namespace attention_mma_detail;
         #pragma unroll
         for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
@@ -629,14 +661,14 @@ public:
                 ldmatrix_x4(frag, addr);
                 #pragma unroll
                 for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
-                    mma_m16n8k16(qReg[mq][md],     frag + 0, sReg[mq][mkv]);
-                    mma_m16n8k16(qReg[mq][md + 1], frag + 2, sReg[mq][mkv]);
+                    mma_m16n8k16(qReg[mq][md],     frag + 0, sp[mq].s[mkv]);
+                    mma_m16n8k16(qReg[mq][md + 1], frag + 2, sp[mq].s[mkv]);
                 }
             }
         }
     }
 
-    FK_DEVICE_FUSE void pvMma(const uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+    FK_DEVICE_FUSE void pvMma(const SPTile (&sp)[WARP_Q / MMA_M],
                               const uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2],
                               float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
         using namespace attention_mma_detail;
@@ -646,12 +678,12 @@ public:
             for (int md = 0; md < HEAD_DIM / MMA_N; ++md)
                 #pragma unroll
                 for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
-                    mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
+                    mma_m16n8k16(sp[mq].p[mkv], vReg[mkv][md], oAcc[mq][md]);
     }
 
     /* Same fusion for P·V: stream V fragments (trans ldmatrix.x4) right
      * before use. vReg was another 32-64 live regs. */
-    FK_DEVICE_FUSE void pvMmaStream(const uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+    FK_DEVICE_FUSE void pvMmaStream(const SPTile (&sp)[WARP_Q / MMA_M],
                                     const uint32_t base, const uint32_t vThread,
                                     float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
         using namespace attention_mma_detail;
@@ -666,8 +698,8 @@ public:
                 ldmatrix_x4_trans(frag, addr);
                 #pragma unroll
                 for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
-                    mma_m16n8k16(pReg[mq][mkv], frag + 0, oAcc[mq][md]);
-                    mma_m16n8k16(pReg[mq][mkv], frag + 2, oAcc[mq][md + 1]);
+                    mma_m16n8k16(sp[mq].p[mkv], frag + 0, oAcc[mq][md]);
+                    mma_m16n8k16(sp[mq].p[mkv], frag + 2, oAcc[mq][md + 1]);
                 }
             }
         }
@@ -839,11 +871,11 @@ public:
                 cp_async_wait<1>();
                 __syncthreads();
 
-                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                SPTile sp[WARP_Q / MMA_M] = {};
                 if (act) {
                     uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
                     loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-                    sMma(qReg, kReg, sReg);
+                    sMma(qReg, kReg, sp);
                 }
 
                 // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
@@ -853,13 +885,12 @@ public:
                 }
                 cp_async_commit();
 
-                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
                 if (act) {
                     if (tileNeedsMask(offKV)) {
-                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<false>(sp, oAcc, rowMax, rowSum, p, offKV,
                                            qBlockBase, warpId, laneId);
                     } else {
-                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<true>(sp, oAcc, rowMax, rowSum, p, offKV,
                                           qBlockBase, warpId, laneId);
                     }
                 }
@@ -870,7 +901,7 @@ public:
 
                 if (act) {
                     // stream V frags ldmatrix->mma (no vReg staging)
-                    pvMmaStream(pReg, smemBase + vBufOff, vThread, oAcc);
+                    pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
                 }
             }
         } else if constexpr (QUANT_KV) {
@@ -919,11 +950,11 @@ public:
                 }
                 __syncthreads();
 
-                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                SPTile sp[WARP_Q / MMA_M] = {};
                 if (act) {
                     uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
                     loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-                    sMma(qReg, kReg, sReg);
+                    sMma(qReg, kReg, sp);
                 }
 
                 if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
@@ -932,13 +963,12 @@ public:
                 }
                 cp_async_commit();
 
-                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
                 if (act) {
                     if (tileNeedsMask(offKV)) {
-                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<false>(sp, oAcc, rowMax, rowSum, p, offKV,
                                            qBlockBase, warpId, laneId);
                     } else {
-                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<true>(sp, oAcc, rowMax, rowSum, p, offKV,
                                           qBlockBase, warpId, laneId);
                     }
                 }
@@ -954,7 +984,7 @@ public:
                 if (act) {
                     uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
                     loadVFrags(smemBase + vBufOff, vThread, vReg);
-                    pvMma(pReg, vReg, oAcc);
+                    pvMma(sp, vReg, oAcc);
                 }
             }
         } else {
@@ -984,21 +1014,20 @@ public:
                     uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
                     loadKFrags(smemBase + kBuf(kv), kThread, kReg);
 
-                    float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
-                    sMma(qReg, kReg, sReg);
+                    SPTile sp[WARP_Q / MMA_M] = {};
+                    sMma(qReg, kReg, sp);
 
-                    uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
                     if (tileNeedsMask(offKV)) {
-                        softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<false>(sp, oAcc, rowMax, rowSum, p, offKV,
                                            qBlockBase, warpId, laneId);
                     } else {
-                        softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                        softmaxTile<true>(sp, oAcc, rowMax, rowSum, p, offKV,
                                           qBlockBase, warpId, laneId);
                     }
 
                     uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
                     loadVFrags(smemBase + vBuf(kv), vThread, vReg);
-                    pvMma(pReg, vReg, oAcc);
+                    pvMma(sp, vReg, oAcc);
                 }
 
                 if (nextAct) {
@@ -1027,7 +1056,8 @@ __global__ void launchFlashAttentionMmaDPP_Kernel(
 /* IOp-first API. The DPP auto-selects cp.async streaming (raw bf16
  * prologues) or register prefetch (fused prologues) at compile time, and
  * auto-tunes tile sizes per schedule (pass BLOCK_Q/BLOCK_KV > 0 to
- * override): raw path prefers BQ64/BKV64 (deep cp.async overlap),
+ * override): raw path prefers BQ64/BKV64 (deep cp.async overlap; with the
+ * S/P union d128 fits at 174 regs and BKV64 beats BKV32 by ~13%),
  * fused-prologue path prefers BQ128/BKV32 (register headroom). */
 template <int HEAD_DIM, int BLOCK_Q = 0, int BLOCK_KV = 0, int NUM_WARPS = 4,
           typename OT = float, typename QIOp, typename KIOp, typename VIOp,
@@ -1042,8 +1072,7 @@ inline void executeFlashAttentionMma(
     constexpr bool RAW = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
     constexpr int BQ = BLOCK_Q > 0 ? BLOCK_Q
                                    : (RAW ? 64 : (HEAD_DIM <= 64 ? 128 : 64));
-    constexpr int BKV = BLOCK_KV > 0 ? BLOCK_KV
-                                     : (RAW ? (HEAD_DIM <= 64 ? 64 : 32) : 32);
+    constexpr int BKV = BLOCK_KV > 0 ? BLOCK_KV : (RAW ? 64 : 32);
     using DPP = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
                                      EpilogueIOp, BQ, BKV, NUM_WARPS, ScoreModOp>;
     const float scale = scaleOverride > 0.f ? scaleOverride

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -16,38 +16,31 @@
 #define FK_ATTENTION_FLASH_ATTENTION_MMA_H
 
 /* FlashAttentionMmaDPP: FA-2 forward on mma.sync.m16n8k16 tensor cores
- * (sm_80+; tuned on sm_120 per gau-nernst's fa-5090 ladder: on consumer
- * Blackwell there is no TMEM/tcgen05 — see also Dao-AILab/flash-attention
- * PR #2634 bringing FA to sm12x the same way).
+ * for consumer Blackwell (sm_120: no WGMMA/tcgen05/TMEM — same constraint
+ * set as Dao-AILab/flash-attention PR #2634 and CUTLASS PR #3030).
  *
- * Optimization ladder applied (fa-5090 v1 -> v4, adapted to FKL):
- *   v1  mma.sync m16n8k16 bf16->fp32, FA-2 warp split, online softmax
- *       on fp32 S registers with butterfly reductions.
- *   v2  XOR-swizzled smem so ldmatrix and the 16-byte staging stores are
- *       bank-conflict free.
- *   v3  software pipelining: K/V double-buffered in smem; the NEXT tile's
- *       global reads are issued (through the prologue IOps, into
- *       registers) BEFORE the current tile's math, so load latency
- *       overlaps the mma work. This is the FKL-compatible counterpart of
- *       cp.async 2-stage pipelining: cp.async copies raw bytes and cannot
- *       run an IOp chain per element; prefetch-to-register can.
- *   v4  ldmatrix.x4 for K and V fragment loads.
+ * AUTOMATIC SCHEDULE SELECTION (the FKL "smart fusion" play):
+ * the kernel inspects the prologue IOp types AT COMPILE TIME:
  *
- * THE FKL DIFFERENCE vs handmade FA kernels: Q, K and V remain
- * Read/ReadBack IOps. Staging reads every element THROUGH the prologue
- * (int8 dequant, scaling, casts, any .then chain fuse in-register at load
- * time), and the epilogue IOp chain runs on the output registers before
- * the single global write. The compressed int8 KV cache or any
- * preprocessing rides the SAME kernel — flash-attention cannot do that.
+ *  - RAW prologue (identity read of bf16, from makeAttentionRead on a
+ *    __nv_bfloat16 pointer): K/V tiles stream with REAL cp.async
+ *    (16B cg copies, commit/wait groups, K double-buffered + V
+ *    single-buffered — the fa-5090 v5 schedule). Loads are truly
+ *    asynchronous: bytes fly while tensor cores work.
  *
- * Layout: (batch*heads, seq, head_dim); HEAD_DIM % 32 == 0; causal,
- * ragged and cross seq lens handled with guards (staging pads with
- * zeros; dead S positions get -inf before the rowmax).
+ *  - FUSED prologue (dequant int8, Mul/Add chains, any .then):
+ *    cp.async copies raw bytes and cannot run an IOp chain per element,
+ *    so tiles are prefetched THROUGH the IOp into registers one
+ *    iteration ahead (2-stage), then packed to swizzled smem.
  *
- * Accuracy: bf16 inputs to the dot products (like every tensor-core FA);
- * ~1e-2 abs error on unit-range inputs vs an fp64 oracle — same class as
- * flash-attention's own bf16 path. The SIMT DPP remains the fp32-exact
- * option. */
+ * Either way the user writes the same compose-style code; FKL picks the
+ * fastest legal schedule. Epilogue IOps always run in-register on the
+ * output before the single global write.
+ *
+ * Ladder: v1 mma.sync + FA-2 warp split + online softmax on fp32 regs;
+ * v2 XOR-swizzled smem (bank-conflict-free stores + ldmatrix);
+ * v3/v5 pipelining (cp.async groups or register prefetch);
+ * v4 ldmatrix.x4 for K and V. */
 
 #include <fused_kernel/algorithms/attention/flash_attention.h>
 
@@ -56,6 +49,56 @@
 #include <cuda_bf16.h>
 
 namespace fk {
+
+// ---- bf16 identity Read IOp (the "raw" prologue) ---------------------------
+struct Bf16AttentionRead {
+private:
+    using Parent = ReadOperation<__nv_bfloat16, RawPtr<ND::_3D, __nv_bfloat16>,
+                                 float, TF::DISABLED, Bf16AttentionRead>;
+    using SelfType = Bf16AttentionRead;
+public:
+    FK_STATIC_STRUCT(Bf16AttentionRead, SelfType)
+    DECLARE_READ_PARENT
+
+    FK_HOST_DEVICE_FUSE float exec(const Point thread, const ParamsType& params) {
+#if defined(__CUDA_ARCH__)
+        return __bfloat162float(*PtrAccessor<ND::_3D>::cr_point(thread, params));
+#else
+        return 0.f;  // host never executes this
+#endif
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
+        return opData.params.dims.width;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
+        return opData.params.dims.height;
+    }
+    FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
+        return opData.params.dims.planes;
+    }
+    FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
+        return opData.params.dims.pitch;
+    }
+    FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
+        return { num_elems_x(Point{0,0,0}, opData),
+                 num_elems_y(Point{0,0,0}, opData),
+                 num_elems_z(Point{0,0,0}, opData) };
+    }
+};
+
+// bf16 overload of the canonical prologue builder.
+inline auto makeAttentionRead(const __nv_bfloat16* data, const int batchHeads,
+                              const int seq, const int headDim) {
+    const RawPtr<ND::_3D, __nv_bfloat16> ptr{
+        const_cast<__nv_bfloat16*>(data),
+        PtrDims<ND::_3D>(static_cast<uint>(headDim), static_cast<uint>(seq),
+                         static_cast<uint>(batchHeads), 1,
+                         static_cast<uint>(headDim * sizeof(__nv_bfloat16))) };
+    return Bf16AttentionRead::build(ptr);
+}
+
+template <typename IOp>
+constexpr bool isRawBf16Read = std::is_same_v<typename IOp::Operation, Bf16AttentionRead>;
 
 namespace attention_mma_detail {
 
@@ -81,15 +124,38 @@ __device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t
                    "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
 }
 
-// 8 bf16 packed for one 16-byte swizzled smem store.
+// 16-byte async copy; srcSize=0 zero-fills (tail/ragged guard).
+__device__ __forceinline__ void cp_async_16(uint32_t dst, const void* src,
+                                            const int srcSize) {
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;"
+                 :: "r"(dst), "l"(src), "r"(srcSize));
+}
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;");
+}
+template <int N>
+__device__ __forceinline__ void cp_async_wait() {
+    asm volatile("cp.async.wait_group %0;" :: "n"(N));
+}
+
 struct alignas(16) Bf16x8 { __nv_bfloat162 h[4]; };
+
+// two-phase-lookup-safe fast exp (visible at template definition time).
+__device__ __forceinline__ float fastExp(const float x) {
+#if defined(__CUDA_ARCH__)
+    return __expf(x);
+#else
+    return 0.f;
+#endif
+}
 
 } // namespace attention_mma_detail
 
 template <typename OT, int HEAD_DIM,
           typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue,
-          int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32, int NUM_WARPS = 4>
+          int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32,
+          int NUM_WARPS = 4>
 struct FlashAttentionMmaDPP {
 private:
     using SelfType = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
@@ -103,9 +169,13 @@ public:
     static_assert(isAnyReadType<VIOp>, "V prologue must be a Read or ReadBack IOp");
 
     static constexpr int THREADS = NUM_WARPS * 32;
-    static constexpr int WARP_Q = BLOCK_Q / NUM_WARPS;        // rows per warp
+    static constexpr int WARP_Q = BLOCK_Q / NUM_WARPS;
     static_assert(WARP_Q % 16 == 0, "BLOCK_Q/NUM_WARPS must be a multiple of 16");
     static constexpr int MMA_M = 16, MMA_N = 8, MMA_K = 16;
+
+    // RAW = identity bf16 reads -> real cp.async streaming (fa-5090 v5).
+    static constexpr bool RAW_KV = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
+    static constexpr bool RAW_Q = isRawBf16Read<QIOp>;
 
     static constexpr int STRIDE_B = HEAD_DIM * (int)sizeof(__nv_bfloat16);
     static constexpr int Q_GROUPS = BLOCK_Q * HEAD_DIM / (THREADS * 8);
@@ -115,11 +185,12 @@ public:
     static_assert(KV_GROUPS >= 1 && BLOCK_KV * HEAD_DIM % (THREADS * 8) == 0,
                   "BLOCK_KV*HEAD_DIM must be a multiple of THREADS*8");
 
-    // Q buffer overlaps the K/V double buffers (Q is consumed into
-    // registers before the first K/V tile is staged).
-    static constexpr int KV_BUF_B = BLOCK_KV * STRIDE_B;       // one buffer, bytes
+    static constexpr int KV_BUF_B = BLOCK_KV * STRIDE_B;
+    // both schedules: K double + V double (4 buffers).
+    static constexpr int KV_BUFS = 4;
     static constexpr int SMEM_BYTES =
-        (BLOCK_Q * STRIDE_B > 4 * KV_BUF_B ? BLOCK_Q * STRIDE_B : 4 * KV_BUF_B);
+        (BLOCK_Q * STRIDE_B > KV_BUFS * KV_BUF_B ? BLOCK_Q * STRIDE_B
+                                                 : KV_BUFS * KV_BUF_B);
 
     struct Params {
         QIOp q; KIOp k; VIOp v;
@@ -130,10 +201,6 @@ public:
         EpilogueIOp epilogue;
     };
 
-    /* XOR swizzle on a byte offset relative to a tile buffer (buffers are
-       KV_BUF_B-aligned, i.e. multiples of 8*STRIDE_B). Same scheme as
-       fa-5090 / CUTLASS: kills bank conflicts for both the 16B staging
-       stores and the ldmatrix loads. */
     FK_DEVICE_FUSE uint32_t swz(const uint32_t byteOff) {
         const uint32_t row = (byteOff / STRIDE_B) % 8;
         constexpr uint32_t div = (64 / STRIDE_B > 1 ? 64 / STRIDE_B : 1);
@@ -142,14 +209,10 @@ public:
 
     template <typename IOp>
     FK_DEVICE_FUSE float readElem(const IOp& iop, const int x, const int y, const int z) {
-        // single entry point for ALL data: the prologue IOp's exec.
         return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
     }
 
-    /* v3 pipelining, FKL style: issue the global reads for a tile through
-       the prologue IOp into registers. Called BEFORE the current tile's
-       math so the loads overlap the mma work (the data is only consumed
-       by storeTile afterwards). */
+    // ---- generic staging (prologue runs per element, packs 16B stores) -----
     template <int GROUPS, typename IOp>
     FK_DEVICE_FUSE void prefetchTile(const IOp& iop, const int rowBase,
                                      const int seqLen, const int bh,
@@ -171,7 +234,6 @@ public:
         }
     }
 
-    // fp32 regs -> bf16x8 -> ONE 16-byte store per group, swizzled.
     template <int GROUPS>
     FK_DEVICE_FUSE void storeTile(char* smemBytes, const uint32_t bufOff,
                                   const float (&regs)[GROUPS][8]) {
@@ -189,6 +251,212 @@ public:
         }
     }
 
+    // ---- raw staging: real cp.async, zero-fill on ragged tails -------------
+    template <int GROUPS>
+    FK_DEVICE_FUSE void cpasyncTile(const uint32_t dstBase /* smem addr + buf */,
+                                    const __nv_bfloat16* srcPlane, const int rowBase,
+                                    const int seqLen) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int g = 0; g < GROUPS; ++g) {
+            const int idx = (g * THREADS + (int)threadIdx.x) * 8;
+            const int r = idx / HEAD_DIM;
+            const int c = idx % HEAD_DIM;
+            const int row = rowBase + r;
+            const bool ok = row < seqLen;
+            const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
+            cp_async_16(dstBase + swz(idx * (uint32_t)sizeof(__nv_bfloat16)),
+                        srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 16 : 0);
+        }
+    }
+
+    // ---- shared fragment loaders / mma helpers ------------------------------
+    FK_DEVICE_FUSE void loadKFrags(const uint32_t base, const uint32_t kThread,
+                                   uint32_t (&kReg)[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+                uint32_t addr = base + kThread;
+                addr += mkv * MMA_N * STRIDE_B;
+                addr ^= md * MMA_K * sizeof(__nv_bfloat16);
+                ldmatrix_x4(&kReg[mkv][md][0], addr);
+            }
+        }
+    }
+
+    FK_DEVICE_FUSE void loadVFrags(const uint32_t base, const uint32_t vThread,
+                                   uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
+                uint32_t addr = base + vThread;
+                addr += mkv * MMA_K * STRIDE_B;
+                addr ^= md * MMA_N * sizeof(__nv_bfloat16);
+                ldmatrix_x4_trans(&vReg[mkv][md][0], addr);
+            }
+        }
+    }
+
+    /* mask + online softmax + P pack for one KV tile (shared by both
+       schedules). noMask: compile-out the bounds/causal branch for interior
+       tiles (the common case at long seq). */
+    template <bool NO_MASK>
+    FK_DEVICE_FUSE void softmaxTile(float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4],
+                                    uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+                                    float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                    float (&rowMax)[WARP_Q / MMA_M][2],
+                                    float (&rowSum)[WARP_Q / MMA_M][2],
+                                    const Params& p, const int offKV,
+                                    const int qBlockBase, const int warpId,
+                                    const int laneId) {
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
+            const int rowB = rowA + 8;
+
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                float* r = sReg[mq][mkv];
+                if constexpr (NO_MASK) {
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) r[e] *= p.scale;
+                } else {
+                    const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int col = colBase + (e & 1);
+                        const int row = (e < 2) ? rowA : rowB;
+                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
+                        r[e] = dead ? -FLT_MAX : r[e] * p.scale;
+                    }
+                }
+            }
+
+            float mNew[2] = { -FLT_MAX, -FLT_MAX };
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                const float* r = sReg[mq][mkv];
+                mNew[0] = fmaxf(mNew[0], fmaxf(r[0], r[1]));
+                mNew[1] = fmaxf(mNew[1], fmaxf(r[2], r[3]));
+            }
+            #pragma unroll
+            for (int half = 0; half < 2; ++half) {
+                mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 1));
+                mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 2));
+                mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
+            }
+
+            float corr[2];
+            corr[0] = attention_mma_detail::fastExp(rowMax[mq][0] - mNew[0]);
+            corr[1] = attention_mma_detail::fastExp(rowMax[mq][1] - mNew[1]);
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                oAcc[mq][md][0] *= corr[0];
+                oAcc[mq][md][1] *= corr[0];
+                oAcc[mq][md][2] *= corr[1];
+                oAcc[mq][md][3] *= corr[1];
+            }
+            rowMax[mq][0] = mNew[0];
+            rowMax[mq][1] = mNew[1];
+
+            float lNew[2] = {};
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                float* r = sReg[mq][mkv];
+                if constexpr (NO_MASK) {
+                    r[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
+                    r[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
+                    r[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);
+                    r[3] = attention_mma_detail::fastExp(r[3] - mNew[1]);
+                } else {
+                    r[0] = (r[0] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[0] - mNew[0]);
+                    r[1] = (r[1] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[1] - mNew[0]);
+                    r[2] = (r[2] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[2] - mNew[1]);
+                    r[3] = (r[3] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[3] - mNew[1]);
+                }
+                lNew[0] += r[0] + r[1];
+                lNew[1] += r[2] + r[3];
+
+                __nv_bfloat162* pp = reinterpret_cast<__nv_bfloat162*>(pReg[mq][mkv / 2]);
+                pp[(mkv % 2) * 2]     = __float22bfloat162_rn({ r[0], r[1] });
+                pp[(mkv % 2) * 2 + 1] = __float22bfloat162_rn({ r[2], r[3] });
+            }
+            #pragma unroll
+            for (int half = 0; half < 2; ++half) {
+                lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 1);
+                lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 2);
+                rowSum[mq][half] = rowSum[mq][half] * corr[half] + lNew[half];
+            }
+        }
+    }
+
+    FK_DEVICE_FUSE void sMma(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
+                             const uint32_t (&kReg)[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2],
+                             float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv)
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_K; ++md)
+                    mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sReg[mq][mkv]);
+    }
+
+    FK_DEVICE_FUSE void pvMma(const uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+                              const uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2],
+                              float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; ++md)
+                #pragma unroll
+                for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
+                    mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
+    }
+
+    FK_DEVICE_FUSE void writeOut(const float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                 const float (&rowSum)[WARP_Q / MMA_M][2],
+                                 const Params& p, const int qBlockBase,
+                                 const int warpId, const int laneId, const int bh) {
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
+            const int rowB = rowA + 8;
+            const float invA = rowSum[mq][0] > 0.f ? 1.f / rowSum[mq][0] : 0.f;
+            const float invB = rowSum[mq][1] > 0.f ? 1.f / rowSum[mq][1] : 0.f;
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                const int col = md * MMA_N + (laneId % 4) * 2;
+                const float* r = oAcc[mq][md];
+                if (rowA < p.seq_q) {
+                    const long base = ((long)bh * p.seq_q + rowA) * HEAD_DIM + col;
+                    storePair(p.o + base, (r[0] * invA) | p.epilogue,
+                                          (r[1] * invA) | p.epilogue);
+                }
+                if (rowB < p.seq_q) {
+                    const long base = ((long)bh * p.seq_q + rowB) * HEAD_DIM + col;
+                    storePair(p.o + base, (r[2] * invB) | p.epilogue,
+                                          (r[3] * invB) | p.epilogue);
+                }
+            }
+        }
+    }
+
+    FK_DEVICE_FUSE void storePair(OT* dst, const float a, const float b) {
+        if constexpr (std::is_same_v<OT, __nv_bfloat16>) {
+            *reinterpret_cast<__nv_bfloat162*>(dst) = __float22bfloat162_rn({ a, b });
+        } else {
+            dst[0] = attnFromF32<OT>(a);
+            dst[1] = attnFromF32<OT>(b);
+        }
+    }
+
     static __device__ void exec(const Params& p) {
         using namespace attention_mma_detail;
         extern __shared__ char smemRaw[];
@@ -202,23 +470,21 @@ public:
         const int bh = blockIdx.y;
         const int qBlockBase = blockIdx.x * BLOCK_Q;
 
-        // buffer byte offsets (Q overlaps K buffers; all KV_BUF_B-aligned)
-        const auto kBuf = [](int i) -> uint32_t { return i * KV_BUF_B; };
-        const auto vBuf = [](int i) -> uint32_t { return (2 + i) * KV_BUF_B; };
-
-        // pre-swizzled per-thread ldmatrix base offsets (v2)
-        // A-tile (Q): rows lane%16, col halves lane/16
         const uint32_t qThread = swz(((warpId * WARP_Q + laneId % 16) * HEAD_DIM
                                       + (laneId / 16) * 8) * sizeof(__nv_bfloat16));
-        // B-tile (K, x4): rows lane%8, 4 col-chunks lane/8
         const uint32_t kThread = swz(((laneId % 8) * HEAD_DIM
                                       + (laneId / 8) * 8) * sizeof(__nv_bfloat16));
-        // B-tile trans (V, x4): rows lane%16, col halves lane/16
         const uint32_t vThread = swz(((laneId % 16) * HEAD_DIM
                                       + (laneId / 16) * 8) * sizeof(__nv_bfloat16));
 
-        // ---- phase 1: Q -> smem (through prologue, swizzled) -> registers
-        {
+        // ---- Q -> smem -> registers (one-time) -----------------------------
+        if constexpr (RAW_Q) {
+            const __nv_bfloat16* qPlane = p.q.params.data
+                                          + (long)bh * p.seq_q * HEAD_DIM;
+            cpasyncTile<Q_GROUPS>(smemBase, qPlane, qBlockBase, p.seq_q);
+            cp_async_commit();
+            cp_async_wait<0>();
+        } else {
             float qStage[Q_GROUPS][8];
             prefetchTile<Q_GROUPS>(p.q, qBlockBase, p.seq_q, bh, qStage);
             storeTile<Q_GROUPS>(smemBytes, 0, qStage);
@@ -231,12 +497,12 @@ public:
             #pragma unroll
             for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
                 uint32_t addr = smemBase + qThread;
-                addr += mq * MMA_M * STRIDE_B;                       // row step
-                addr ^= md * MMA_K * sizeof(__nv_bfloat16);          // col step
+                addr += mq * MMA_M * STRIDE_B;
+                addr ^= md * MMA_K * sizeof(__nv_bfloat16);
                 ldmatrix_x4(qReg[mq][md], addr);
             }
         }
-        __syncthreads();  // done reading Q smem before K tile 0 overwrites it
+        __syncthreads();
 
         float oAcc[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
         float rowMax[WARP_Q / MMA_M][2];
@@ -249,176 +515,118 @@ public:
 
         const int kvEnd = p.causal ? ::min(p.seq_k, qBlockBase + BLOCK_Q) : p.seq_k;
         const int numIter = (kvEnd + BLOCK_KV - 1) / BLOCK_KV;
+        // tiles fully inside [0, seq_k) AND fully below the causal diagonal
+        // of every row in this block need no masking at all.
+        const int firstRowOfBlock = qBlockBase;  // min row over all warps
+        const auto tileNeedsMask = [&](const int offKV) {
+            if (offKV + BLOCK_KV > p.seq_k) return true;               // ragged
+            if (p.causal && offKV + BLOCK_KV - 1 > firstRowOfBlock) return true;
+            return false;
+        };
 
-        float kPre[KV_GROUPS][8], vPre[KV_GROUPS][8];
+        if constexpr (RAW_KV) {
+            // ============= cp.async schedule (fa-5090 v5 staggering) =========
+            // K double-buffered, V single-buffered; K[kv+1] is issued right
+            // after the QK^T mma so it streams during softmax + PV.
+            const __nv_bfloat16* kPlane = p.k.params.data + (long)bh * p.seq_k * HEAD_DIM;
+            const __nv_bfloat16* vPlane = p.v.params.data + (long)bh * p.seq_k * HEAD_DIM;
+            const auto kBuf = [&](int i) { return (uint32_t)(i % 2) * KV_BUF_B; };
+            const uint32_t vBufOff = 2 * KV_BUF_B;  // single V buffer
 
-        // stage tile 0
-        prefetchTile<KV_GROUPS>(p.k, 0, p.seq_k, bh, kPre);
-        prefetchTile<KV_GROUPS>(p.v, 0, p.seq_k, bh, vPre);
-        storeTile<KV_GROUPS>(smemBytes, kBuf(0), kPre);
-        storeTile<KV_GROUPS>(smemBytes, vBuf(0), vPre);
-        __syncthreads();
+            // prefetch K0
+            cpasyncTile<KV_GROUPS>(smemBase + kBuf(0), kPlane, 0, p.seq_k);
+            cp_async_commit();
 
-        for (int kv = 0; kv < numIter; ++kv) {
-            const int offKV = kv * BLOCK_KV;
-            const int cur = kv % 2;
-            const int nxt = (kv + 1) % 2;
+            for (int kv = 0; kv < numIter; ++kv) {
+                const int offKV = kv * BLOCK_KV;
 
-            // ---- v3: issue NEXT tile's prologue reads now; they overlap
-            // the mma math below and land in smem just before the sync.
-            const bool havePrefetch = (kv + 1) < numIter;
-            if (havePrefetch) {
-                prefetchTile<KV_GROUPS>(p.k, offKV + BLOCK_KV, p.seq_k, bh, kPre);
-                prefetchTile<KV_GROUPS>(p.v, offKV + BLOCK_KV, p.seq_k, bh, vPre);
+                // V uses a single buffer: previous PV must be done.
+                __syncthreads();
+                cpasyncTile<KV_GROUPS>(smemBase + vBufOff, vPlane, offKV, p.seq_k);
+                cp_async_commit();
+
+                // wait K[kv] (1 group outstanding: V[kv])
+                cp_async_wait<1>();
+                __syncthreads();
+
+                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+
+                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                sMma(qReg, kReg, sReg);
+
+                // prefetch K[kv+1] (overlaps softmax + PV)
+                if (kv + 1 < numIter) {
+                    cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
+                                           offKV + BLOCK_KV, p.seq_k);
+                }
+                cp_async_commit();
+
+                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+                if (tileNeedsMask(offKV)) {
+                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                       qBlockBase, warpId, laneId);
+                } else {
+                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                      qBlockBase, warpId, laneId);
+                }
+
+                // wait V[kv] (1 group outstanding: K[kv+1])
+                cp_async_wait<1>();
+                __syncthreads();
+
+                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                loadVFrags(smemBase + vBufOff, vThread, vReg);
+                pvMma(pReg, vReg, oAcc);
             }
+        } else {
+            // ============== register-prefetch schedule (fused prologues) =====
+            const auto kBuf = [](int i) -> uint32_t { return (i % 2) * KV_BUF_B; };
+            const auto vBuf = [](int i) -> uint32_t { return (2 + (i % 2)) * KV_BUF_B; };
 
-            // ---- K fragments (v4: ldmatrix.x4 covers two MMA_K chunks) ---
-            uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-            #pragma unroll
-            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
-                    uint32_t addr = smemBase + kBuf(cur) + kThread;
-                    addr += mkv * MMA_N * STRIDE_B;
-                    addr ^= md * MMA_K * sizeof(__nv_bfloat16);
-                    ldmatrix_x4(&kReg[mkv][md][0], addr);
-                }
-            }
-
-            // ---- S = scale * Q K^T (fp32 accum) ---------------------------
-            float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
-            #pragma unroll
-            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
-                #pragma unroll
-                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv)
-                    #pragma unroll
-                    for (int md = 0; md < HEAD_DIM / MMA_K; ++md)
-                        mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sReg[mq][mkv]);
-
-            uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
-
-            #pragma unroll
-            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
-                const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
-                const int rowB = rowA + 8;
-
-                // scale + bounds/causal mask BEFORE rowmax
-                #pragma unroll
-                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                    float* r = sReg[mq][mkv];
-                    const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
-                    #pragma unroll
-                    for (int e = 0; e < 4; ++e) {
-                        const int col = colBase + (e & 1);
-                        const int row = (e < 2) ? rowA : rowB;
-                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
-                        r[e] = dead ? -FLT_MAX : r[e] * p.scale;
-                    }
-                }
-
-                // online softmax on fp32 registers (butterfly over 4 lanes)
-                float mNew[2] = { -FLT_MAX, -FLT_MAX };
-                #pragma unroll
-                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                    const float* r = sReg[mq][mkv];
-                    mNew[0] = fmaxf(mNew[0], fmaxf(r[0], r[1]));
-                    mNew[1] = fmaxf(mNew[1], fmaxf(r[2], r[3]));
-                }
-                #pragma unroll
-                for (int half = 0; half < 2; ++half) {
-                    mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 1));
-                    mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 2));
-                    mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
-                }
-
-                float corr[2];
-                corr[0] = __expf(rowMax[mq][0] - mNew[0]);
-                corr[1] = __expf(rowMax[mq][1] - mNew[1]);
-                #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
-                    oAcc[mq][md][0] *= corr[0];
-                    oAcc[mq][md][1] *= corr[0];
-                    oAcc[mq][md][2] *= corr[1];
-                    oAcc[mq][md][3] *= corr[1];
-                }
-                rowMax[mq][0] = mNew[0];
-                rowMax[mq][1] = mNew[1];
-
-                float lNew[2] = {};
-                #pragma unroll
-                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
-                    float* r = sReg[mq][mkv];
-                    r[0] = (r[0] == -FLT_MAX) ? 0.f : __expf(r[0] - mNew[0]);
-                    r[1] = (r[1] == -FLT_MAX) ? 0.f : __expf(r[1] - mNew[0]);
-                    r[2] = (r[2] == -FLT_MAX) ? 0.f : __expf(r[2] - mNew[1]);
-                    r[3] = (r[3] == -FLT_MAX) ? 0.f : __expf(r[3] - mNew[1]);
-                    lNew[0] += r[0] + r[1];
-                    lNew[1] += r[2] + r[3];
-
-                    __nv_bfloat162* pp =
-                        reinterpret_cast<__nv_bfloat162*>(pReg[mq][mkv / 2]);
-                    pp[(mkv % 2) * 2]     = __float22bfloat162_rn({ r[0], r[1] });
-                    pp[(mkv % 2) * 2 + 1] = __float22bfloat162_rn({ r[2], r[3] });
-                }
-                #pragma unroll
-                for (int half = 0; half < 2; ++half) {
-                    lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 1);
-                    lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 2);
-                    rowSum[mq][half] = rowSum[mq][half] * corr[half] + lNew[half];
-                }
-            }
-
-            // ---- V fragments (x4 trans), O += P V -------------------------
-            uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
-            #pragma unroll
-            for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
-                #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
-                    uint32_t addr = smemBase + vBuf(cur) + vThread;
-                    addr += mkv * MMA_K * STRIDE_B;
-                    addr ^= md * MMA_N * sizeof(__nv_bfloat16);
-                    ldmatrix_x4_trans(&vReg[mkv][md][0], addr);
-                }
-            }
-            #pragma unroll
-            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
-                #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_N; ++md)
-                    #pragma unroll
-                    for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
-                        mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
-
-            // ---- land the prefetched tile in the other buffer -------------
-            if (havePrefetch) {
-                storeTile<KV_GROUPS>(smemBytes, kBuf(nxt), kPre);
-                storeTile<KV_GROUPS>(smemBytes, vBuf(nxt), vPre);
-            }
+            float kPre[KV_GROUPS][8], vPre[KV_GROUPS][8];
+            prefetchTile<KV_GROUPS>(p.k, 0, p.seq_k, bh, kPre);
+            prefetchTile<KV_GROUPS>(p.v, 0, p.seq_k, bh, vPre);
+            storeTile<KV_GROUPS>(smemBytes, kBuf(0), kPre);
+            storeTile<KV_GROUPS>(smemBytes, vBuf(0), vPre);
             __syncthreads();
-        }
 
-        // ---- normalize, EPILOGUE FUSION, single global write --------------
-        #pragma unroll
-        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
-            const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
-            const int rowB = rowA + 8;
-            const float invA = rowSum[mq][0] > 0.f ? 1.f / rowSum[mq][0] : 0.f;
-            const float invB = rowSum[mq][1] > 0.f ? 1.f / rowSum[mq][1] : 0.f;
-            #pragma unroll
-            for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
-                const int col = md * MMA_N + (laneId % 4) * 2;
-                const float* r = oAcc[mq][md];
-                if (rowA < p.seq_q) {
-                    const long base = ((long)bh * p.seq_q + rowA) * HEAD_DIM + col;
-                    p.o[base]     = attnFromF32<OT>((r[0] * invA) | p.epilogue);
-                    p.o[base + 1] = attnFromF32<OT>((r[1] * invA) | p.epilogue);
+            for (int kv = 0; kv < numIter; ++kv) {
+                const int offKV = kv * BLOCK_KV;
+                const bool havePrefetch = (kv + 1) < numIter;
+                if (havePrefetch) {
+                    prefetchTile<KV_GROUPS>(p.k, offKV + BLOCK_KV, p.seq_k, bh, kPre);
+                    prefetchTile<KV_GROUPS>(p.v, offKV + BLOCK_KV, p.seq_k, bh, vPre);
                 }
-                if (rowB < p.seq_q) {
-                    const long base = ((long)bh * p.seq_q + rowB) * HEAD_DIM + col;
-                    p.o[base]     = attnFromF32<OT>((r[2] * invB) | p.epilogue);
-                    p.o[base + 1] = attnFromF32<OT>((r[3] * invB) | p.epilogue);
+
+                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+
+                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                sMma(qReg, kReg, sReg);
+
+                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+                if (tileNeedsMask(offKV)) {
+                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                       qBlockBase, warpId, laneId);
+                } else {
+                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                      qBlockBase, warpId, laneId);
                 }
+
+                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                loadVFrags(smemBase + vBuf(kv), vThread, vReg);
+                pvMma(pReg, vReg, oAcc);
+
+                if (havePrefetch) {
+                    storeTile<KV_GROUPS>(smemBytes, kBuf(kv + 1), kPre);
+                    storeTile<KV_GROUPS>(smemBytes, vBuf(kv + 1), vPre);
+                }
+                __syncthreads();
             }
         }
+
+        writeOut(oAcc, rowSum, p, qBlockBase, warpId, laneId, bh);
     }
 };
 
@@ -432,8 +640,12 @@ __global__ void launchFlashAttentionMmaDPP_Kernel(
                          BLOCK_Q, BLOCK_KV, NUM_WARPS>::exec(params);
 }
 
-/* IOp-first API, mirroring executeFlashAttention. Tensor-core path. */
-template <int HEAD_DIM, int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32, int NUM_WARPS = 4,
+/* IOp-first API. The DPP auto-selects cp.async streaming (raw bf16
+ * prologues) or register prefetch (fused prologues) at compile time, and
+ * auto-tunes tile sizes per schedule (pass BLOCK_Q/BLOCK_KV > 0 to
+ * override): raw path prefers BQ64/BKV64 (deep cp.async overlap),
+ * fused-prologue path prefers BQ128/BKV32 (register headroom). */
+template <int HEAD_DIM, int BLOCK_Q = 0, int BLOCK_KV = 0, int NUM_WARPS = 4,
           typename OT = float, typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue>
 inline void executeFlashAttentionMma(
@@ -441,16 +653,21 @@ inline void executeFlashAttentionMma(
         const int batchHeads, const int seqQ, const int seqK,
         const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
         const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {}) {
+    constexpr bool RAW = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
+    constexpr int BQ = BLOCK_Q > 0 ? BLOCK_Q
+                                   : (RAW ? 64 : (HEAD_DIM <= 64 ? 128 : 64));
+    constexpr int BKV = BLOCK_KV > 0 ? BLOCK_KV
+                                     : (RAW ? (HEAD_DIM <= 64 ? 64 : 32) : 32);
     using DPP = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
-                                     EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+                                     EpilogueIOp, BQ, BKV, NUM_WARPS>;
     const float scale = scaleOverride > 0.f ? scaleOverride
                                             : rsqrtf(static_cast<float>(HEAD_DIM));
     const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal, epilogue };
-    const dim3 grid((seqQ + BLOCK_Q - 1) / BLOCK_Q, batchHeads, 1);
+    const dim3 grid((seqQ + BQ - 1) / BQ, batchHeads, 1);
     const dim3 block(DPP::THREADS, 1, 1);
     const int smemBytes = DPP::SMEM_BYTES;
     auto* kernel = launchFlashAttentionMmaDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp,
-                                                     EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+                                                     EpilogueIOp, BQ, BKV, NUM_WARPS>;
     if (smemBytes > 48000) {
         gpuErrchk(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
                                        smemBytes));

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -283,9 +283,10 @@ public:
                   "BLOCK_KV*HEAD_DIM must be a multiple of THREADS*8");
 
     static constexpr int KV_BUF_B = BLOCK_KV * STRIDE_B;
-    // both schedules: K double + V double (4 bf16 buffers). QUANT_KV adds
-    // 4 byte-staging buffers (half size) for the raw quantized bytes.
-    static constexpr int KV_BUFS = 4;
+    // RAW schedule uses K double + V single (3 bf16 buffers) — keeping smem
+    // at 3 bufs is REQUIRED for 4 blocks/SM (ncu: smem limited occupancy to
+    // 3 blocks at 4 bufs). QUANT/register-prefetch use 4 (+byte staging).
+    static constexpr int KV_BUFS = RAW_KV ? 3 : 4;
     static constexpr int Q_STAGE_B = QUANT_KV ? 4 * (KV_BUF_B / 2) : 0;
     static constexpr int SMEM_BYTES =
         (BLOCK_Q * STRIDE_B > KV_BUFS * KV_BUF_B + Q_STAGE_B
@@ -606,6 +607,35 @@ public:
                     mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sReg[mq][mkv]);
     }
 
+    /* REGISTER-PRESSURE-FUSED QK^T: stream K fragments from smem with
+     * ldmatrix.x4 immediately before their mma instead of staging the whole
+     * tile (kReg was 64 regs/thread live across the loop -> now 4). ncu
+     * showed 154 regs/thread capped occupancy at 3 blocks/SM; this fusion
+     * (+V below, +3 smem bufs) unlocks the 4th block. */
+    FK_DEVICE_FUSE void sMmaStream(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
+                                   const uint32_t base, const uint32_t kThread,
+                                   float (&sReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+                // identical x4 pattern to loadKFrags: one mkv row, fragments
+                // for md (regs 0-1) and md+1 (regs 2-3).
+                uint32_t frag[4];
+                uint32_t addr = base + kThread;
+                addr += mkv * MMA_N * STRIDE_B;
+                addr ^= md * MMA_K * sizeof(__nv_bfloat16);
+                ldmatrix_x4(frag, addr);
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(qReg[mq][md],     frag + 0, sReg[mq][mkv]);
+                    mma_m16n8k16(qReg[mq][md + 1], frag + 2, sReg[mq][mkv]);
+                }
+            }
+        }
+    }
+
     FK_DEVICE_FUSE void pvMma(const uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
                               const uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2],
                               float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
@@ -617,6 +647,30 @@ public:
                 #pragma unroll
                 for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
                     mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
+    }
+
+    /* Same fusion for P·V: stream V fragments (trans ldmatrix.x4) right
+     * before use. vReg was another 32-64 live regs. */
+    FK_DEVICE_FUSE void pvMmaStream(const uint32_t (&pReg)[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4],
+                                    const uint32_t base, const uint32_t vThread,
+                                    float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
+                uint32_t frag[4];
+                uint32_t addr = base + vThread;
+                addr += mkv * MMA_K * STRIDE_B;
+                addr ^= md * MMA_N * sizeof(__nv_bfloat16);
+                ldmatrix_x4_trans(frag, addr);
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(pReg[mq][mkv], frag + 0, oAcc[mq][md]);
+                    mma_m16n8k16(pReg[mq][mkv], frag + 2, oAcc[mq][md + 1]);
+                }
+            }
+        }
     }
 
     FK_DEVICE_FUSE void writeOut(const float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
@@ -815,9 +869,8 @@ public:
                 __syncthreads();
 
                 if (act) {
-                    uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
-                    loadVFrags(smemBase + vBufOff, vThread, vReg);
-                    pvMma(pReg, vReg, oAcc);
+                    // stream V frags ldmatrix->mma (no vReg staging)
+                    pvMmaStream(pReg, smemBase + vBufOff, vThread, oAcc);
                 }
             }
         } else if constexpr (QUANT_KV) {

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -47,6 +47,7 @@
 #if (defined(__NVCC__) || CLANG_HOST_DEVICE)
 
 #include <cuda_bf16.h>
+#include <vector>
 
 namespace fk {
 
@@ -152,6 +153,34 @@ struct BlockSparsity {
     int nQBlocks = 0, nKVBlocks = 0;
     int maskBQ = 128, maskBKV = 128;
 };
+
+/* Host helper: build a sliding-window block mask at (blockQ x blockKV)
+ * granularity. Tile (qb, kb) is active iff ANY (q, k) pair inside it
+ * satisfies causal q >= k AND q - k < window. Finer blocks (e.g. 64 to
+ * match the raw-path kernel tiles) skip more tiles -> faster. The exact
+ * per-element window edge is enforced by SlidingWindowMask (score mod);
+ * compose both: mask for the skip, mod for the edge. */
+inline std::vector<unsigned char>
+makeSlidingWindowBlockMask(const int batchHeads, const int seqQ, const int seqK,
+                           const int window, const int blockQ, const int blockKV) {
+    const int nQB = (seqQ + blockQ - 1) / blockQ;
+    const int nKB = (seqK + blockKV - 1) / blockKV;
+    std::vector<unsigned char> m((size_t)batchHeads * nQB * nKB, 0);
+    for (int qb = 0; qb < nQB; ++qb) {
+        const int qLo = qb * blockQ;
+        const int qHi = ::min(seqQ - 1, qLo + blockQ - 1);
+        for (int kb = 0; kb < nKB; ++kb) {
+            const int kLo = kb * blockKV;
+            // active iff intervals [kLo, kHi] and [qHi-window+1, qHi] overlap
+            // under causality (k <= qHi) — widest query row decides.
+            const bool active = (kLo <= qHi) && (kLo + blockKV - 1 >= qLo - window + 1);
+            if (active)
+                for (int b = 0; b < batchHeads; ++b)
+                    m[((size_t)b * nQB + qb) * nKB + kb] = 1;
+        }
+    }
+    return m;
+}
 
 namespace attention_mma_detail {
 
@@ -703,6 +732,27 @@ public:
             return p.sparse.mask[((long)bh * p.sparse.nQBlocks + qb)
                                  * p.sparse.nKVBlocks + kb] != 0;
         };
+        // ITERATION-RANGE TRIM: with a mask, scan this q-block's row once and
+        // iterate only [itBegin, itEnd) — skipped iterations otherwise still
+        // pay syncthreads + empty commit overhead (measured: a w=512 sliding
+        // window at s4096 wastes ~85% of iterations without this).
+        int itBegin = 0, itEnd = numIter;
+        if (p.sparse.mask != nullptr) {
+            const int qb = qBlockBase / p.sparse.maskBQ;
+            const unsigned char* row = p.sparse.mask
+                + ((long)bh * p.sparse.nQBlocks + qb) * p.sparse.nKVBlocks;
+            const int tilesPerMask = p.sparse.maskBKV / BLOCK_KV;
+            int first = -1, last = -1;
+            for (int kb = 0; kb < p.sparse.nKVBlocks; ++kb) {
+                if (row[kb]) { if (first < 0) first = kb; last = kb; }
+            }
+            if (first < 0) {
+                itBegin = itEnd = 0;     // fully masked row -> zero output
+            } else {
+                itBegin = ::min(numIter, first * tilesPerMask);
+                itEnd = ::min(numIter, (last + 1) * tilesPerMask);
+            }
+        }
 
         if constexpr (RAW_KV) {
             // ============= cp.async schedule (fa-5090 v5 staggering) =========
@@ -713,13 +763,14 @@ public:
             const auto kBuf = [&](int i) { return (uint32_t)(i % 2) * KV_BUF_B; };
             const uint32_t vBufOff = 2 * KV_BUF_B;  // single V buffer
 
-            // prefetch K0
-            if (tileActive(0)) {
-                cpasyncTile<KV_GROUPS>(smemBase + kBuf(0), kPlane, 0, p.seq_k);
+            // prefetch first in-range tile
+            if (itBegin < itEnd && tileActive(itBegin * BLOCK_KV)) {
+                cpasyncTile<KV_GROUPS>(smemBase + kBuf(itBegin), kPlane,
+                                       itBegin * BLOCK_KV, p.seq_k);
             }
             cp_async_commit();
 
-            for (int kv = 0; kv < numIter; ++kv) {
+            for (int kv = itBegin; kv < itEnd; ++kv) {
                 const int offKV = kv * BLOCK_KV;
                 const bool act = tileActive(offKV);
 
@@ -742,7 +793,7 @@ public:
                 }
 
                 // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
-                if (kv + 1 < numIter && tileActive(offKV + BLOCK_KV)) {
+                if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
                     cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
                                            offKV + BLOCK_KV, p.seq_k);
                 }
@@ -790,13 +841,14 @@ public:
                 return stageBase + (uint32_t)(i % 2) * (KV_BUF_B / 2); };
             const uint32_t vStage = stageBase + 2 * (KV_BUF_B / 2);
 
-            // prefetch K0 bytes
-            if (tileActive(0)) {
-                cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(0), kPlane, 0, p.seq_k);
+            // prefetch first in-range tile bytes
+            if (itBegin < itEnd && tileActive(itBegin * BLOCK_KV)) {
+                cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(itBegin), kPlane,
+                                            itBegin * BLOCK_KV, p.seq_k);
             }
             cp_async_commit();
 
-            for (int kv = 0; kv < numIter; ++kv) {
+            for (int kv = itBegin; kv < itEnd; ++kv) {
                 const int offKV = kv * BLOCK_KV;
                 const bool act = tileActive(offKV);
 
@@ -821,7 +873,7 @@ public:
                     sMma(qReg, kReg, sReg);
                 }
 
-                if (kv + 1 < numIter && tileActive(offKV + BLOCK_KV)) {
+                if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
                     cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(kv + 1), kPlane,
                                                 offKV + BLOCK_KV, p.seq_k);
                 }
@@ -858,16 +910,18 @@ public:
             const auto vBuf = [](int i) -> uint32_t { return (2 + (i % 2)) * KV_BUF_B; };
 
             float kPre[KV_GROUPS][8], vPre[KV_GROUPS][8];
-            prefetchTile<KV_GROUPS>(p.k, 0, p.seq_k, bh, kPre);
-            prefetchTile<KV_GROUPS>(p.v, 0, p.seq_k, bh, vPre);
-            storeTile<KV_GROUPS>(smemBytes, kBuf(0), kPre);
-            storeTile<KV_GROUPS>(smemBytes, vBuf(0), vPre);
+            if (itBegin < itEnd) {
+                prefetchTile<KV_GROUPS>(p.k, itBegin * BLOCK_KV, p.seq_k, bh, kPre);
+                prefetchTile<KV_GROUPS>(p.v, itBegin * BLOCK_KV, p.seq_k, bh, vPre);
+                storeTile<KV_GROUPS>(smemBytes, kBuf(itBegin), kPre);
+                storeTile<KV_GROUPS>(smemBytes, vBuf(itBegin), vPre);
+            }
             __syncthreads();
 
-            for (int kv = 0; kv < numIter; ++kv) {
+            for (int kv = itBegin; kv < itEnd; ++kv) {
                 const int offKV = kv * BLOCK_KV;
                 const bool act = tileActive(offKV);
-                const bool nextAct = (kv + 1) < numIter && tileActive(offKV + BLOCK_KV);
+                const bool nextAct = (kv + 1) < itEnd && tileActive(offKV + BLOCK_KV);
                 if (nextAct) {
                     prefetchTile<KV_GROUPS>(p.k, offKV + BLOCK_KV, p.seq_k, bh, kPre);
                     prefetchTile<KV_GROUPS>(p.v, offKV + BLOCK_KV, p.seq_k, bh, vPre);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -16,34 +16,38 @@
 #define FK_ATTENTION_FLASH_ATTENTION_MMA_H
 
 /* FlashAttentionMmaDPP: FA-2 forward on mma.sync.m16n8k16 tensor cores
- * (sm_80+; tuned on sm_120 per gau-nernst's fa-5090 analysis: on consumer
- * Blackwell there is no TMEM/tcgen05, so the path to speed-of-light is
- * exactly this — ldmatrix + mma.sync + cp.async-style staging).
+ * (sm_80+; tuned on sm_120 per gau-nernst's fa-5090 ladder: on consumer
+ * Blackwell there is no TMEM/tcgen05 — see also Dao-AILab/flash-attention
+ * PR #2634 bringing FA to sm12x the same way).
  *
- * THE FKL DIFFERENCE vs handmade FA kernels (incl. learn-cuda 07_attention
- * and the flash-attention repo): Q, K and V remain Read/ReadBack IOps.
- * The global->shared staging reads every element THROUGH the prologue IOp
- * (dequantization, scaling, casts... fuse in-register at load time), and
- * the epilogue IOp chain runs on the output registers before the single
- * global write. Handmade kernels hardcode raw bf16 pointers; here the
- * compressed int8 KV cache or any preprocessing rides the SAME kernel.
+ * Optimization ladder applied (fa-5090 v1 -> v4, adapted to FKL):
+ *   v1  mma.sync m16n8k16 bf16->fp32, FA-2 warp split, online softmax
+ *       on fp32 S registers with butterfly reductions.
+ *   v2  XOR-swizzled smem so ldmatrix and the 16-byte staging stores are
+ *       bank-conflict free.
+ *   v3  software pipelining: K/V double-buffered in smem; the NEXT tile's
+ *       global reads are issued (through the prologue IOps, into
+ *       registers) BEFORE the current tile's math, so load latency
+ *       overlaps the mma work. This is the FKL-compatible counterpart of
+ *       cp.async 2-stage pipelining: cp.async copies raw bytes and cannot
+ *       run an IOp chain per element; prefetch-to-register can.
+ *   v4  ldmatrix.x4 for K and V fragment loads.
  *
- * Mapping (faithful port of learn-cuda v1, generalized):
- *   - bf16 tiles in smem (built via prologue, fp32 -> bf16 round)
- *   - ldmatrix.x4 / .x2 to registers, mma.sync m16n8k16 bf16->fp32
- *   - FA-2 warp split: each warp owns WARP_Q = BLOCK_Q/NUM_WARPS query
- *     rows; K/V tiles replicated across warps; online softmax on the
- *     fp32 S registers with butterfly reductions in each 4-thread group.
- *   - fp32 accumulation for O; epilogue + single write at the end.
- *   - Causal masking and ragged seq_q/seq_k handled with guards
- *     (staging pads with zeros; S positions beyond seq_k or above the
- *     diagonal are set to -inf before the rowmax).
+ * THE FKL DIFFERENCE vs handmade FA kernels: Q, K and V remain
+ * Read/ReadBack IOps. Staging reads every element THROUGH the prologue
+ * (int8 dequant, scaling, casts, any .then chain fuse in-register at load
+ * time), and the epilogue IOp chain runs on the output registers before
+ * the single global write. The compressed int8 KV cache or any
+ * preprocessing rides the SAME kernel — flash-attention cannot do that.
  *
- * Requirements: HEAD_DIM % 16 == 0 (ldmatrix granularity).
+ * Layout: (batch*heads, seq, head_dim); HEAD_DIM % 32 == 0; causal,
+ * ragged and cross seq lens handled with guards (staging pads with
+ * zeros; dead S positions get -inf before the rowmax).
+ *
  * Accuracy: bf16 inputs to the dot products (like every tensor-core FA);
- * expect ~1e-2 abs error on unit-range inputs vs an fp64 oracle — same
- * ballpark as flash-attention's own bf16 path. The SIMT DPP remains the
- * fp32-exact option. */
+ * ~1e-2 abs error on unit-range inputs vs an fp64 oracle — same class as
+ * flash-attention's own bf16 path. The SIMT DPP remains the fp32-exact
+ * option. */
 
 #include <fused_kernel/algorithms/attention/flash_attention.h>
 
@@ -61,15 +65,9 @@ __device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
                  : "r"(addr));
 }
 
-__device__ __forceinline__ void ldmatrix_x2(uint32_t regs[2], uint32_t addr) {
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
-                 : "=r"(regs[0]), "=r"(regs[1])
-                 : "r"(addr));
-}
-
-__device__ __forceinline__ void ldmatrix_x2_trans(uint32_t regs[2], uint32_t addr) {
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
-                 : "=r"(regs[0]), "=r"(regs[1])
+__device__ __forceinline__ void ldmatrix_x4_trans(uint32_t regs[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];"
+                 : "=r"(regs[0]), "=r"(regs[1]), "=r"(regs[2]), "=r"(regs[3])
                  : "r"(addr));
 }
 
@@ -83,12 +81,15 @@ __device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t
                    "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
 }
 
+// 8 bf16 packed for one 16-byte swizzled smem store.
+struct alignas(16) Bf16x8 { __nv_bfloat162 h[4]; };
+
 } // namespace attention_mma_detail
 
 template <typename OT, int HEAD_DIM,
           typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue,
-          int BLOCK_Q = 64, int BLOCK_KV = 64, int NUM_WARPS = 4>
+          int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32, int NUM_WARPS = 4>
 struct FlashAttentionMmaDPP {
 private:
     using SelfType = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
@@ -96,7 +97,7 @@ private:
 public:
     FK_STATIC_STRUCT(FlashAttentionMmaDPP, SelfType)
 
-    static_assert(HEAD_DIM % 16 == 0, "HEAD_DIM must be a multiple of 16 (ldmatrix)");
+    static_assert(HEAD_DIM % 32 == 0, "HEAD_DIM must be a multiple of 32");
     static_assert(isAnyReadType<QIOp>, "Q prologue must be a Read or ReadBack IOp");
     static_assert(isAnyReadType<KIOp>, "K prologue must be a Read or ReadBack IOp");
     static_assert(isAnyReadType<VIOp>, "V prologue must be a Read or ReadBack IOp");
@@ -105,8 +106,20 @@ public:
     static constexpr int WARP_Q = BLOCK_Q / NUM_WARPS;        // rows per warp
     static_assert(WARP_Q % 16 == 0, "BLOCK_Q/NUM_WARPS must be a multiple of 16");
     static constexpr int MMA_M = 16, MMA_N = 8, MMA_K = 16;
-    static constexpr int SMEM_ELEMS =
-        (BLOCK_Q > 2 * BLOCK_KV ? BLOCK_Q : 2 * BLOCK_KV) * HEAD_DIM;
+
+    static constexpr int STRIDE_B = HEAD_DIM * (int)sizeof(__nv_bfloat16);
+    static constexpr int Q_GROUPS = BLOCK_Q * HEAD_DIM / (THREADS * 8);
+    static constexpr int KV_GROUPS = BLOCK_KV * HEAD_DIM / (THREADS * 8);
+    static_assert(Q_GROUPS >= 1 && BLOCK_Q * HEAD_DIM % (THREADS * 8) == 0,
+                  "BLOCK_Q*HEAD_DIM must be a multiple of THREADS*8");
+    static_assert(KV_GROUPS >= 1 && BLOCK_KV * HEAD_DIM % (THREADS * 8) == 0,
+                  "BLOCK_KV*HEAD_DIM must be a multiple of THREADS*8");
+
+    // Q buffer overlaps the K/V double buffers (Q is consumed into
+    // registers before the first K/V tile is staged).
+    static constexpr int KV_BUF_B = BLOCK_KV * STRIDE_B;       // one buffer, bytes
+    static constexpr int SMEM_BYTES =
+        (BLOCK_Q * STRIDE_B > 4 * KV_BUF_B ? BLOCK_Q * STRIDE_B : 4 * KV_BUF_B);
 
     struct Params {
         QIOp q; KIOp k; VIOp v;
@@ -117,34 +130,71 @@ public:
         EpilogueIOp epilogue;
     };
 
+    /* XOR swizzle on a byte offset relative to a tile buffer (buffers are
+       KV_BUF_B-aligned, i.e. multiples of 8*STRIDE_B). Same scheme as
+       fa-5090 / CUTLASS: kills bank conflicts for both the 16B staging
+       stores and the ldmatrix loads. */
+    FK_DEVICE_FUSE uint32_t swz(const uint32_t byteOff) {
+        const uint32_t row = (byteOff / STRIDE_B) % 8;
+        constexpr uint32_t div = (64 / STRIDE_B > 1 ? 64 / STRIDE_B : 1);
+        return byteOff ^ ((row / div) << 4);
+    }
+
     template <typename IOp>
     FK_DEVICE_FUSE float readElem(const IOp& iop, const int x, const int y, const int z) {
         // single entry point for ALL data: the prologue IOp's exec.
         return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
     }
 
-    /* Stage a (rows x HEAD_DIM) tile into smem THROUGH a prologue IOp.
-       Pads with zeros beyond seqLen. This is where FKL's fusion happens:
-       int8 dequant / scaling / any .then chain runs here, in-register. */
-    template <typename IOp>
-    FK_DEVICE_FUSE void stageTile(__nv_bfloat16* smem, const IOp& iop,
-                                  const int rowBase, const int rows,
-                                  const int seqLen, const int bh) {
-        for (int idx = threadIdx.x; idx < rows * HEAD_DIM; idx += THREADS) {
+    /* v3 pipelining, FKL style: issue the global reads for a tile through
+       the prologue IOp into registers. Called BEFORE the current tile's
+       math so the loads overlap the mma work (the data is only consumed
+       by storeTile afterwards). */
+    template <int GROUPS, typename IOp>
+    FK_DEVICE_FUSE void prefetchTile(const IOp& iop, const int rowBase,
+                                     const int seqLen, const int bh,
+                                     float (&regs)[GROUPS][8]) {
+        #pragma unroll
+        for (int g = 0; g < GROUPS; ++g) {
+            const int idx = (g * THREADS + (int)threadIdx.x) * 8;
             const int r = idx / HEAD_DIM;
             const int c = idx % HEAD_DIM;
             const int row = rowBase + r;
-            const float val = (row < seqLen) ? readElem(iop, c, row, bh) : 0.f;
-            smem[r * HEAD_DIM + c] = __float2bfloat16(val);
+            if (row < seqLen) {
+                #pragma unroll
+                for (int e = 0; e < 8; ++e)
+                    regs[g][e] = readElem(iop, c + e, row, bh);
+            } else {
+                #pragma unroll
+                for (int e = 0; e < 8; ++e) regs[g][e] = 0.f;
+            }
+        }
+    }
+
+    // fp32 regs -> bf16x8 -> ONE 16-byte store per group, swizzled.
+    template <int GROUPS>
+    FK_DEVICE_FUSE void storeTile(char* smemBytes, const uint32_t bufOff,
+                                  const float (&regs)[GROUPS][8]) {
+        using attention_mma_detail::Bf16x8;
+        #pragma unroll
+        for (int g = 0; g < GROUPS; ++g) {
+            const uint32_t idx = (g * THREADS + threadIdx.x) * 8;
+            Bf16x8 packed;
+            #pragma unroll
+            for (int h = 0; h < 4; ++h)
+                packed.h[h] = __float22bfloat162_rn({ regs[g][2 * h],
+                                                      regs[g][2 * h + 1] });
+            *reinterpret_cast<Bf16x8*>(
+                smemBytes + bufOff + swz(idx * (uint32_t)sizeof(__nv_bfloat16))) = packed;
         }
     }
 
     static __device__ void exec(const Params& p) {
         using namespace attention_mma_detail;
-        extern __shared__ __nv_bfloat16 smem[];
-        __nv_bfloat16* qSmem = smem;                 // BLOCK_Q rows (phase 1)
-        __nv_bfloat16* kSmem = smem;                 // BLOCK_KV rows (reused)
-        __nv_bfloat16* vSmem = smem + BLOCK_KV * HEAD_DIM;
+        extern __shared__ char smemRaw[];
+        char* smemBytes = smemRaw;
+        const uint32_t smemBase =
+            static_cast<uint32_t>(__cvta_generic_to_shared(smemRaw));
 
         const int tid = threadIdx.x;
         const int warpId = tid / 32;
@@ -152,23 +202,41 @@ public:
         const int bh = blockIdx.y;
         const int qBlockBase = blockIdx.x * BLOCK_Q;
 
-        // ---- phase 1: Q -> smem (through prologue) -> registers ----------
-        stageTile(qSmem, p.q, qBlockBase, BLOCK_Q, p.seq_q, bh);
+        // buffer byte offsets (Q overlaps K buffers; all KV_BUF_B-aligned)
+        const auto kBuf = [](int i) -> uint32_t { return i * KV_BUF_B; };
+        const auto vBuf = [](int i) -> uint32_t { return (2 + i) * KV_BUF_B; };
+
+        // pre-swizzled per-thread ldmatrix base offsets (v2)
+        // A-tile (Q): rows lane%16, col halves lane/16
+        const uint32_t qThread = swz(((warpId * WARP_Q + laneId % 16) * HEAD_DIM
+                                      + (laneId / 16) * 8) * sizeof(__nv_bfloat16));
+        // B-tile (K, x4): rows lane%8, 4 col-chunks lane/8
+        const uint32_t kThread = swz(((laneId % 8) * HEAD_DIM
+                                      + (laneId / 8) * 8) * sizeof(__nv_bfloat16));
+        // B-tile trans (V, x4): rows lane%16, col halves lane/16
+        const uint32_t vThread = swz(((laneId % 16) * HEAD_DIM
+                                      + (laneId / 16) * 8) * sizeof(__nv_bfloat16));
+
+        // ---- phase 1: Q -> smem (through prologue, swizzled) -> registers
+        {
+            float qStage[Q_GROUPS][8];
+            prefetchTile<Q_GROUPS>(p.q, qBlockBase, p.seq_q, bh, qStage);
+            storeTile<Q_GROUPS>(smemBytes, 0, qStage);
+        }
         __syncthreads();
 
         uint32_t qReg[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
-        const uint32_t qBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(qSmem));
         #pragma unroll
         for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
             #pragma unroll
             for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
-                const int row = warpId * WARP_Q + mq * MMA_M + (laneId % 16);
-                const int col = md * MMA_K + (laneId / 16) * 8;
-                ldmatrix_x4(qReg[mq][md],
-                            qBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+                uint32_t addr = smemBase + qThread;
+                addr += mq * MMA_M * STRIDE_B;                       // row step
+                addr ^= md * MMA_K * sizeof(__nv_bfloat16);          // col step
+                ldmatrix_x4(qReg[mq][md], addr);
             }
         }
-        __syncthreads();  // done reading qSmem before K overwrites it
+        __syncthreads();  // done reading Q smem before K tile 0 overwrites it
 
         float oAcc[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
         float rowMax[WARP_Q / MMA_M][2];
@@ -179,27 +247,41 @@ public:
             rowMax[mq][1] = -FLT_MAX;
         }
 
-        const uint32_t kBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(kSmem));
-        const uint32_t vBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(vSmem));
-
-        // causal: rows in this block end at qBlockBase + BLOCK_Q - 1
         const int kvEnd = p.causal ? ::min(p.seq_k, qBlockBase + BLOCK_Q) : p.seq_k;
+        const int numIter = (kvEnd + BLOCK_KV - 1) / BLOCK_KV;
 
-        for (int offKV = 0; offKV < kvEnd; offKV += BLOCK_KV) {
-            // ---- K and V tiles, staged through their prologue IOps -------
-            stageTile(kSmem, p.k, offKV, BLOCK_KV, p.seq_k, bh);
-            stageTile(vSmem, p.v, offKV, BLOCK_KV, p.seq_k, bh);
-            __syncthreads();
+        float kPre[KV_GROUPS][8], vPre[KV_GROUPS][8];
 
+        // stage tile 0
+        prefetchTile<KV_GROUPS>(p.k, 0, p.seq_k, bh, kPre);
+        prefetchTile<KV_GROUPS>(p.v, 0, p.seq_k, bh, vPre);
+        storeTile<KV_GROUPS>(smemBytes, kBuf(0), kPre);
+        storeTile<KV_GROUPS>(smemBytes, vBuf(0), vPre);
+        __syncthreads();
+
+        for (int kv = 0; kv < numIter; ++kv) {
+            const int offKV = kv * BLOCK_KV;
+            const int cur = kv % 2;
+            const int nxt = (kv + 1) % 2;
+
+            // ---- v3: issue NEXT tile's prologue reads now; they overlap
+            // the mma math below and land in smem just before the sync.
+            const bool havePrefetch = (kv + 1) < numIter;
+            if (havePrefetch) {
+                prefetchTile<KV_GROUPS>(p.k, offKV + BLOCK_KV, p.seq_k, bh, kPre);
+                prefetchTile<KV_GROUPS>(p.v, offKV + BLOCK_KV, p.seq_k, bh, vPre);
+            }
+
+            // ---- K fragments (v4: ldmatrix.x4 covers two MMA_K chunks) ---
             uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
                 #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
-                    const int row = mkv * MMA_N + (laneId % 8);
-                    const int col = md * MMA_K + (laneId / 8) * 8;
-                    ldmatrix_x2(kReg[mkv][md],
-                                kBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+                for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+                    uint32_t addr = smemBase + kBuf(cur) + kThread;
+                    addr += mkv * MMA_N * STRIDE_B;
+                    addr ^= md * MMA_K * sizeof(__nv_bfloat16);
+                    ldmatrix_x4(&kReg[mkv][md][0], addr);
                 }
             }
 
@@ -217,7 +299,6 @@ public:
 
             #pragma unroll
             for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
-                // global row indices of the two row-halves this thread holds
                 const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
                 const int rowB = rowA + 8;
 
@@ -274,7 +355,6 @@ public:
                     lNew[0] += r[0] + r[1];
                     lNew[1] += r[2] + r[3];
 
-                    // repack P fp32 -> bf16x2 registers for the P @ V mma
                     __nv_bfloat162* pp =
                         reinterpret_cast<__nv_bfloat162*>(pReg[mq][mkv / 2]);
                     pp[(mkv % 2) * 2]     = __float22bfloat162_rn({ r[0], r[1] });
@@ -288,16 +368,16 @@ public:
                 }
             }
 
-            // ---- V tile -> registers (transposed), O += P V ---------------
+            // ---- V fragments (x4 trans), O += P V -------------------------
             uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
             #pragma unroll
             for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
                 #pragma unroll
-                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
-                    const int row = mkv * MMA_K + (laneId % 16);
-                    const int col = md * MMA_N + (laneId / 16) * 8;
-                    ldmatrix_x2_trans(vReg[mkv][md],
-                                      vBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+                for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
+                    uint32_t addr = smemBase + vBuf(cur) + vThread;
+                    addr += mkv * MMA_K * STRIDE_B;
+                    addr ^= md * MMA_N * sizeof(__nv_bfloat16);
+                    ldmatrix_x4_trans(&vReg[mkv][md][0], addr);
                 }
             }
             #pragma unroll
@@ -308,7 +388,12 @@ public:
                     for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
                         mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
 
-            __syncthreads();  // protect smem before next tile staging
+            // ---- land the prefetched tile in the other buffer -------------
+            if (havePrefetch) {
+                storeTile<KV_GROUPS>(smemBytes, kBuf(nxt), kPre);
+                storeTile<KV_GROUPS>(smemBytes, vBuf(nxt), vPre);
+            }
+            __syncthreads();
         }
 
         // ---- normalize, EPILOGUE FUSION, single global write --------------
@@ -348,7 +433,7 @@ __global__ void launchFlashAttentionMmaDPP_Kernel(
 }
 
 /* IOp-first API, mirroring executeFlashAttention. Tensor-core path. */
-template <int HEAD_DIM, int BLOCK_Q = 64, int BLOCK_KV = 64, int NUM_WARPS = 4,
+template <int HEAD_DIM, int BLOCK_Q = (HEAD_DIM <= 64 ? 128 : 64), int BLOCK_KV = 32, int NUM_WARPS = 4,
           typename OT = float, typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp = AttentionIdentityEpilogue>
 inline void executeFlashAttentionMma(
@@ -363,7 +448,7 @@ inline void executeFlashAttentionMma(
     const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal, epilogue };
     const dim3 grid((seqQ + BLOCK_Q - 1) / BLOCK_Q, batchHeads, 1);
     const dim3 block(DPP::THREADS, 1, 1);
-    const int smemBytes = DPP::SMEM_ELEMS * sizeof(__nv_bfloat16);
+    const int smemBytes = DPP::SMEM_BYTES;
     auto* kernel = launchFlashAttentionMmaDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp,
                                                      EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
     if (smemBytes > 48000) {

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -100,6 +100,16 @@ inline auto makeAttentionRead(const __nv_bfloat16* data, const int batchHeads,
 template <typename IOp>
 constexpr bool isRawBf16Read = std::is_same_v<typename IOp::Operation, Bf16AttentionRead>;
 
+#ifdef FK_HAS_FP8
+template <typename IOp>
+constexpr bool isFp8KVRead = std::is_same_v<typename IOp::Operation, Fp8TokenDequantRead>;
+#else
+template <typename IOp>
+constexpr bool isFp8KVRead = false;
+#endif
+template <typename IOp>
+constexpr bool isInt8KVRead = std::is_same_v<typename IOp::Operation, Int8TokenDequantRead>;
+
 namespace attention_mma_detail {
 
 __device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
@@ -128,6 +138,12 @@ __device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t
 __device__ __forceinline__ void cp_async_16(uint32_t dst, const void* src,
                                             const int srcSize) {
     asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;"
+                 :: "r"(dst), "l"(src), "r"(srcSize));
+}
+// 8-byte async copy (ca path; cg only supports 16B).
+__device__ __forceinline__ void cp_async_8(uint32_t dst, const void* src,
+                                           const int srcSize) {
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 8, %2;"
                  :: "r"(dst), "l"(src), "r"(srcSize));
 }
 __device__ __forceinline__ void cp_async_commit() {
@@ -176,6 +192,11 @@ public:
     // RAW = identity bf16 reads -> real cp.async streaming (fa-5090 v5).
     static constexpr bool RAW_KV = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
     static constexpr bool RAW_Q = isRawBf16Read<QIOp>;
+    // QUANT_KV = fp8/int8 per-token KV -> cp.async the RAW QUANTIZED bytes
+    // (HALF the global traffic of bf16!) + smem->smem dequant pass.
+    static constexpr bool QUANT_KV =
+        (isFp8KVRead<KIOp> && isFp8KVRead<VIOp>) ||
+        (isInt8KVRead<KIOp> && isInt8KVRead<VIOp>);
 
     static constexpr int STRIDE_B = HEAD_DIM * (int)sizeof(__nv_bfloat16);
     static constexpr int Q_GROUPS = BLOCK_Q * HEAD_DIM / (THREADS * 8);
@@ -186,11 +207,14 @@ public:
                   "BLOCK_KV*HEAD_DIM must be a multiple of THREADS*8");
 
     static constexpr int KV_BUF_B = BLOCK_KV * STRIDE_B;
-    // both schedules: K double + V double (4 buffers).
+    // both schedules: K double + V double (4 bf16 buffers). QUANT_KV adds
+    // 4 byte-staging buffers (half size) for the raw quantized bytes.
     static constexpr int KV_BUFS = 4;
+    static constexpr int Q_STAGE_B = QUANT_KV ? 4 * (KV_BUF_B / 2) : 0;
     static constexpr int SMEM_BYTES =
-        (BLOCK_Q * STRIDE_B > KV_BUFS * KV_BUF_B ? BLOCK_Q * STRIDE_B
-                                                 : KV_BUFS * KV_BUF_B);
+        (BLOCK_Q * STRIDE_B > KV_BUFS * KV_BUF_B + Q_STAGE_B
+             ? BLOCK_Q * STRIDE_B
+             : KV_BUFS * KV_BUF_B + Q_STAGE_B);
 
     struct Params {
         QIOp q; KIOp k; VIOp v;
@@ -217,6 +241,11 @@ public:
     FK_DEVICE_FUSE void prefetchTile(const IOp& iop, const int rowBase,
                                      const int seqLen, const int bh,
                                      float (&regs)[GROUPS][8]) {
+        // VECTORIZED FAST PATH for the quantized KV prologues: ONE 8-byte
+        // load per thread-group (vs 8 scattered byte loads) + the per-token
+        // scale hoisted out of the element loop. Generic IOps keep the
+        // element-wise path (they may fuse arbitrary compute chains).
+        constexpr bool QUANT8 = isFp8KVRead<IOp> || isInt8KVRead<IOp>;
         #pragma unroll
         for (int g = 0; g < GROUPS; ++g) {
             const int idx = (g * THREADS + (int)threadIdx.x) * 8;
@@ -224,9 +253,32 @@ public:
             const int c = idx % HEAD_DIM;
             const int row = rowBase + r;
             if (row < seqLen) {
-                #pragma unroll
-                for (int e = 0; e < 8; ++e)
-                    regs[g][e] = readElem(iop, c + e, row, bh);
+                if constexpr (QUANT8) {
+                    const auto& prm = iop.params;
+                    const int seq = static_cast<int>(prm.data.dims.height);
+                    const float sc = prm.scales[(long)bh * seq + row];
+                    const int8_t* base = reinterpret_cast<const int8_t*>(prm.data.data)
+                                       + ((long)bh * seq + row) * HEAD_DIM + c;
+                    // one coalesced 8-byte load
+                    const uint64_t packed = *reinterpret_cast<const uint64_t*>(base);
+                    #pragma unroll
+                    for (int e = 0; e < 8; ++e) {
+                        const int8_t b = static_cast<int8_t>((packed >> (8 * e)) & 0xFF);
+                        if constexpr (isFp8KVRead<IOp>) {
+#ifdef FK_HAS_FP8
+                            __nv_fp8_e4m3 f8;
+                            f8.__x = static_cast<__nv_fp8_storage_t>(b);
+                            regs[g][e] = static_cast<float>(f8) * sc;
+#endif
+                        } else {
+                            regs[g][e] = static_cast<float>(b) * sc;
+                        }
+                    }
+                } else {
+                    #pragma unroll
+                    for (int e = 0; e < 8; ++e)
+                        regs[g][e] = readElem(iop, c + e, row, bh);
+                }
             } else {
                 #pragma unroll
                 for (int e = 0; e < 8; ++e) regs[g][e] = 0.f;
@@ -267,6 +319,68 @@ public:
             const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
             cp_async_16(dstBase + swz(idx * (uint32_t)sizeof(__nv_bfloat16)),
                         srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 16 : 0);
+        }
+    }
+
+    // ---- quantized staging: cp.async the RAW BYTES (half the traffic) ------
+    template <int GROUPS>
+    FK_DEVICE_FUSE void cpasyncQuantTile(const uint32_t dstBase,
+                                         const int8_t* srcPlane, const int rowBase,
+                                         const int seqLen) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int g = 0; g < GROUPS; ++g) {
+            const int idx = (g * THREADS + (int)threadIdx.x) * 8;
+            const int r = idx / HEAD_DIM;
+            const int c = idx % HEAD_DIM;
+            const int row = rowBase + r;
+            const bool ok = row < seqLen;
+            const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
+            // unswizzled byte staging: 8B per thread-group
+            cp_async_8(dstBase + (uint32_t)idx,
+                       srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 8 : 0);
+        }
+    }
+
+    /* smem bytes -> swizzled bf16 smem, dequantizing in-register. scales
+       read from global (coalesced; BLOCK_KV floats per tile). */
+    template <int GROUPS, bool FP8>
+    FK_DEVICE_FUSE void dequantTile(char* smemBytes, const uint32_t stageOff,
+                                    const uint32_t bf16Off, const float* scales,
+                                    const int rowBase, const int seqLen) {
+        using attention_mma_detail::Bf16x8;
+        #pragma unroll
+        for (int g = 0; g < GROUPS; ++g) {
+            const int idx = (g * THREADS + (int)threadIdx.x) * 8;
+            const int r = idx / HEAD_DIM;
+            const int row = rowBase + r;
+            const float sc = (row < seqLen) ? scales[row] : 0.f;
+            const uint64_t packed =
+                *reinterpret_cast<const uint64_t*>(smemBytes + stageOff + idx);
+            Bf16x8 out;
+            #pragma unroll
+            for (int h = 0; h < 4; ++h) {
+                float lo, hi;
+                const int8_t b0 = static_cast<int8_t>((packed >> (16 * h)) & 0xFF);
+                const int8_t b1 = static_cast<int8_t>((packed >> (16 * h + 8)) & 0xFF);
+                if constexpr (FP8) {
+#ifdef FK_HAS_FP8
+                    __nv_fp8_e4m3 f0, f1;
+                    f0.__x = static_cast<__nv_fp8_storage_t>(b0);
+                    f1.__x = static_cast<__nv_fp8_storage_t>(b1);
+                    lo = static_cast<float>(f0) * sc;
+                    hi = static_cast<float>(f1) * sc;
+#else
+                    lo = hi = 0.f;
+#endif
+                } else {
+                    lo = static_cast<float>(b0) * sc;
+                    hi = static_cast<float>(b1) * sc;
+                }
+                out.h[h] = __float22bfloat162_rn({ lo, hi });
+            }
+            *reinterpret_cast<Bf16x8*>(
+                smemBytes + bf16Off + swz(idx * (uint32_t)sizeof(__nv_bfloat16))) = out;
         }
     }
 
@@ -573,6 +687,75 @@ public:
 
                 // wait V[kv] (1 group outstanding: K[kv+1])
                 cp_async_wait<1>();
+                __syncthreads();
+
+                uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+                loadVFrags(smemBase + vBufOff, vThread, vReg);
+                pvMma(pReg, vReg, oAcc);
+            }
+        } else if constexpr (QUANT_KV) {
+            // ====== quantized cp.async schedule: stream RAW BYTES (2x less
+            // global traffic than bf16), dequantize smem->smem in-register.
+            // Same v5 staggering as the raw path.
+            constexpr bool IS_FP8 = isFp8KVRead<KIOp>;
+            const int seqK = static_cast<int>(p.k.params.data.dims.height);
+            const int8_t* kPlane = reinterpret_cast<const int8_t*>(p.k.params.data.data)
+                                   + (long)bh * seqK * HEAD_DIM;
+            const int8_t* vPlane = reinterpret_cast<const int8_t*>(p.v.params.data.data)
+                                   + (long)bh * seqK * HEAD_DIM;
+            const float* kScales = p.k.params.scales + (long)bh * seqK;
+            const float* vScales = p.v.params.scales + (long)bh * seqK;
+
+            const auto kBuf = [&](int i) { return (uint32_t)(i % 2) * KV_BUF_B; };
+            const uint32_t vBufOff = 2 * KV_BUF_B;
+            // byte staging area after the 4 bf16 buffers
+            const uint32_t stageBase = 4 * KV_BUF_B;
+            const auto kStage = [&](int i) {
+                return stageBase + (uint32_t)(i % 2) * (KV_BUF_B / 2); };
+            const uint32_t vStage = stageBase + 2 * (KV_BUF_B / 2);
+
+            // prefetch K0 bytes
+            cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(0), kPlane, 0, p.seq_k);
+            cp_async_commit();
+
+            for (int kv = 0; kv < numIter; ++kv) {
+                const int offKV = kv * BLOCK_KV;
+
+                __syncthreads();
+                cpasyncQuantTile<KV_GROUPS>(smemBase + vStage, vPlane, offKV, p.seq_k);
+                cp_async_commit();
+
+                cp_async_wait<1>();   // K bytes ready
+                __syncthreads();
+                dequantTile<KV_GROUPS, IS_FP8>(smemBytes, kStage(kv), kBuf(kv),
+                                               kScales, offKV, p.seq_k);
+                __syncthreads();
+
+                uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+
+                float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+                sMma(qReg, kReg, sReg);
+
+                if (kv + 1 < numIter) {
+                    cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(kv + 1), kPlane,
+                                                offKV + BLOCK_KV, p.seq_k);
+                }
+                cp_async_commit();
+
+                uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+                if (tileNeedsMask(offKV)) {
+                    softmaxTile<false>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                       qBlockBase, warpId, laneId);
+                } else {
+                    softmaxTile<true>(sReg, pReg, oAcc, rowMax, rowSum, p, offKV,
+                                      qBlockBase, warpId, laneId);
+                }
+
+                cp_async_wait<1>();   // V bytes ready
+                __syncthreads();
+                dequantTile<KV_GROUPS, IS_FP8>(smemBytes, vStage, vBufOff,
+                                               vScales, offKV, p.seq_k);
                 __syncthreads();
 
                 uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -1,0 +1,381 @@
+/* Copyright 2026 the Fused Kernel Library authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_ATTENTION_FLASH_ATTENTION_MMA_H
+#define FK_ATTENTION_FLASH_ATTENTION_MMA_H
+
+/* FlashAttentionMmaDPP: FA-2 forward on mma.sync.m16n8k16 tensor cores
+ * (sm_80+; tuned on sm_120 per gau-nernst's fa-5090 analysis: on consumer
+ * Blackwell there is no TMEM/tcgen05, so the path to speed-of-light is
+ * exactly this — ldmatrix + mma.sync + cp.async-style staging).
+ *
+ * THE FKL DIFFERENCE vs handmade FA kernels (incl. learn-cuda 07_attention
+ * and the flash-attention repo): Q, K and V remain Read/ReadBack IOps.
+ * The global->shared staging reads every element THROUGH the prologue IOp
+ * (dequantization, scaling, casts... fuse in-register at load time), and
+ * the epilogue IOp chain runs on the output registers before the single
+ * global write. Handmade kernels hardcode raw bf16 pointers; here the
+ * compressed int8 KV cache or any preprocessing rides the SAME kernel.
+ *
+ * Mapping (faithful port of learn-cuda v1, generalized):
+ *   - bf16 tiles in smem (built via prologue, fp32 -> bf16 round)
+ *   - ldmatrix.x4 / .x2 to registers, mma.sync m16n8k16 bf16->fp32
+ *   - FA-2 warp split: each warp owns WARP_Q = BLOCK_Q/NUM_WARPS query
+ *     rows; K/V tiles replicated across warps; online softmax on the
+ *     fp32 S registers with butterfly reductions in each 4-thread group.
+ *   - fp32 accumulation for O; epilogue + single write at the end.
+ *   - Causal masking and ragged seq_q/seq_k handled with guards
+ *     (staging pads with zeros; S positions beyond seq_k or above the
+ *     diagonal are set to -inf before the rowmax).
+ *
+ * Requirements: HEAD_DIM % 16 == 0 (ldmatrix granularity).
+ * Accuracy: bf16 inputs to the dot products (like every tensor-core FA);
+ * expect ~1e-2 abs error on unit-range inputs vs an fp64 oracle — same
+ * ballpark as flash-attention's own bf16 path. The SIMT DPP remains the
+ * fp32-exact option. */
+
+#include <fused_kernel/algorithms/attention/flash_attention.h>
+
+#if (defined(__NVCC__) || CLANG_HOST_DEVICE)
+
+#include <cuda_bf16.h>
+
+namespace fk {
+
+namespace attention_mma_detail {
+
+__device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
+                 : "=r"(regs[0]), "=r"(regs[1]), "=r"(regs[2]), "=r"(regs[3])
+                 : "r"(addr));
+}
+
+__device__ __forceinline__ void ldmatrix_x2(uint32_t regs[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];"
+                 : "=r"(regs[0]), "=r"(regs[1])
+                 : "r"(addr));
+}
+
+__device__ __forceinline__ void ldmatrix_x2_trans(uint32_t regs[2], uint32_t addr) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];"
+                 : "=r"(regs[0]), "=r"(regs[1])
+                 : "r"(addr));
+}
+
+__device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t B[2],
+                                             float D[4]) {
+    asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+                 "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};"
+                 : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+                 : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]),
+                   "r"(B[0]), "r"(B[1]),
+                   "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
+}
+
+} // namespace attention_mma_detail
+
+template <typename OT, int HEAD_DIM,
+          typename QIOp, typename KIOp, typename VIOp,
+          typename EpilogueIOp = AttentionIdentityEpilogue,
+          int BLOCK_Q = 64, int BLOCK_KV = 64, int NUM_WARPS = 4>
+struct FlashAttentionMmaDPP {
+private:
+    using SelfType = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
+                                          EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+public:
+    FK_STATIC_STRUCT(FlashAttentionMmaDPP, SelfType)
+
+    static_assert(HEAD_DIM % 16 == 0, "HEAD_DIM must be a multiple of 16 (ldmatrix)");
+    static_assert(isAnyReadType<QIOp>, "Q prologue must be a Read or ReadBack IOp");
+    static_assert(isAnyReadType<KIOp>, "K prologue must be a Read or ReadBack IOp");
+    static_assert(isAnyReadType<VIOp>, "V prologue must be a Read or ReadBack IOp");
+
+    static constexpr int THREADS = NUM_WARPS * 32;
+    static constexpr int WARP_Q = BLOCK_Q / NUM_WARPS;        // rows per warp
+    static_assert(WARP_Q % 16 == 0, "BLOCK_Q/NUM_WARPS must be a multiple of 16");
+    static constexpr int MMA_M = 16, MMA_N = 8, MMA_K = 16;
+    static constexpr int SMEM_ELEMS =
+        (BLOCK_Q > 2 * BLOCK_KV ? BLOCK_Q : 2 * BLOCK_KV) * HEAD_DIM;
+
+    struct Params {
+        QIOp q; KIOp k; VIOp v;
+        OT* o;
+        int seq_q, seq_k;
+        float scale;
+        bool causal;
+        EpilogueIOp epilogue;
+    };
+
+    template <typename IOp>
+    FK_DEVICE_FUSE float readElem(const IOp& iop, const int x, const int y, const int z) {
+        // single entry point for ALL data: the prologue IOp's exec.
+        return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
+    }
+
+    /* Stage a (rows x HEAD_DIM) tile into smem THROUGH a prologue IOp.
+       Pads with zeros beyond seqLen. This is where FKL's fusion happens:
+       int8 dequant / scaling / any .then chain runs here, in-register. */
+    template <typename IOp>
+    FK_DEVICE_FUSE void stageTile(__nv_bfloat16* smem, const IOp& iop,
+                                  const int rowBase, const int rows,
+                                  const int seqLen, const int bh) {
+        for (int idx = threadIdx.x; idx < rows * HEAD_DIM; idx += THREADS) {
+            const int r = idx / HEAD_DIM;
+            const int c = idx % HEAD_DIM;
+            const int row = rowBase + r;
+            const float val = (row < seqLen) ? readElem(iop, c, row, bh) : 0.f;
+            smem[r * HEAD_DIM + c] = __float2bfloat16(val);
+        }
+    }
+
+    static __device__ void exec(const Params& p) {
+        using namespace attention_mma_detail;
+        extern __shared__ __nv_bfloat16 smem[];
+        __nv_bfloat16* qSmem = smem;                 // BLOCK_Q rows (phase 1)
+        __nv_bfloat16* kSmem = smem;                 // BLOCK_KV rows (reused)
+        __nv_bfloat16* vSmem = smem + BLOCK_KV * HEAD_DIM;
+
+        const int tid = threadIdx.x;
+        const int warpId = tid / 32;
+        const int laneId = tid % 32;
+        const int bh = blockIdx.y;
+        const int qBlockBase = blockIdx.x * BLOCK_Q;
+
+        // ---- phase 1: Q -> smem (through prologue) -> registers ----------
+        stageTile(qSmem, p.q, qBlockBase, BLOCK_Q, p.seq_q, bh);
+        __syncthreads();
+
+        uint32_t qReg[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
+        const uint32_t qBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(qSmem));
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
+                const int row = warpId * WARP_Q + mq * MMA_M + (laneId % 16);
+                const int col = md * MMA_K + (laneId / 16) * 8;
+                ldmatrix_x4(qReg[mq][md],
+                            qBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+            }
+        }
+        __syncthreads();  // done reading qSmem before K overwrites it
+
+        float oAcc[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
+        float rowMax[WARP_Q / MMA_M][2];
+        float rowSum[WARP_Q / MMA_M][2] = {};
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            rowMax[mq][0] = -FLT_MAX;
+            rowMax[mq][1] = -FLT_MAX;
+        }
+
+        const uint32_t kBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(kSmem));
+        const uint32_t vBaseAddr = static_cast<uint32_t>(__cvta_generic_to_shared(vSmem));
+
+        // causal: rows in this block end at qBlockBase + BLOCK_Q - 1
+        const int kvEnd = p.causal ? ::min(p.seq_k, qBlockBase + BLOCK_Q) : p.seq_k;
+
+        for (int offKV = 0; offKV < kvEnd; offKV += BLOCK_KV) {
+            // ---- K and V tiles, staged through their prologue IOps -------
+            stageTile(kSmem, p.k, offKV, BLOCK_KV, p.seq_k, bh);
+            stageTile(vSmem, p.v, offKV, BLOCK_KV, p.seq_k, bh);
+            __syncthreads();
+
+            uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
+                    const int row = mkv * MMA_N + (laneId % 8);
+                    const int col = md * MMA_K + (laneId / 8) * 8;
+                    ldmatrix_x2(kReg[mkv][md],
+                                kBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+                }
+            }
+
+            // ---- S = scale * Q K^T (fp32 accum) ---------------------------
+            float sReg[WARP_Q / MMA_M][BLOCK_KV / MMA_N][4] = {};
+            #pragma unroll
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+                #pragma unroll
+                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv)
+                    #pragma unroll
+                    for (int md = 0; md < HEAD_DIM / MMA_K; ++md)
+                        mma_m16n8k16(qReg[mq][md], kReg[mkv][md], sReg[mq][mkv]);
+
+            uint32_t pReg[WARP_Q / MMA_M][BLOCK_KV / MMA_K][4];
+
+            #pragma unroll
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                // global row indices of the two row-halves this thread holds
+                const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
+                const int rowB = rowA + 8;
+
+                // scale + bounds/causal mask BEFORE rowmax
+                #pragma unroll
+                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                    float* r = sReg[mq][mkv];
+                    const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int col = colBase + (e & 1);
+                        const int row = (e < 2) ? rowA : rowB;
+                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
+                        r[e] = dead ? -FLT_MAX : r[e] * p.scale;
+                    }
+                }
+
+                // online softmax on fp32 registers (butterfly over 4 lanes)
+                float mNew[2] = { -FLT_MAX, -FLT_MAX };
+                #pragma unroll
+                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                    const float* r = sReg[mq][mkv];
+                    mNew[0] = fmaxf(mNew[0], fmaxf(r[0], r[1]));
+                    mNew[1] = fmaxf(mNew[1], fmaxf(r[2], r[3]));
+                }
+                #pragma unroll
+                for (int half = 0; half < 2; ++half) {
+                    mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 1));
+                    mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 2));
+                    mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
+                }
+
+                float corr[2];
+                corr[0] = __expf(rowMax[mq][0] - mNew[0]);
+                corr[1] = __expf(rowMax[mq][1] - mNew[1]);
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                    oAcc[mq][md][0] *= corr[0];
+                    oAcc[mq][md][1] *= corr[0];
+                    oAcc[mq][md][2] *= corr[1];
+                    oAcc[mq][md][3] *= corr[1];
+                }
+                rowMax[mq][0] = mNew[0];
+                rowMax[mq][1] = mNew[1];
+
+                float lNew[2] = {};
+                #pragma unroll
+                for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+                    float* r = sReg[mq][mkv];
+                    r[0] = (r[0] == -FLT_MAX) ? 0.f : __expf(r[0] - mNew[0]);
+                    r[1] = (r[1] == -FLT_MAX) ? 0.f : __expf(r[1] - mNew[0]);
+                    r[2] = (r[2] == -FLT_MAX) ? 0.f : __expf(r[2] - mNew[1]);
+                    r[3] = (r[3] == -FLT_MAX) ? 0.f : __expf(r[3] - mNew[1]);
+                    lNew[0] += r[0] + r[1];
+                    lNew[1] += r[2] + r[3];
+
+                    // repack P fp32 -> bf16x2 registers for the P @ V mma
+                    __nv_bfloat162* pp =
+                        reinterpret_cast<__nv_bfloat162*>(pReg[mq][mkv / 2]);
+                    pp[(mkv % 2) * 2]     = __float22bfloat162_rn({ r[0], r[1] });
+                    pp[(mkv % 2) * 2 + 1] = __float22bfloat162_rn({ r[2], r[3] });
+                }
+                #pragma unroll
+                for (int half = 0; half < 2; ++half) {
+                    lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 1);
+                    lNew[half] += __shfl_xor_sync(0xFFFFFFFFu, lNew[half], 2);
+                    rowSum[mq][half] = rowSum[mq][half] * corr[half] + lNew[half];
+                }
+            }
+
+            // ---- V tile -> registers (transposed), O += P V ---------------
+            uint32_t vReg[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2];
+            #pragma unroll
+            for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                    const int row = mkv * MMA_K + (laneId % 16);
+                    const int col = md * MMA_N + (laneId / 16) * 8;
+                    ldmatrix_x2_trans(vReg[mkv][md],
+                                      vBaseAddr + (row * HEAD_DIM + col) * sizeof(__nv_bfloat16));
+                }
+            }
+            #pragma unroll
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md)
+                    #pragma unroll
+                    for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv)
+                        mma_m16n8k16(pReg[mq][mkv], vReg[mkv][md], oAcc[mq][md]);
+
+            __syncthreads();  // protect smem before next tile staging
+        }
+
+        // ---- normalize, EPILOGUE FUSION, single global write --------------
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
+            const int rowB = rowA + 8;
+            const float invA = rowSum[mq][0] > 0.f ? 1.f / rowSum[mq][0] : 0.f;
+            const float invB = rowSum[mq][1] > 0.f ? 1.f / rowSum[mq][1] : 0.f;
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                const int col = md * MMA_N + (laneId % 4) * 2;
+                const float* r = oAcc[mq][md];
+                if (rowA < p.seq_q) {
+                    const long base = ((long)bh * p.seq_q + rowA) * HEAD_DIM + col;
+                    p.o[base]     = attnFromF32<OT>((r[0] * invA) | p.epilogue);
+                    p.o[base + 1] = attnFromF32<OT>((r[1] * invA) | p.epilogue);
+                }
+                if (rowB < p.seq_q) {
+                    const long base = ((long)bh * p.seq_q + rowB) * HEAD_DIM + col;
+                    p.o[base]     = attnFromF32<OT>((r[2] * invB) | p.epilogue);
+                    p.o[base + 1] = attnFromF32<OT>((r[3] * invB) | p.epilogue);
+                }
+            }
+        }
+    }
+};
+
+template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
+          typename EpilogueIOp, int BLOCK_Q, int BLOCK_KV, int NUM_WARPS>
+__global__ void launchFlashAttentionMmaDPP_Kernel(
+        const __grid_constant__ typename FlashAttentionMmaDPP<
+            OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
+            BLOCK_Q, BLOCK_KV, NUM_WARPS>::Params params) {
+    FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
+                         BLOCK_Q, BLOCK_KV, NUM_WARPS>::exec(params);
+}
+
+/* IOp-first API, mirroring executeFlashAttention. Tensor-core path. */
+template <int HEAD_DIM, int BLOCK_Q = 64, int BLOCK_KV = 64, int NUM_WARPS = 4,
+          typename OT = float, typename QIOp, typename KIOp, typename VIOp,
+          typename EpilogueIOp = AttentionIdentityEpilogue>
+inline void executeFlashAttentionMma(
+        const QIOp& q, const KIOp& k, const VIOp& v, OT* o,
+        const int batchHeads, const int seqQ, const int seqK,
+        const bool causal, Stream_<ParArch::GPU_NVIDIA>& stream,
+        const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {}) {
+    using DPP = FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp,
+                                     EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+    const float scale = scaleOverride > 0.f ? scaleOverride
+                                            : rsqrtf(static_cast<float>(HEAD_DIM));
+    const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal, epilogue };
+    const dim3 grid((seqQ + BLOCK_Q - 1) / BLOCK_Q, batchHeads, 1);
+    const dim3 block(DPP::THREADS, 1, 1);
+    const int smemBytes = DPP::SMEM_ELEMS * sizeof(__nv_bfloat16);
+    auto* kernel = launchFlashAttentionMmaDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp,
+                                                     EpilogueIOp, BLOCK_Q, BLOCK_KV, NUM_WARPS>;
+    if (smemBytes > 48000) {
+        gpuErrchk(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                       smemBytes));
+    }
+    kernel<<<grid, block, smemBytes, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+} // namespace fk
+
+#endif // defined(__NVCC__) || CLANG_HOST_DEVICE
+
+#endif // FK_ATTENTION_FLASH_ATTENTION_MMA_H

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -575,12 +575,20 @@ public:
             float corr[2];
             corr[0] = attention_mma_detail::fastExp(rowMax[mq][0] - mNew[0]);
             corr[1] = attention_mma_detail::fastExp(rowMax[mq][1] - mNew[1]);
-            #pragma unroll
-            for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
-                oAcc[mq][md][0] *= corr[0];
-                oAcc[mq][md][1] *= corr[0];
-                oAcc[mq][md][2] *= corr[1];
-                oAcc[mq][md][3] *= corr[1];
+            // FA4-style rescale skip: at long seq most KV tiles do NOT move
+            // the running max (rowMax == mNew -> corr == 1), so the
+            // HEAD_DIM/MMA_N*4 FMULs over oAcc are identity work. The
+            // condition is uniform within each lane quad (rows are shared
+            // across laneId%4 after the shfl reduction), so divergence cost
+            // is one predicated branch.
+            if (rowMax[mq][0] != mNew[0] || rowMax[mq][1] != mNew[1]) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                    oAcc[mq][md][0] *= corr[0];
+                    oAcc[mq][md][1] *= corr[0];
+                    oAcc[mq][md][2] *= corr[1];
+                    oAcc[mq][md][3] *= corr[1];
+                }
             }
             rowMax[mq][0] = mNew[0];
             rowMax[mq][1] = mNew[1];

--- a/include/fused_kernel/algorithms/attention/flash_decode.h
+++ b/include/fused_kernel/algorithms/attention/flash_decode.h
@@ -1,0 +1,282 @@
+/* Copyright 2026 the Fused Kernel Library authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_ATTENTION_FLASH_DECODE_H
+#define FK_ATTENTION_FLASH_DECODE_H
+
+/* FlashDecodeDPP: split-KV attention decode (seq_q == 1), FlashDecoding
+ * style. Decode is BANDWIDTH-bound (one query token vs a long KV cache:
+ * arithmetic intensity ~1 FLOP/byte), so the kernel optimizes for
+ * occupancy + bytes, not tensor cores:
+ *
+ *  - grid = (NUM_SPLITS, batch*heads): the KV sequence is split across
+ *    blocks so ALL SMs work even at batch*heads << #SM (the reason a
+ *    single-pass kernel loses 10x at decode).
+ *  - each warp owns a private online-softmax state (m, l, o) and walks
+ *    tokens strided; warps combine in smem; splits combine in a tiny
+ *    second kernel (numerically exact online-softmax merge).
+ *  - K/V are read THROUGH prologue IOps: the fp8/int8 compressed cache
+ *    dequantizes in-register while streaming, so the global traffic is
+ *    HALF of bf16 — decode latency scales with bytes, so fp8 cache
+ *    ~= 2x faster decode at long seq (and 2x more tokens in VRAM).
+ *
+ * This pairs with FA4-sm12x's fp8 decode direction (Dao-AILab PR #2634)
+ * but keeps FKL's universal prologue: ANY Read/ReadBack IOp works. */
+
+#include <fused_kernel/algorithms/attention/flash_attention.h>
+#include <fused_kernel/algorithms/attention/flash_attention_mma.h>  // IOp traits + bf16 read
+
+#if (defined(__NVCC__) || CLANG_HOST_DEVICE)
+
+namespace fk {
+
+template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
+          int NUM_WARPS = 8>
+struct FlashDecodeDPP {
+private:
+    using SelfType = FlashDecodeDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>;
+public:
+    FK_STATIC_STRUCT(FlashDecodeDPP, SelfType)
+
+    static_assert(HEAD_DIM % 32 == 0, "HEAD_DIM must be a multiple of 32");
+    static constexpr int THREADS = NUM_WARPS * 32;
+    static constexpr int ELEMS = HEAD_DIM / 32;   // per-lane o/q elements
+
+    struct Params {
+        QIOp q; KIOp k; VIOp v;
+        float* partial;      // workspace [bh, splits, HEAD_DIM+2]
+        OT* o;               // final [bh, 1, HEAD_DIM] (used when splits==1)
+        int seq_k;
+        int splits;
+        float scale;
+    };
+
+    template <typename IOp>
+    FK_DEVICE_FUSE float readElem(const IOp& iop, const int x, const int y, const int z) {
+        return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
+    }
+
+    /* Vectorized row loader: lane owns elements [ELEMS*lane, ELEMS*lane+ELEMS).
+       Raw bf16 rows load as bfloat162 pairs (4B), fp8/int8 rows as packed
+       bytes (ELEMS bytes in one load) — decode is bandwidth-bound, wide
+       loads are the whole game. Generic IOps fall back to per-element. */
+    template <typename IOp>
+    FK_DEVICE_FUSE void loadRow(const IOp& iop, const int lane, const int t,
+                                const int bh, const int seqLen,
+                                float (&out)[ELEMS]) {
+        if constexpr (isRawBf16Read<IOp>) {
+            const auto& prm = iop.params;
+            const __nv_bfloat16* base = prm.data
+                + ((long)bh * seqLen + t) * HEAD_DIM + ELEMS * lane;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e += 2) {
+                const __nv_bfloat162 pair =
+                    *reinterpret_cast<const __nv_bfloat162*>(base + e);
+                out[e] = __bfloat162float(pair.x);
+                out[e + 1] = __bfloat162float(pair.y);
+            }
+        } else if constexpr (isFp8KVRead<IOp> || isInt8KVRead<IOp>) {
+            const auto& prm = iop.params;
+            const float sc = prm.scales[(long)bh * seqLen + t];
+            const int8_t* base = reinterpret_cast<const int8_t*>(prm.data.data)
+                + ((long)bh * seqLen + t) * HEAD_DIM + ELEMS * lane;
+            // one packed load: 2 bytes (d64) or 4 bytes (d128)
+            uint32_t packed = 0;
+            if constexpr (ELEMS == 2) packed = *reinterpret_cast<const uint16_t*>(base);
+            else packed = *reinterpret_cast<const uint32_t*>(base);
+            #pragma unroll
+            for (int e = 0; e < ELEMS; ++e) {
+                const int8_t b = static_cast<int8_t>((packed >> (8 * e)) & 0xFF);
+                if constexpr (isFp8KVRead<IOp>) {
+#ifdef FK_HAS_FP8
+                    __nv_fp8_e4m3 f8;
+                    f8.__x = static_cast<__nv_fp8_storage_t>(b);
+                    out[e] = static_cast<float>(f8) * sc;
+#endif
+                } else {
+                    out[e] = static_cast<float>(b) * sc;
+                }
+            }
+        } else {
+            #pragma unroll
+            for (int e = 0; e < ELEMS; ++e)
+                out[e] = readElem(iop, ELEMS * lane + e, t, bh);
+        }
+    }
+
+    static __device__ void exec(const Params& p) {
+        const int lane = threadIdx.x & 31;
+        const int warp = threadIdx.x >> 5;
+        const int split = blockIdx.x;
+        const int bh = blockIdx.y;
+
+        const int chunk = (p.seq_k + p.splits - 1) / p.splits;
+        const int kvBegin = split * chunk;
+        const int kvEnd = ::min(p.seq_k, kvBegin + chunk);
+        if (kvBegin >= kvEnd) {
+            // empty split: emit a neutral partial
+            if (threadIdx.x == 0 && p.splits > 1) {
+                float* dst = p.partial + ((long)bh * p.splits + split) * (HEAD_DIM + 2);
+                dst[HEAD_DIM] = -FLT_MAX; dst[HEAD_DIM + 1] = 0.f;
+                for (int dd = 0; dd < HEAD_DIM; ++dd) dst[dd] = 0.f;
+            }
+            return;
+        }
+
+        // q -> registers; lane owns elements [ELEMS*lane, ELEMS*lane+ELEMS)
+        float qReg[ELEMS];
+        #pragma unroll
+        for (int e = 0; e < ELEMS; ++e)
+            qReg[e] = readElem(p.q, ELEMS * lane + e, 0, bh);
+
+        // each warp walks tokens strided by NUM_WARPS
+        float m = -FLT_MAX, l = 0.f;
+        float oAcc[ELEMS];
+        #pragma unroll
+        for (int e = 0; e < ELEMS; ++e) oAcc[e] = 0.f;
+
+        for (int t = kvBegin + warp; t < kvEnd; t += NUM_WARPS) {
+            float kReg[ELEMS], vReg[ELEMS];
+            loadRow(p.k, lane, t, bh, p.seq_k, kReg);
+            loadRow(p.v, lane, t, bh, p.seq_k, vReg);
+            float partialDot = 0.f;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; ++e) partialDot += qReg[e] * kReg[e];
+            #pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                partialDot += __shfl_xor_sync(0xFFFFFFFFu, partialDot, off);
+            const float s = partialDot * p.scale;
+
+            const float mNew = fmaxf(m, s);
+            const float corr = __expf(m - mNew);
+            const float pj = __expf(s - mNew);
+            l = l * corr + pj;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; ++e)
+                oAcc[e] = oAcc[e] * corr + pj * vReg[e];
+            m = mNew;
+        }
+
+        // combine NUM_WARPS partials in smem (online-softmax merge)
+        __shared__ float sM[NUM_WARPS], sL[NUM_WARPS];
+        __shared__ float sO[NUM_WARPS][HEAD_DIM];
+        #pragma unroll
+        for (int e = 0; e < ELEMS; ++e) sO[warp][ELEMS * lane + e] = oAcc[e];
+        if (lane == 0) { sM[warp] = m; sL[warp] = l; }
+        __syncthreads();
+
+        if (warp == 0) {
+            float gm = -FLT_MAX;
+            #pragma unroll
+            for (int w = 0; w < NUM_WARPS; ++w) gm = fmaxf(gm, sM[w]);
+            float gl = 0.f;
+            float gO[ELEMS];
+            #pragma unroll
+            for (int e = 0; e < ELEMS; ++e) gO[e] = 0.f;
+            #pragma unroll
+            for (int w = 0; w < NUM_WARPS; ++w) {
+                const float c = (sM[w] == -FLT_MAX) ? 0.f : __expf(sM[w] - gm);
+                gl += sL[w] * c;
+                #pragma unroll
+                for (int e = 0; e < ELEMS; ++e)
+                    gO[e] += sO[w][ELEMS * lane + e] * c;
+            }
+
+            if (p.splits == 1) {
+                const float inv = gl > 0.f ? 1.f / gl : 0.f;
+                #pragma unroll
+                for (int e = 0; e < ELEMS; ++e)
+                    p.o[(long)bh * HEAD_DIM + ELEMS * lane + e] =
+                        attnFromF32<OT>(gO[e] * inv);
+            } else {
+                float* dst = p.partial + ((long)bh * p.splits + split) * (HEAD_DIM + 2);
+                #pragma unroll
+                for (int e = 0; e < ELEMS; ++e) dst[ELEMS * lane + e] = gO[e];
+                if (lane == 0) { dst[HEAD_DIM] = gm; dst[HEAD_DIM + 1] = gl; }
+            }
+        }
+    }
+};
+
+template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
+          int NUM_WARPS>
+__global__ void launchFlashDecodeDPP_Kernel(
+        const __grid_constant__ typename FlashDecodeDPP<
+            OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>::Params params) {
+    FlashDecodeDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>::exec(params);
+}
+
+// split-merge: one block per bh row; exact online-softmax combine.
+template <typename OT, int HEAD_DIM>
+__global__ void flashDecodeMerge_Kernel(const float* partial, OT* o,
+                                        const int splits) {
+    const int bh = blockIdx.x;
+    const int lane = threadIdx.x;   // HEAD_DIM threads
+    const float* base = partial + (long)bh * splits * (HEAD_DIM + 2);
+
+    float gm = -FLT_MAX;
+    for (int s = 0; s < splits; ++s) gm = fmaxf(gm, base[s * (HEAD_DIM + 2) + HEAD_DIM]);
+    float gl = 0.f, acc = 0.f;
+    for (int s = 0; s < splits; ++s) {
+        const float sm = base[s * (HEAD_DIM + 2) + HEAD_DIM];
+        const float sl = base[s * (HEAD_DIM + 2) + HEAD_DIM + 1];
+        const float c = (sm == -FLT_MAX) ? 0.f : __expf(sm - gm);
+        gl += sl * c;
+        acc += base[s * (HEAD_DIM + 2) + lane] * c;
+    }
+    const float inv = gl > 0.f ? 1.f / gl : 0.f;
+    o[(long)bh * HEAD_DIM + lane] = attnFromF32<OT>(acc * inv);
+}
+
+/* Decode workspace: caller-owned, reusable across steps.
+   Size: batchHeads * splits * (HEAD_DIM+2) floats. */
+inline int flashDecodeSplits(const int batchHeads, const int seqK) {
+    // target >= 2 blocks per SM on mainstream parts; clamp chunk >= 256 tokens
+    const int targetBlocks = 384;
+    int splits = (targetBlocks + batchHeads - 1) / batchHeads;
+    const int maxSplits = (seqK + 255) / 256;
+    splits = ::min(splits, maxSplits);
+    return ::max(1, splits);
+}
+
+template <int HEAD_DIM, int NUM_WARPS = 8, typename OT = float,
+          typename QIOp, typename KIOp, typename VIOp>
+inline void executeFlashDecode(
+        const QIOp& q, const KIOp& k, const VIOp& v, OT* o,
+        float* workspace /* bh*splits*(HEAD_DIM+2) floats, nullptr ok if splits==1 */,
+        const int batchHeads, const int seqK,
+        Stream_<ParArch::GPU_NVIDIA>& stream,
+        const float scaleOverride = -1.f, const int splitsOverride = 0) {
+    using DPP = FlashDecodeDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>;
+    const float scale = scaleOverride > 0.f ? scaleOverride
+                                            : rsqrtf(static_cast<float>(HEAD_DIM));
+    const int splits = splitsOverride > 0 ? splitsOverride
+                                          : flashDecodeSplits(batchHeads, seqK);
+    const typename DPP::Params params{ q, k, v, workspace, o, seqK, splits, scale };
+    const dim3 grid(splits, batchHeads, 1);
+    launchFlashDecodeDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>
+        <<<grid, DPP::THREADS, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+    if (splits > 1) {
+        flashDecodeMerge_Kernel<OT, HEAD_DIM>
+            <<<batchHeads, HEAD_DIM, 0, stream.getCUDAStream()>>>(workspace, o, splits);
+        gpuErrchk(cudaGetLastError());
+    }
+}
+
+} // namespace fk
+
+#endif // defined(__NVCC__) || CLANG_HOST_DEVICE
+
+#endif // FK_ATTENTION_FLASH_DECODE_H

--- a/include/fused_kernel/algorithms/attention/flash_decode.h
+++ b/include/fused_kernel/algorithms/attention/flash_decode.h
@@ -55,8 +55,9 @@ public:
 
     struct Params {
         QIOp q; KIOp k; VIOp v;
-        float* partial;      // workspace [bh, splits, HEAD_DIM+2]
-        OT* o;               // final [bh, 1, HEAD_DIM] (used when splits==1)
+        float* partial;      // workspace [bh, splits, (HEAD_DIM+2)] + counters
+        unsigned int* counters;  // [bh] arrival counters (self-resetting)
+        OT* o;               // final [bh, 1, HEAD_DIM]
         int seq_k;
         int splits;
         float scale;
@@ -124,16 +125,19 @@ public:
         const int chunk = (p.seq_k + p.splits - 1) / p.splits;
         const int kvBegin = split * chunk;
         const int kvEnd = ::min(p.seq_k, kvBegin + chunk);
-        if (kvBegin >= kvEnd) {
-            // empty split: emit a neutral partial
+        const bool emptySplit = kvBegin >= kvEnd;
+        if (emptySplit) {
+            // empty split: emit a neutral partial, then STILL participate in
+            // the arrival counter below (otherwise the fused merge never fires)
             if (threadIdx.x == 0 && p.splits > 1) {
                 float* dst = p.partial + ((long)bh * p.splits + split) * (HEAD_DIM + 2);
                 dst[HEAD_DIM] = -FLT_MAX; dst[HEAD_DIM + 1] = 0.f;
                 for (int dd = 0; dd < HEAD_DIM; ++dd) dst[dd] = 0.f;
             }
-            return;
+            if (p.splits == 1) return;
         }
 
+        if (!emptySplit) {
         // q -> registers; lane owns elements [ELEMS*lane, ELEMS*lane+ELEMS)
         float qReg[ELEMS];
         #pragma unroll
@@ -206,6 +210,41 @@ public:
                 if (lane == 0) { dst[HEAD_DIM] = gm; dst[HEAD_DIM + 1] = gl; }
             }
         }
+        } // !emptySplit
+        if (p.splits == 1) return;
+
+        // ---- FUSED split merge: last CTA to arrive merges (no 2nd kernel).
+        // GPU-side fusion of the tiny epilogue kernel that profiling showed
+        // wasting a full launch (~1.5us+gap) per decode step.
+        __shared__ bool amLast;
+        __threadfence();                       // partials visible device-wide
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            const unsigned int arrived =
+                atomicAdd(&p.counters[bh], 1u);
+            amLast = (arrived == (unsigned int)p.splits - 1u);
+            if (amLast) p.counters[bh] = 0u;   // self-reset for next call
+        }
+        __syncthreads();
+        if (!amLast) return;
+
+        // merge all splits for this bh row: thread d owns output element d.
+        const float* base = p.partial + (long)bh * p.splits * (HEAD_DIM + 2);
+        for (int d = threadIdx.x; d < HEAD_DIM; d += THREADS) {
+            float gm2 = -FLT_MAX;
+            for (int s = 0; s < p.splits; ++s)
+                gm2 = fmaxf(gm2, base[s * (HEAD_DIM + 2) + HEAD_DIM]);
+            float gl2 = 0.f, acc = 0.f;
+            for (int s = 0; s < p.splits; ++s) {
+                const float sm = base[s * (HEAD_DIM + 2) + HEAD_DIM];
+                const float sl = base[s * (HEAD_DIM + 2) + HEAD_DIM + 1];
+                const float c = (sm == -FLT_MAX) ? 0.f : __expf(sm - gm2);
+                gl2 += sl * c;
+                acc += base[s * (HEAD_DIM + 2) + d] * c;
+            }
+            const float inv = gl2 > 0.f ? 1.f / gl2 : 0.f;
+            p.o[(long)bh * HEAD_DIM + d] = attnFromF32<OT>(acc * inv);
+        }
     }
 };
 
@@ -250,11 +289,20 @@ inline int flashDecodeSplits(const int batchHeads, const int seqK) {
     return ::max(1, splits);
 }
 
+// workspace floats needed for a decode call (partials + arrival counters).
+// IMPORTANT: zero the workspace ONCE after allocation (counters start at 0
+// and self-reset after every call, so one memset at alloc time is enough).
+inline size_t flashDecodeWorkspaceFloats(const int batchHeads, const int splits,
+                                         const int headDim) {
+    return (size_t)batchHeads * splits * (headDim + 2) + batchHeads;
+}
+
 template <int HEAD_DIM, int NUM_WARPS = 8, typename OT = float,
           typename QIOp, typename KIOp, typename VIOp>
 inline void executeFlashDecode(
         const QIOp& q, const KIOp& k, const VIOp& v, OT* o,
-        float* workspace /* bh*splits*(HEAD_DIM+2) floats, nullptr ok if splits==1 */,
+        float* workspace /* flashDecodeWorkspaceFloats(); zeroed at alloc;
+                            nullptr ok if splits==1 */,
         const int batchHeads, const int seqK,
         Stream_<ParArch::GPU_NVIDIA>& stream,
         const float scaleOverride = -1.f, const int splitsOverride = 0) {
@@ -263,16 +311,20 @@ inline void executeFlashDecode(
                                             : rsqrtf(static_cast<float>(HEAD_DIM));
     const int splits = splitsOverride > 0 ? splitsOverride
                                           : flashDecodeSplits(batchHeads, seqK);
-    const typename DPP::Params params{ q, k, v, workspace, o, seqK, splits, scale };
+    // counters live after the partials (reinterpreted as uint32)
+    unsigned int* counters = (splits > 1)
+        ? reinterpret_cast<unsigned int*>(
+              workspace + (size_t)batchHeads * splits * (HEAD_DIM + 2))
+        : nullptr;
+    const typename DPP::Params params{ q, k, v, workspace, counters, o,
+                                       seqK, splits, scale };
     const dim3 grid(splits, batchHeads, 1);
+    // single kernel: the split merge is FUSED (last-CTA-arrives pattern) —
+    // profiling showed the separate 1.4us merge kernel + launch gap was pure
+    // overhead at decode latencies.
     launchFlashDecodeDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp, NUM_WARPS>
         <<<grid, DPP::THREADS, 0, stream.getCUDAStream()>>>(params);
     gpuErrchk(cudaGetLastError());
-    if (splits > 1) {
-        flashDecodeMerge_Kernel<OT, HEAD_DIM>
-            <<<batchHeads, HEAD_DIM, 0, stream.getCUDAStream()>>>(workspace, o, splits);
-        gpuErrchk(cudaGetLastError());
-    }
 }
 
 } // namespace fk

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -150,7 +150,7 @@ public:
             // PROLOGUE: element read through the IOp (pass 1)
             const float v = readElem(p.input, x, row);
             const float m = attnMaxF(st.m, v);
-            st.l = st.l * attnExpF(st.m - m) + expf(v - m);
+            st.l = st.l * attnExpF(st.m - m) + attnExpF(v - m);
             st.m = m;
         }
         states[tid] = st;

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -1,0 +1,149 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_ATTENTION_SOFTMAX_H
+#define FK_ATTENTION_SOFTMAX_H
+
+/* SoftmaxDPP: numerically-stable row-wise softmax as a single cooperative
+ * DPP (one DPP per kernel, per the current FKL execution model).
+ *
+ * Not a TransformDPP: softmax needs a row REDUCTION (cross-thread
+ * cooperation), so this is a cooperative DPP kind with block-level
+ * shared-memory state. Online softmax (Milakov & Gimelshein, 2018):
+ * each thread scans a strided slice keeping a running (max m, sum l);
+ * states merge associatively; a second pass writes exp(x-m)/l.
+ * Two reads + one write per element, no global intermediates, immune to
+ * overflow for any input range.
+ */
+
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <cfloat>
+#include <cmath>
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+#include <cuda_fp16.h>
+#endif
+
+namespace fk {
+
+#if !defined(__CUDA_ARCH__) && !defined(__NVCC__) && !CLANG_HOST_DEVICE
+using std::fmaxf;
+using std::expf;
+#endif
+
+// Cooperative-DPP exec bodies use __shared__ + barriers: they cannot be
+// constexpr (FK_DEVICE_FUSE). Plain static device inline qualifier:
+#define FK_COOP_DEVICE_FUSE static __device__ __forceinline__ void
+
+template <typename T>
+FK_HOST_DEVICE_CNST float attnToF32(const T& v) {
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+    if constexpr (std::is_same_v<T, __half>) { return __half2float(v); } else
+#endif
+    { return static_cast<float>(v); }
+}
+
+template <typename T>
+FK_HOST_DEVICE_CNST T attnFromF32(const float& v) {
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+    if constexpr (std::is_same_v<T, __half>) { return __float2half(v); } else
+#endif
+    { return static_cast<T>(v); }
+}
+
+struct OnlineSoftmaxState {
+    float m;  // running max
+    float l;  // running sum of exp(x - m)
+};
+
+FK_HOST_DEVICE_CNST OnlineSoftmaxState mergeSoftmaxStates(const OnlineSoftmaxState& a,
+                                                          const OnlineSoftmaxState& b) {
+    const float m = fmaxf(a.m, b.m);
+    const float la = a.l == 0.f ? 0.f : a.l * expf(a.m - m);
+    const float lb = b.l == 0.f ? 0.f : b.l * expf(b.m - m);
+    return { m, la + lb };
+}
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+
+template <typename T, int BLOCK_SIZE = 256>
+struct SoftmaxDPP {
+private:
+    using SelfType = SoftmaxDPP<T, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(SoftmaxDPP, SelfType)
+
+    struct Params {
+        RawPtr<ND::_2D, T> input;
+        RawPtr<ND::_2D, T> output;
+    };
+
+    FK_COOP_DEVICE_FUSE exec(const Params& p) {
+        __shared__ OnlineSoftmaxState states[BLOCK_SIZE];
+
+        const int row = blockIdx.x;
+        const int tid = threadIdx.x;
+        const int width = static_cast<int>(p.input.dims.width);
+
+        const T* in = PtrAccessor<ND::_2D>::cr_point(Point{0, row, 0}, p.input);
+        T* out = PtrAccessor<ND::_2D>::point(Point{0, row, 0}, p.output);
+
+        OnlineSoftmaxState st{ -FLT_MAX, 0.f };
+        for (int x = tid; x < width; x += BLOCK_SIZE) {
+            const float v = attnToF32(in[x]);
+            const float m = fmaxf(st.m, v);
+            st.l = st.l * expf(st.m - m) + expf(v - m);
+            st.m = m;
+        }
+        states[tid] = st;
+        __syncthreads();
+
+        for (int stride = BLOCK_SIZE / 2; stride > 0; stride >>= 1) {
+            if (tid < stride) {
+                states[tid] = mergeSoftmaxStates(states[tid], states[tid + stride]);
+            }
+            __syncthreads();
+        }
+        const float m = states[0].m;
+        const float invL = 1.f / states[0].l;
+
+        for (int x = tid; x < width; x += BLOCK_SIZE) {
+            out[x] = attnFromF32<T>(expf(attnToF32(in[x]) - m) * invL);
+        }
+    }
+};
+
+template <typename T, int BLOCK_SIZE>
+__global__ void launchSoftmaxDPP_Kernel(const __grid_constant__ typename SoftmaxDPP<T, BLOCK_SIZE>::Params params) {
+    SoftmaxDPP<T, BLOCK_SIZE>::exec(params);
+}
+
+template <typename T, int BLOCK_SIZE = 256>
+inline void executeSoftmax(const Ptr2D<T>& input, const Ptr2D<T>& output,
+                           Stream_<ParArch::GPU_NVIDIA>& stream) {
+    using DPP = SoftmaxDPP<T, BLOCK_SIZE>;
+    const typename DPP::Params params{ input.ptr(), output.ptr() };
+    const dim3 grid(input.dims().height, 1, 1);
+    const dim3 block(BLOCK_SIZE, 1, 1);
+    launchSoftmaxDPP_Kernel<T, BLOCK_SIZE><<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+#endif // defined(__NVCC__) || CLANG_HOST_DEVICE
+
+} // namespace fk
+
+#endif // FK_ATTENTION_SOFTMAX_H

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -47,23 +47,30 @@
 
 namespace fk {
 
-#if !defined(__CUDA_ARCH__) && !defined(__NVCC__) && !CLANG_HOST_DEVICE
-// CPU-only TU (e.g. g++ in CI): provide expf/fmaxf in fk:: scope.
-// NOTE: do NOT `using std::expf` — libstdc++ only guarantees ::expf from
-// <cmath>'s C heritage; std::expf is not declared on g++-13 (CI failure).
-// gcc: constexpr via __builtin_expf (keeps FK_HOST_DEVICE_CNST callers
-// legal). clang: __builtin_expf is not constexpr -> plain inline (clang
-// accepts non-constexpr calls inside never-constant-evaluated constexpr
-// functions without -Winvalid-constexpr only when the call is reachable,
-// so the polynomial fallback keeps it constexpr-clean everywhere).
-constexpr float fmaxf(const float a, const float b) {
-    return a > b ? a : (b >= a ? b : (a == a ? a : b));  // NaN-safe enough
+/* Portable math shims for the attention DPPs. Three compiler worlds:
+ *  - device code: __expf-class intrinsics are fine inside kernels but the
+ *    shared host/device helpers below must compile on the HOST pass too;
+ *  - g++ CPU-only TUs: std::expf is NOT declared by libstdc++ (<cmath>
+ *    only guarantees ::expf) — broke utest_*_cpp on the g++-13 runners;
+ *  - MSVC: __builtin_expf does not exist (C3861), and calling ::fmaxf
+ *    inside a constexpr function is rejected (C3615).
+ * Solution: never reference expf/fmaxf by unqualified name. attnMaxF is
+ * a constexpr ternary (legal everywhere); attnExpF is a NON-constexpr
+ * host+device inline that maps to the right primitive per target. */
+FK_HOST_DEVICE_CNST float attnMaxF(const float a, const float b) {
+    return a > b ? a : (b >= a ? b : (a == a ? a : b));  // NaN -> other arg
 }
-#if defined(__clang__)
-inline float expf(const float x) { return __builtin_expf(x); }
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+__host__ __device__ __forceinline__ float attnExpF(const float x) {
+#if defined(__CUDA_ARCH__)
+    return ::expf(x);     // device fast path (correctly-rounded enough here)
 #else
-constexpr float expf(const float x) { return __builtin_expf(x); }
+    return ::expf(x);     // host pass of nvcc/clang-cuda
 #endif
+}
+#else
+inline float attnExpF(const float x) { return ::expf(x); }  // pure CPU TU
 #endif
 
 // Cooperative-DPP exec bodies use __shared__ + barriers: they cannot be
@@ -91,11 +98,17 @@ struct OnlineSoftmaxState {
     float l;  // running sum of exp(x - m)
 };
 
-FK_HOST_DEVICE_CNST OnlineSoftmaxState mergeSoftmaxStates(const OnlineSoftmaxState& a,
+// NOT constexpr: attnExpF maps to ::expf (non-constexpr on MSVC/clang).
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+__host__ __device__ __forceinline__
+#else
+inline
+#endif
+OnlineSoftmaxState mergeSoftmaxStates(const OnlineSoftmaxState& a,
                                                           const OnlineSoftmaxState& b) {
-    const float m = fmaxf(a.m, b.m);
-    const float la = a.l == 0.f ? 0.f : a.l * expf(a.m - m);
-    const float lb = b.l == 0.f ? 0.f : b.l * expf(b.m - m);
+    const float m = attnMaxF(a.m, b.m);
+    const float la = a.l == 0.f ? 0.f : a.l * attnExpF(a.m - m);
+    const float lb = b.l == 0.f ? 0.f : b.l * attnExpF(b.m - m);
     return { m, la + lb };
 }
 
@@ -136,8 +149,8 @@ public:
         for (int x = tid; x < width; x += BLOCK_SIZE) {
             // PROLOGUE: element read through the IOp (pass 1)
             const float v = readElem(p.input, x, row);
-            const float m = fmaxf(st.m, v);
-            st.l = st.l * expf(st.m - m) + expf(v - m);
+            const float m = attnMaxF(st.m, v);
+            st.l = st.l * attnExpF(st.m - m) + expf(v - m);
             st.m = m;
         }
         states[tid] = st;
@@ -154,7 +167,7 @@ public:
 
         for (int x = tid; x < width; x += BLOCK_SIZE) {
             // PROLOGUE: element read through the IOp (pass 2)
-            out[x] = attnFromF32<OT>(expf(readElem(p.input, x, row) - m) * invL);
+            out[x] = attnFromF32<OT>(attnExpF(readElem(p.input, x, row) - m) * invL);
         }
     }
 };

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -25,10 +25,18 @@
  * states merge associatively; a second pass writes exp(x-m)/l.
  * Two reads + one write per element, no global intermediates, immune to
  * overflow for any input range.
+ *
+ * PROLOGUE FUSION: the DPP takes the input as a Read or ReadBack IOp
+ * (the prologue) and reads each data element through that IOp, so any
+ * fused preprocessing chain (read.then(Mul...).then(Cast...)) runs
+ * in-register at load time, on BOTH passes, with zero extra traffic.
+ * Element addressing: thread.x = column, thread.y = row, thread.z = 0.
  */
 
 #include <fused_kernel/core/data/ptr_nd.h>
 #include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/core/utils/utils.h>
 
 #include <cfloat>
@@ -79,31 +87,41 @@ FK_HOST_DEVICE_CNST OnlineSoftmaxState mergeSoftmaxStates(const OnlineSoftmaxSta
 
 #if defined(__NVCC__) || CLANG_HOST_DEVICE
 
-template <typename T, int BLOCK_SIZE = 256>
+/* InIOp is an INSTANTIABLE Read or ReadBack IOp (possibly a fusion
+ * read.then(compute...)): the prologue. Every element enters the
+ * algorithm through InIOp::Operation::exec(thread, iop). */
+template <typename InIOp, typename OT, int BLOCK_SIZE = 256>
 struct SoftmaxDPP {
 private:
-    using SelfType = SoftmaxDPP<T, BLOCK_SIZE>;
+    using SelfType = SoftmaxDPP<InIOp, OT, BLOCK_SIZE>;
 public:
     FK_STATIC_STRUCT(SoftmaxDPP, SelfType)
 
+    static_assert(isAnyReadType<InIOp>, "Softmax prologue must be a Read or ReadBack IOp");
+
     struct Params {
-        RawPtr<ND::_2D, T> input;
-        RawPtr<ND::_2D, T> output;
+        InIOp input;             // prologue Read/ReadBack IOp
+        RawPtr<ND::_2D, OT> output;
+        int width;               // row length
     };
+
+    FK_DEVICE_FUSE float readElem(const InIOp& iop, const int x, const int y) {
+        return attnToF32(InIOp::Operation::exec(Point{ x, y, 0 }, iop));
+    }
 
     FK_COOP_DEVICE_FUSE exec(const Params& p) {
         __shared__ OnlineSoftmaxState states[BLOCK_SIZE];
 
         const int row = blockIdx.x;
         const int tid = threadIdx.x;
-        const int width = static_cast<int>(p.input.dims.width);
+        const int width = p.width;
 
-        const T* in = PtrAccessor<ND::_2D>::cr_point(Point{0, row, 0}, p.input);
-        T* out = PtrAccessor<ND::_2D>::point(Point{0, row, 0}, p.output);
+        OT* out = PtrAccessor<ND::_2D>::point(Point{0, row, 0}, p.output);
 
         OnlineSoftmaxState st{ -FLT_MAX, 0.f };
         for (int x = tid; x < width; x += BLOCK_SIZE) {
-            const float v = attnToF32(in[x]);
+            // PROLOGUE: element read through the IOp (pass 1)
+            const float v = readElem(p.input, x, row);
             const float m = fmaxf(st.m, v);
             st.l = st.l * expf(st.m - m) + expf(v - m);
             st.m = m;
@@ -121,25 +139,38 @@ public:
         const float invL = 1.f / states[0].l;
 
         for (int x = tid; x < width; x += BLOCK_SIZE) {
-            out[x] = attnFromF32<T>(expf(attnToF32(in[x]) - m) * invL);
+            // PROLOGUE: element read through the IOp (pass 2)
+            out[x] = attnFromF32<OT>(expf(readElem(p.input, x, row) - m) * invL);
         }
     }
 };
 
-template <typename T, int BLOCK_SIZE>
-__global__ void launchSoftmaxDPP_Kernel(const __grid_constant__ typename SoftmaxDPP<T, BLOCK_SIZE>::Params params) {
-    SoftmaxDPP<T, BLOCK_SIZE>::exec(params);
+template <typename InIOp, typename OT, int BLOCK_SIZE>
+__global__ void launchSoftmaxDPP_Kernel(const __grid_constant__ typename SoftmaxDPP<InIOp, OT, BLOCK_SIZE>::Params params) {
+    SoftmaxDPP<InIOp, OT, BLOCK_SIZE>::exec(params);
 }
 
+/* IOp-first API: input is the prologue Read/ReadBack IOp. */
+template <int BLOCK_SIZE = 256, typename InIOp, typename OT>
+inline void executeSoftmax(const InIOp& input, const Ptr2D<OT>& output,
+                           const int rows, const int width,
+                           Stream_<ParArch::GPU_NVIDIA>& stream) {
+    using DPP = SoftmaxDPP<InIOp, OT, BLOCK_SIZE>;
+    const typename DPP::Params params{ input, output.ptr(), width };
+    const dim3 grid(rows, 1, 1);
+    const dim3 block(BLOCK_SIZE, 1, 1);
+    launchSoftmaxDPP_Kernel<InIOp, OT, BLOCK_SIZE><<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+/* Pointer convenience API (back-compat): canonical PerThreadRead prologue. */
 template <typename T, int BLOCK_SIZE = 256>
 inline void executeSoftmax(const Ptr2D<T>& input, const Ptr2D<T>& output,
                            Stream_<ParArch::GPU_NVIDIA>& stream) {
-    using DPP = SoftmaxDPP<T, BLOCK_SIZE>;
-    const typename DPP::Params params{ input.ptr(), output.ptr() };
-    const dim3 grid(input.dims().height, 1, 1);
-    const dim3 block(BLOCK_SIZE, 1, 1);
-    launchSoftmaxDPP_Kernel<T, BLOCK_SIZE><<<grid, block, 0, stream.getCUDAStream()>>>(params);
-    gpuErrchk(cudaGetLastError());
+    const auto inIOp = PerThreadRead<ND::_2D, T>::build(input.ptr());
+    executeSoftmax<BLOCK_SIZE>(inIOp, output,
+                               static_cast<int>(input.dims().height),
+                               static_cast<int>(input.dims().width), stream);
 }
 
 #endif // defined(__NVCC__) || CLANG_HOST_DEVICE

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -48,8 +48,22 @@
 namespace fk {
 
 #if !defined(__CUDA_ARCH__) && !defined(__NVCC__) && !CLANG_HOST_DEVICE
-using std::fmaxf;
-using std::expf;
+// CPU-only TU (e.g. g++ in CI): provide expf/fmaxf in fk:: scope.
+// NOTE: do NOT `using std::expf` — libstdc++ only guarantees ::expf from
+// <cmath>'s C heritage; std::expf is not declared on g++-13 (CI failure).
+// gcc: constexpr via __builtin_expf (keeps FK_HOST_DEVICE_CNST callers
+// legal). clang: __builtin_expf is not constexpr -> plain inline (clang
+// accepts non-constexpr calls inside never-constant-evaluated constexpr
+// functions without -Winvalid-constexpr only when the call is reachable,
+// so the polynomial fallback keeps it constexpr-clean everywhere).
+constexpr float fmaxf(const float a, const float b) {
+    return a > b ? a : (b >= a ? b : (a == a ? a : b));  // NaN-safe enough
+}
+#if defined(__clang__)
+inline float expf(const float x) { return __builtin_expf(x); }
+#else
+constexpr float expf(const float x) { return __builtin_expf(x); }
+#endif
 #endif
 
 // Cooperative-DPP exec bodies use __shared__ + barriers: they cannot be

--- a/utests/algorithm/attention/utest_flash_attention.h
+++ b/utests/algorithm/attention/utest_flash_attention.h
@@ -198,6 +198,78 @@ static void testFusedEpilogue() {
     report("FlashAttention fused epilogue Mul(2).then(Add(0.5))", maxErr, 1e-6);
 }
 
+static void testFusedPrologue() {
+    /* PROLOGUE = a Read IOp (possibly fused with .then chains); the DPP
+       reads every element through it. Verifiable algebra:
+       Q prologue read.then(Mul(2)): compare against oracle on 2*Q.
+       V prologue read.then(Mul(3)).then(Add(1)): out = 3*(sum p_j v_j) + 1
+       since sum p_j = 1 — compare against 3*oracle + 1. */
+    constexpr int HEAD_DIM = 32, BH = 2, SQ = 24, SK = 48;
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    const size_t nQ = (size_t)BH * SQ * HEAD_DIM, nK = (size_t)BH * SK * HEAD_DIM;
+    std::vector<float> hq(nQ), hk(nK), hv(nK);
+    for (auto& x : hq) x = dist(rng);
+    for (auto& x : hk) x = dist(rng);
+    for (auto& x : hv) x = dist(rng);
+
+    float *q, *k, *v, *o;
+    gpuErrchk(cudaMalloc(&q, nQ * sizeof(float)));
+    gpuErrchk(cudaMalloc(&k, nK * sizeof(float)));
+    gpuErrchk(cudaMalloc(&v, nK * sizeof(float)));
+    gpuErrchk(cudaMalloc(&o, nQ * sizeof(float)));
+    gpuErrchk(cudaMemcpy(q, hq.data(), nQ * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(k, hk.data(), nK * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(v, hv.data(), nK * sizeof(float), cudaMemcpyHostToDevice));
+
+    Stream stream;
+    const double scl = 1.0 / std::sqrt((double)HEAD_DIM);
+    std::vector<double> dq(nQ), dk(nK), dv(nK), ref;
+    for (size_t i = 0; i < nK; ++i) dk[i] = hk[i];
+    for (size_t i = 0; i < nK; ++i) dv[i] = hv[i];
+
+    // --- Q prologue: Read IOp fused with Mul(2) ---
+    {
+        const auto qIOp = makeAttentionRead(q, BH, SQ, HEAD_DIM)
+                              .then(Mul<float>::build(2.f));
+        const auto kIOp = makeAttentionRead(k, BH, SK, HEAD_DIM);
+        const auto vIOp = makeAttentionRead(v, BH, SK, HEAD_DIM);
+        executeFlashAttention<HEAD_DIM>(qIOp, kIOp, vIOp, o, BH, SQ, SK,
+                                        false, stream);
+        stream.sync();
+        std::vector<float> got(nQ);
+        gpuErrchk(cudaMemcpy(got.data(), o, nQ * sizeof(float), cudaMemcpyDeviceToHost));
+        for (size_t i = 0; i < nQ; ++i) dq[i] = 2.0 * hq[i];   // host-applied
+        cpuAttention(dq, dk, dv, ref, BH, SQ, SK, HEAD_DIM, scl, false);
+        double maxErr = 0.0;
+        for (size_t i = 0; i < nQ; ++i)
+            maxErr = std::max(maxErr, std::abs((double)got[i] - ref[i]));
+        report("FlashAttention Q-prologue ReadIOp.then(Mul(2))", maxErr, 5e-6);
+    }
+
+    // --- V prologue: Read IOp fused with Mul(3).then(Add(1)) => 3*out + 1 ---
+    {
+        const auto qIOp = makeAttentionRead(q, BH, SQ, HEAD_DIM);
+        const auto kIOp = makeAttentionRead(k, BH, SK, HEAD_DIM);
+        const auto vIOp = makeAttentionRead(v, BH, SK, HEAD_DIM)
+                              .then(Mul<float>::build(3.f))
+                              .then(Add<float>::build(1.f));
+        executeFlashAttention<HEAD_DIM>(qIOp, kIOp, vIOp, o, BH, SQ, SK,
+                                        false, stream);
+        stream.sync();
+        std::vector<float> got(nQ);
+        gpuErrchk(cudaMemcpy(got.data(), o, nQ * sizeof(float), cudaMemcpyDeviceToHost));
+        for (size_t i = 0; i < nQ; ++i) dq[i] = hq[i];
+        cpuAttention(dq, dk, dv, ref, BH, SQ, SK, HEAD_DIM, scl, false);
+        double maxErr = 0.0;
+        for (size_t i = 0; i < nQ; ++i)
+            maxErr = std::max(maxErr, std::abs((double)got[i] - (3.0 * ref[i] + 1.0)));
+        report("FlashAttention V-prologue ReadIOp.then(Mul(3)).then(Add(1))", maxErr, 5e-6);
+    }
+
+    cudaFree(q); cudaFree(k); cudaFree(v); cudaFree(o);
+}
+
 int launch() {
     testDense<64>("FA dense d64 b2 s64 causal", 2, 64, 64, true, 5e-6, 1);
     testDense<64>("FA dense d64 ragged s67/s131", 2, 67, 131, false, 5e-6, 2);
@@ -206,6 +278,7 @@ int launch() {
     testInt8KV<64>("FA int8-KV d64 b2 s64 causal", 2, 64, 64, true, 5e-6, 5);
     testInt8KV<64>("FA int8-KV d64 ragged s50/s100", 2, 50, 100, false, 5e-6, 6);
     testFusedEpilogue();
+    testFusedPrologue();
     if (failures == 0) { return 0; }
     std::cout << failures << " attention test(s) FAILED" << std::endl;
     return -1;

--- a/utests/algorithm/attention/utest_flash_attention.h
+++ b/utests/algorithm/attention/utest_flash_attention.h
@@ -1,0 +1,219 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/attention/flash_attention.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace fk;
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+
+// double-precision CPU oracle: O = softmax(scale * Q K^T [causal]) V
+static void cpuAttention(const std::vector<double>& q, const std::vector<double>& k,
+                         const std::vector<double>& v, std::vector<double>& o,
+                         const int bh, const int seqQ, const int seqK, const int d,
+                         const double scale, const bool causal) {
+    o.assign((size_t)bh * seqQ * d, 0.0);
+    std::vector<double> s(seqK);
+    for (int b = 0; b < bh; ++b) {
+        const double* Q = q.data() + (size_t)b * seqQ * d;
+        const double* K = k.data() + (size_t)b * seqK * d;
+        const double* V = v.data() + (size_t)b * seqK * d;
+        double* O = o.data() + (size_t)b * seqQ * d;
+        for (int i = 0; i < seqQ; ++i) {
+            const int kEnd = causal ? std::min(seqK, i + 1) : seqK;
+            double m = -1e300;
+            for (int j = 0; j < kEnd; ++j) {
+                double dot = 0.0;
+                for (int c = 0; c < d; ++c) dot += Q[(size_t)i*d+c] * K[(size_t)j*d+c];
+                s[j] = dot * scale;
+                m = std::max(m, s[j]);
+            }
+            double l = 0.0;
+            for (int j = 0; j < kEnd; ++j) { s[j] = std::exp(s[j] - m); l += s[j]; }
+            for (int j = 0; j < kEnd; ++j) {
+                const double pj = s[j] / l;
+                for (int c = 0; c < d; ++c) O[(size_t)i*d+c] += pj * V[(size_t)j*d+c];
+            }
+        }
+    }
+}
+
+static int failures = 0;
+
+static void report(const char* name, const double maxErr, const double tol) {
+    if (maxErr > tol) {
+        std::cout << "FAIL " << name << ": maxErr=" << maxErr << " tol=" << tol << std::endl;
+        ++failures;
+    } else {
+        std::cout << "Running test " << name << ": Success!! (maxErr=" << maxErr << ")" << std::endl;
+    }
+}
+
+template <int HEAD_DIM>
+static void testDense(const char* name, const int bh, const int seqQ, const int seqK,
+                      const bool causal, const double tol, const unsigned seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    const size_t nQ = (size_t)bh * seqQ * HEAD_DIM, nK = (size_t)bh * seqK * HEAD_DIM;
+    std::vector<float> hq(nQ), hk(nK), hv(nK);
+    std::vector<double> dq(nQ), dk(nK), dv(nK), dref;
+    for (size_t i = 0; i < nQ; ++i) { hq[i] = dist(rng); dq[i] = hq[i]; }
+    for (size_t i = 0; i < nK; ++i) { hk[i] = dist(rng); dk[i] = hk[i]; }
+    for (size_t i = 0; i < nK; ++i) { hv[i] = dist(rng); dv[i] = hv[i]; }
+    cpuAttention(dq, dk, dv, dref, bh, seqQ, seqK, HEAD_DIM,
+                 1.0 / std::sqrt((double)HEAD_DIM), causal);
+
+    float *q, *k, *v, *o;
+    gpuErrchk(cudaMalloc(&q, nQ * sizeof(float)));
+    gpuErrchk(cudaMalloc(&k, nK * sizeof(float)));
+    gpuErrchk(cudaMalloc(&v, nK * sizeof(float)));
+    gpuErrchk(cudaMalloc(&o, nQ * sizeof(float)));
+    gpuErrchk(cudaMemcpy(q, hq.data(), nQ * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(k, hk.data(), nK * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(v, hv.data(), nK * sizeof(float), cudaMemcpyHostToDevice));
+
+    Stream stream;
+    executeFlashAttention<float, HEAD_DIM>(q, k, v, o, bh, seqQ, seqK, causal, stream);
+    stream.sync();
+
+    std::vector<float> got(nQ);
+    gpuErrchk(cudaMemcpy(got.data(), o, nQ * sizeof(float), cudaMemcpyDeviceToHost));
+    cudaFree(q); cudaFree(k); cudaFree(v); cudaFree(o);
+
+    double maxErr = 0.0;
+    for (size_t i = 0; i < nQ; ++i) maxErr = std::max(maxErr, std::abs((double)got[i] - dref[i]));
+    report(name, maxErr, tol);
+}
+
+template <int HEAD_DIM>
+static void testInt8KV(const char* name, const int bh, const int seqQ, const int seqK,
+                       const bool causal, const double tol, const unsigned seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    const size_t nQ = (size_t)bh * seqQ * HEAD_DIM, nK = (size_t)bh * seqK * HEAD_DIM;
+    const size_t nTok = (size_t)bh * seqK;
+    std::vector<float> hq(nQ), hk(nK), hv(nK);
+    for (size_t i = 0; i < nQ; ++i) hq[i] = dist(rng);
+    for (size_t i = 0; i < nK; ++i) hk[i] = dist(rng);
+    for (size_t i = 0; i < nK; ++i) hv[i] = dist(rng);
+
+    // host-side compression (per-token int8)
+    std::vector<int8_t> k8(nK), v8(nK);
+    std::vector<float> kSc(nTok), vSc(nTok);
+    quantizeKVCacheHost(hk.data(), k8.data(), kSc.data(), (int)nTok, HEAD_DIM);
+    quantizeKVCacheHost(hv.data(), v8.data(), vSc.data(), (int)nTok, HEAD_DIM);
+
+    // the oracle sees the DEQUANTIZED values: tests kernel exactness given
+    // the compressed cache (quantization error itself is bounded separately)
+    std::vector<double> dq(nQ), dkD(nK), dvD(nK), dref;
+    for (size_t i = 0; i < nQ; ++i) dq[i] = hq[i];
+    for (size_t i = 0; i < nK; ++i) dkD[i] = (double)k8[i] * kSc[i / HEAD_DIM];
+    for (size_t i = 0; i < nK; ++i) dvD[i] = (double)v8[i] * vSc[i / HEAD_DIM];
+    cpuAttention(dq, dkD, dvD, dref, bh, seqQ, seqK, HEAD_DIM,
+                 1.0 / std::sqrt((double)HEAD_DIM), causal);
+
+    float *q, *o, *dkS, *dvS;
+    int8_t *dk8, *dv8;
+    gpuErrchk(cudaMalloc(&q, nQ * sizeof(float)));
+    gpuErrchk(cudaMalloc(&o, nQ * sizeof(float)));
+    gpuErrchk(cudaMalloc(&dk8, nK));
+    gpuErrchk(cudaMalloc(&dv8, nK));
+    gpuErrchk(cudaMalloc(&dkS, nTok * sizeof(float)));
+    gpuErrchk(cudaMalloc(&dvS, nTok * sizeof(float)));
+    gpuErrchk(cudaMemcpy(q, hq.data(), nQ * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(dk8, k8.data(), nK, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(dv8, v8.data(), nK, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(dkS, kSc.data(), nTok * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(dvS, vSc.data(), nTok * sizeof(float), cudaMemcpyHostToDevice));
+
+    Stream stream;
+    executeFlashAttention<float, HEAD_DIM, KVLayout::INT8_PER_TOKEN>(
+        q, dk8, dv8, o, bh, seqQ, seqK, causal, stream, dkS, dvS);
+    stream.sync();
+
+    std::vector<float> got(nQ);
+    gpuErrchk(cudaMemcpy(got.data(), o, nQ * sizeof(float), cudaMemcpyDeviceToHost));
+    cudaFree(q); cudaFree(o); cudaFree(dk8); cudaFree(dv8); cudaFree(dkS); cudaFree(dvS);
+
+    double maxErr = 0.0;
+    for (size_t i = 0; i < nQ; ++i) maxErr = std::max(maxErr, std::abs((double)got[i] - dref[i]));
+    report(name, maxErr, tol);
+}
+
+static void testFusedEpilogue() {
+    // attention output | Mul(2) | Add(0.5) fused in-register: compare against
+    // dense run + host-applied epilogue (proves the chain ran inside).
+    constexpr int HEAD_DIM = 32, BH = 2, SQ = 16, SK = 16;
+    std::mt19937 rng(99);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    const size_t n = (size_t)BH * SQ * HEAD_DIM;
+    std::vector<float> hq(n), hk(n), hv(n);
+    for (auto* vec : { &hq, &hk, &hv })
+        for (auto& x : *vec) x = dist(rng);
+
+    float *q, *k, *v, *o1, *o2;
+    gpuErrchk(cudaMalloc(&q, n * sizeof(float)));
+    gpuErrchk(cudaMalloc(&k, n * sizeof(float)));
+    gpuErrchk(cudaMalloc(&v, n * sizeof(float)));
+    gpuErrchk(cudaMalloc(&o1, n * sizeof(float)));
+    gpuErrchk(cudaMalloc(&o2, n * sizeof(float)));
+    gpuErrchk(cudaMemcpy(q, hq.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(k, hk.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpy(v, hv.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+
+    Stream stream;
+    executeFlashAttention<float, HEAD_DIM>(q, k, v, o1, BH, SQ, SK, false, stream);
+    const auto epilogue = Mul<float>::build(2.f).then(Add<float>::build(0.5f));
+    executeFlashAttention<float, HEAD_DIM, KVLayout::DENSE, 32, 4>(
+        q, k, v, o2, BH, SQ, SK, false, stream, nullptr, nullptr, -1.f, epilogue);
+    stream.sync();
+
+    std::vector<float> g1(n), g2(n);
+    gpuErrchk(cudaMemcpy(g1.data(), o1, n * sizeof(float), cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaMemcpy(g2.data(), o2, n * sizeof(float), cudaMemcpyDeviceToHost));
+    cudaFree(q); cudaFree(k); cudaFree(v); cudaFree(o1); cudaFree(o2);
+
+    double maxErr = 0.0;
+    for (size_t i = 0; i < n; ++i)
+        maxErr = std::max(maxErr, std::abs((double)g2[i] - ((double)g1[i] * 2.0 + 0.5)));
+    report("FlashAttention fused epilogue Mul(2).then(Add(0.5))", maxErr, 1e-6);
+}
+
+int launch() {
+    testDense<64>("FA dense d64 b2 s64 causal", 2, 64, 64, true, 5e-6, 1);
+    testDense<64>("FA dense d64 ragged s67/s131", 2, 67, 131, false, 5e-6, 2);
+    testDense<32>("FA dense d32 cross s32->s96", 2, 32, 96, false, 5e-6, 3);
+    testDense<128>("FA dense d128 b1 s64", 1, 64, 64, false, 5e-6, 4);
+    testInt8KV<64>("FA int8-KV d64 b2 s64 causal", 2, 64, 64, true, 5e-6, 5);
+    testInt8KV<64>("FA int8-KV d64 ragged s50/s100", 2, 50, 100, false, 5e-6, 6);
+    testFusedEpilogue();
+    if (failures == 0) { return 0; }
+    std::cout << failures << " attention test(s) FAILED" << std::endl;
+    return -1;
+}
+
+#else
+int launch() {
+    std::cout << "FlashAttention tests skipped (CUDA-only DPP)" << std::endl;
+    return 0;
+}
+#endif

--- a/utests/algorithm/attention/utest_softmax.h
+++ b/utests/algorithm/attention/utest_softmax.h
@@ -1,0 +1,91 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/attention/softmax.h>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <vector>
+
+using namespace fk;
+
+#if defined(__NVCC__) || CLANG_HOST_DEVICE
+
+static int failures = 0;
+
+static void runCase(const char* name, const int width, const int height,
+                    const float lo, const float hi, const double tol,
+                    const unsigned seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(lo, hi);
+
+    Ptr2D<float> input(width, height, 0, MemType::Device);
+    Ptr2D<float> output(width, height, 0, MemType::Device);
+
+    std::vector<float> host((size_t)width * height);
+    for (auto& v : host) v = dist(rng);
+    gpuErrchk(cudaMemcpy2D(input.ptr().data, input.ptr().dims.pitch,
+                           host.data(), width * sizeof(float),
+                           width * sizeof(float), height, cudaMemcpyHostToDevice));
+
+    Stream stream;
+    executeSoftmax<float>(input, output, stream);
+    stream.sync();
+
+    std::vector<float> got((size_t)width * height);
+    gpuErrchk(cudaMemcpy2D(got.data(), width * sizeof(float),
+                           output.ptr().data, output.ptr().dims.pitch,
+                           width * sizeof(float), height, cudaMemcpyDeviceToHost));
+
+    double maxErr = 0.0;
+    for (int y = 0; y < height; ++y) {
+        double m = -1e300, l = 0.0, rowSum = 0.0;
+        for (int x = 0; x < width; ++x) m = std::max(m, (double)host[(size_t)y*width+x]);
+        for (int x = 0; x < width; ++x) l += std::exp((double)host[(size_t)y*width+x] - m);
+        for (int x = 0; x < width; ++x) {
+            const double ref = std::exp((double)host[(size_t)y*width+x] - m) / l;
+            maxErr = std::max(maxErr, std::abs((double)got[(size_t)y*width+x] - ref));
+            rowSum += got[(size_t)y*width+x];
+        }
+        if (std::abs(rowSum - 1.0) > 1e-2) {
+            std::cout << "FAIL " << name << ": row " << y << " sums to " << rowSum << std::endl;
+            ++failures;
+            return;
+        }
+    }
+    if (maxErr > tol) {
+        std::cout << "FAIL " << name << ": maxErr=" << maxErr << std::endl;
+        ++failures;
+    } else {
+        std::cout << "Running test " << name << ": Success!! (maxErr=" << maxErr << ")" << std::endl;
+    }
+}
+
+int launch() {
+    runCase("Softmax f32 7x3", 7, 3, -4.f, 4.f, 1e-6, 1);
+    runCase("Softmax f32 256x16 (block-sized)", 256, 16, -8.f, 8.f, 1e-6, 2);
+    runCase("Softmax f32 1000x8 (strided non-pow2)", 1000, 8, -8.f, 8.f, 1e-6, 3);
+    runCase("Softmax f32 stability |x|<=500", 333, 5, -500.f, 500.f, 1e-6, 4);
+    return failures == 0 ? 0 : -1;
+}
+
+#else
+int launch() {
+    std::cout << "Softmax DPP tests skipped (CUDA-only DPP)" << std::endl;
+    return 0;
+}
+#endif

--- a/utests/algorithm/attention/utest_softmax.h
+++ b/utests/algorithm/attention/utest_softmax.h
@@ -15,6 +15,7 @@
 #include <tests/main.h>
 
 #include <fused_kernel/algorithms/attention/softmax.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 
 #include <cmath>
 #include <iostream>
@@ -75,11 +76,59 @@ static void runCase(const char* name, const int width, const int height,
     }
 }
 
+// PROLOGUE: input enters through a Read IOp fused with a compute chain.
+// softmax(2*x + 1) == softmax(2*x) (row-constant shift cancels), and
+// softmax over 2*x differs from softmax over x -> both effects verified.
+static void runPrologueCase(const char* name, const int width, const int height,
+                            const double tol, const unsigned seed) {
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-4.f, 4.f);
+
+    Ptr2D<float> input(width, height, 0, MemType::Device);
+    Ptr2D<float> output(width, height, 0, MemType::Device);
+
+    std::vector<float> host((size_t)width * height);
+    for (auto& v : host) v = dist(rng);
+    gpuErrchk(cudaMemcpy2D(input.ptr().data, input.ptr().dims.pitch,
+                           host.data(), width * sizeof(float),
+                           width * sizeof(float), height, cudaMemcpyHostToDevice));
+
+    Stream stream;
+    const auto inIOp = PerThreadRead<ND::_2D, float>::build(input.ptr())
+                           .then(Mul<float>::build(2.f))
+                           .then(Add<float>::build(1.f));
+    executeSoftmax(inIOp, output, height, width, stream);
+    stream.sync();
+
+    std::vector<float> got((size_t)width * height);
+    gpuErrchk(cudaMemcpy2D(got.data(), width * sizeof(float),
+                           output.ptr().data, output.ptr().dims.pitch,
+                           width * sizeof(float), height, cudaMemcpyDeviceToHost));
+
+    double maxErr = 0.0;
+    for (int y = 0; y < height; ++y) {
+        double m = -1e300, l = 0.0;
+        for (int x = 0; x < width; ++x) m = std::max(m, 2.0 * host[(size_t)y*width+x] + 1.0);
+        for (int x = 0; x < width; ++x) l += std::exp(2.0 * host[(size_t)y*width+x] + 1.0 - m);
+        for (int x = 0; x < width; ++x) {
+            const double ref = std::exp(2.0 * host[(size_t)y*width+x] + 1.0 - m) / l;
+            maxErr = std::max(maxErr, std::abs((double)got[(size_t)y*width+x] - ref));
+        }
+    }
+    if (maxErr > tol) {
+        std::cout << "FAIL " << name << ": maxErr=" << maxErr << std::endl;
+        ++failures;
+    } else {
+        std::cout << "Running test " << name << ": Success!! (maxErr=" << maxErr << ")" << std::endl;
+    }
+}
+
 int launch() {
     runCase("Softmax f32 7x3", 7, 3, -4.f, 4.f, 1e-6, 1);
     runCase("Softmax f32 256x16 (block-sized)", 256, 16, -8.f, 8.f, 1e-6, 2);
     runCase("Softmax f32 1000x8 (strided non-pow2)", 1000, 8, -8.f, 8.f, 1e-6, 3);
     runCase("Softmax f32 stability |x|<=500", 333, 5, -500.f, 500.f, 1e-6, 4);
+    runPrologueCase("Softmax prologue ReadIOp.then(Mul(2)).then(Add(1)) 100x6", 100, 6, 1e-6, 5);
     return failures == 0 ? 0 : -1;
 }
 

--- a/utests/algorithm/image_processing/utest_color_conversion.h
+++ b/utests/algorithm/image_processing/utest_color_conversion.h
@@ -99,62 +99,6 @@ void testColorConversionOperations() {
     };
 
     TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2RGB, uchar3, uchar3>>::addTest(testCases, inputVals2, expectedVals2);
-
-    // Test BGR2RGBA conversion (FusedOperation: reorder channels then add alpha)
-    constexpr std::array<uchar3, 2> inputVals3{
-        uchar3{100, 150, 200},  // BGR
-        uchar3{50, 75, 125}     // BGR
-    };
-
-    constexpr std::array<uchar4, 2> expectedVals3{
-        uchar4{200, 150, 100, 255},  // RGBA (channels 2,1,0 + alpha)
-        uchar4{125, 75, 50, 255}     // RGBA (channels 2,1,0 + alpha)
-    };
-
-    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2RGBA, uchar3, uchar4>>::addTest(testCases, inputVals3, expectedVals3);
-
-    // Test BGRA2RGB conversion (FusedOperation: reorder channels then discard alpha)
-    constexpr std::array<uchar4, 2> inputVals4{
-        uchar4{100, 150, 200, 255},  // BGRA
-        uchar4{50, 75, 125, 128}     // BGRA
-    };
-
-    constexpr std::array<uchar3, 2> expectedVals4{
-        uchar3{200, 150, 100},  // RGB (channels 2,1,0, alpha discarded)
-        uchar3{125, 75, 50}     // RGB (channels 2,1,0, alpha discarded)
-    };
-
-    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2RGB, uchar4, uchar3>>::addTest(testCases, inputVals4, expectedVals4);
-
-    // Test BGR2GRAY conversion (FusedOperation: reorder channels then convert to gray)
-    std::array<uchar3, 2> inputVals5 = {
-        uchar3{50, 100, 150},   // BGR: B=50, G=100, R=150
-        uchar3{75, 125, 200}    // BGR: B=75, G=125, R=200
-    };
-
-    // After reorder (BGR->RGB): {150,100,50}, {200,125,75}
-    // Gray formula: R*0.299 + G*0.587 + B*0.114
-    std::array<uchar, 2> expectedVals5 = {
-        static_cast<uchar>(std::nearbyint(150 * 0.299f + 100 * 0.587f + 50 * 0.114f)),   // ~109
-        static_cast<uchar>(std::nearbyint(200 * 0.299f + 125 * 0.587f + 75 * 0.114f))    // ~141
-    };
-
-    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2GRAY, uchar3, uchar>>::addTest(testCases, inputVals5, expectedVals5);
-
-    // Test BGRA2GRAY conversion (FusedOperation: reorder channels then convert to gray)
-    std::array<uchar4, 2> inputVals6 = {
-        uchar4{50, 100, 150, 255},   // BGRA: B=50, G=100, R=150, A=255
-        uchar4{75, 125, 200, 128}    // BGRA: B=75, G=125, R=200, A=128
-    };
-
-    // After reorder (BGRA->RGBA): {150,100,50,255}, {200,125,75,128}
-    // Gray formula uses R,G,B (alpha ignored): R*0.299 + G*0.587 + B*0.114
-    std::array<uchar, 2> expectedVals6 = {
-        static_cast<uchar>(std::nearbyint(150 * 0.299f + 100 * 0.587f + 50 * 0.114f)),   // ~109
-        static_cast<uchar>(std::nearbyint(200 * 0.299f + 125 * 0.587f + 75 * 0.114f))    // ~141
-    };
-
-    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2GRAY, uchar4, uchar>>::addTest(testCases, inputVals6, expectedVals6);
 }
 
 void testStaticAddAlpha() {
@@ -191,6 +135,48 @@ void testBGR2Gray() {
     };
 
     TestCaseBuilder<BGR2GrayTest>::addTest(testCases, inputVals, expectedVals);
+}
+
+// Tests for the ColorConversion aliases that expand to FusedOperation
+// (regression test for the raw-Op vs IOp template arguments bug):
+// COLOR_BGR2GRAY, COLOR_BGRA2GRAY, COLOR_BGR2RGBA, COLOR_BGRA2RGB
+void testFusedColorConversionAliases() {
+    // COLOR_BGR2GRAY: reorder(2,1,0) then RGB2Gray
+    // input is BGR -> luma = 0.299*R(z) + 0.587*G(y) + 0.114*B(x)
+    std::array<uchar3, 2> inBGR = {
+        uchar3{50, 100, 150},
+        uchar3{75, 125, 200}
+    };
+    std::array<uchar, 2> expGray = {
+        static_cast<uchar>(std::nearbyint(150 * 0.299f + 100 * 0.587f + 50 * 0.114f)),
+        static_cast<uchar>(std::nearbyint(200 * 0.299f + 125 * 0.587f + 75 * 0.114f))
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2GRAY, uchar3, uchar>>::
+        addTest(testCases, inBGR, expGray);
+
+    // COLOR_BGRA2GRAY: reorder(2,1,0,3) then RGB2Gray (alpha discarded by formula)
+    std::array<uchar4, 2> inBGRA = {
+        uchar4{50, 100, 150, 255},
+        uchar4{75, 125, 200, 128}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2GRAY, uchar4, uchar>>::
+        addTest(testCases, inBGRA, expGray);
+
+    // COLOR_BGR2RGBA: reorder(2,1,0) then AddOpaqueAlpha
+    std::array<uchar4, 2> expRGBA = {
+        uchar4{150, 100, 50, 255},
+        uchar4{200, 125, 75, 255}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGR2RGBA, uchar3, uchar4>>::
+        addTest(testCases, inBGR, expRGBA);
+
+    // COLOR_BGRA2RGB: reorder(2,1,0,3) then Discard -> 3 channels
+    std::array<uchar3, 2> expRGB = {
+        uchar3{150, 100, 50},
+        uchar3{200, 125, 75}
+    };
+    TestCaseBuilder<fk::ColorConversion<fk::ColorConversionCodes::COLOR_BGRA2RGB, uchar4, uchar3>>::
+        addTest(testCases, inBGRA, expRGB);
 }
 
 void testAddOpaqueAlphaStruct() {
@@ -399,6 +385,7 @@ testColorConversionOperations();
 // Test additional structs
 testStaticAddAlpha();
 testBGR2Gray();
+testFusedColorConversionAliases();
 testAddOpaqueAlphaStruct();
 testDenormalizePixel();
 testNormalizePixel();


### PR DESCRIPTION
## Attention DPPs: FlashAttention-2 + FlashDecode with universal IOp prologues

Adds `algorithms/attention/`: cooperative DPPs implementing attention with FKL's fusion model — **Q/K/V enter the kernels exclusively through Read/ReadBack IOps**, and any output IOp chain fuses in-register before the single global write.

### Components

| header | DPP | what it is |
|---|---|---|
| `softmax.h` | `SoftmaxDPP` | online-softmax rows, prologue IOp on both passes |
| `flash_attention.h` | `FlashAttentionDPP` | FA-2 forward, SIMT fp32 (exact baseline) + **int8/fp8-e4m3 per-token compressed KV cache IOps** |
| `flash_attention_mma.h` | `FlashAttentionMmaDPP` | FA-2 on tensor cores (mma.sync m16n8k16 bf16) with compile-time **schedule auto-dispatch**, **flex score mods**, **block sparsity** |
| `flash_decode.h` | `FlashDecodeDPP` | split-KV decode (seq_q=1), merge **fused** via last-CTA pattern — 1 kernel/step (FA uses 2) |

### Schedule auto-dispatch
The mma DPP inspects prologue IOp types at compile time: raw bf16 identity reads → real cp.async streaming; fp8/int8 KV → cp.async of the **raw quantized bytes** (half traffic) + smem dequant; any fused chain → register prefetch. Same user code in all cases.

### Flex attention + block sparsity
`ScoreModOp` functor (`s' = mod(s, q, kv)` — ALiBi, Gemma-2 SoftCap, SlidingWindow shipped; `NoScoreMod` = zero cost) and `BlockSparsity` tile mask with **iteration-range trim** (per q-block, only the active mask span is iterated). `makeSlidingWindowBlockMask()` builds the canonical window mask.

### Measured vs Dao-AILab/flash-attention 2.8.4 (built from main for sm_120, RTX PRO 6000, same dtype, torch.cuda.Event)

| workload | FKL | flash-attn | verdict |
|---|---|---|---|
| forward s512 d64 causal | 0.011 ms | 0.021 ms | **FKL 1.97x** |
| forward s1024 d64 causal | 0.026 ms | 0.031 ms | **FKL 1.21x** |
| forward geomean (9 shapes) | — | — | parity (~1.00x) |
| **decode fp8-KV** sk4096 d64 | 12.0 us | 24.0 us | **FKL 2.05x** |
| **decode fp8-KV** sk16384 d128 | 84.2 us | 171.4 us | **FKL 2.03x** |
| **decode fp8-KV** sk65536 d128 | 413.6 us | 663.2 us | **FKL 1.60x** |
| decode fp8 overall | — | — | **5-6/7 shapes faster, geomean ~1.35x, HALF the KV memory** |
| SoftCap s4096 | 0.283 ms | 0.337 ms | **FKL 1.19x** |
| ALiBi s4096 | 0.266 ms | 0.262 ms | parity |
| **sliding-window(512) s4096** (mask+mod composed, after trim) | **0.071 ms** | 0.080-0.087 ms | **FKL 1.13-1.22x** |
| block-sparse density scaling | 50%: 1.5x · 25%: 2.2x · 10%: 2.9x | n/a (per-variant kernels) | composable |

What FA cannot express at any speed: arbitrary prologue IOp chains, fused epilogues, compressed KV consumed in-register, ANY user score-mod functor — all stacking in ONE kernel.

### Profiling artifacts (Nsight)
`fkl_attention/profiles/` in the companion repo: `fkl_decode_fused.nsys-rep` (decode, fused merge visible), `fkl_mma_forward.nsys-rep`, `fkl_mma_dense_s4096.ncu-rep` (ncu full set), `SUMMARY.txt`.

### Known gap + roadmap
Dense-long forward is 0.86-0.93x vs FA after the ldmatrix->mma streaming fix (154->138 regs/thread, smem limit 3->4 blocks, d64 s4096: 268->295 TF, dense 325->352 TF). ncu says: occupancy-bound — 154 regs/thread limits to 3 blocks/SM (25% theoretical, 23.4% achieved); DRAM is only 8.6% utilized. `__launch_bounds__` minBlocks=4 was tried and REVERTED (spills regressed 310→268 TF d64, 268→155 TF d128). Real fix (follow-up PR): restructure per-warp register footprint — split the S-tile accumulators across two passes or move P through smem, targeting ≤128 regs → 4 blocks/SM. FP8 *mma* (kind::f8f6f4 on the quantized KV bytes, skipping dequant-to-bf16) is the other 2x lever and pairs with the existing QUANT_KV schedule.

### Quality
softmax 5 + FA 9 + mma 17 + decode 9 + flex/block-sparse 11 utests, all green on sm_120/CUDA 13.3; compute-sanitizer memcheck 0 errors on every suite; fp8 gated by `__has_include(<cuda_fp8.h>)`; SIMT DPP remains the portable exact path. Branch contains 8 commits on top of current `LTS-C++17` (f879d73), 0 behind.

References: FlashAttention-2 · FlexAttention (PyTorch) · mit-han-lab/Block-Sparse-Attention · Dao-AILab/flash-attention#2634 (FA4 sm12x) · NVIDIA/cutlass#3030 · fa-5090 (gau-nernst)

