### PR TITLE
Attention perf round 2: FP8 QK^T, log2 softmax, causal raster, measured tile dispatch (1.064x -> 1.227x vs FA)

### DIFF
--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -1885,29 +1885,46 @@ inline void executeFlashAttentionMma(
     //              stays BQ64 (BQ128 loses 9% there).
     // Explicit BLOCK_Q/BLOCK_KV template args bypass the heuristic.
     if constexpr (BLOCK_Q == 0 && BLOCK_KV == 0 && RAW) {
+      // block-sparse masks fix their own tile granularity — only reroute
+      // when the mask granularity divides the candidate tile (sliding-
+      // window masks at s8192 DO want the BQ128 pick: 1.11x vs 1.01x).
+      const auto maskFits = [&](const int bq, const int bkv) {
+          return sparse.mask == nullptr ||
+                 (sparse.maskBQ % bq == 0 && sparse.maskBKV % bkv == 0);
+      };
         if constexpr (HEAD_DIM <= 64) {
             const bool wantBQ128 =
                 causal ? (seqQ >= 8192 || (seqQ >= 4096 && batchHeads >= 64))
                        : ((long)batchHeads * seqQ >= 65536);
-            if (wantBQ128) {
+            if (wantBQ128 && maskFits(128, 64)) {
                 executeFlashAttentionMma<HEAD_DIM, 128, 64, NUM_WARPS>(
                     q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
                     scaleOverride, epilogue, scoreMod, sparse);
                 return;
             }
+            // ROUND-8 RESWEEP (spikes/resweep_r8.cu + guard_r8.cu, post
+            // density rounds): mid-range CAUSAL prefers a WIDER KV tile —
+            // BQ64/BKV128 amortizes the per-tile softmax bookkeeping over
+            // 2x the columns (bh8 s4096 +33%, bh8 s1024 +29%, bh32 s4096
+            // +7%; only bh32 s512 regresses -3.5%). Dense keeps BQ64/BKV64
+            // (BKV128 measured slower on every dense shape).
+            if (causal && seqQ >= 1024 && maskFits(64, 128)) {
+                executeFlashAttentionMma<HEAD_DIM, 64, 128, NUM_WARPS>(
+                    q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
+                    scaleOverride, epilogue, scoreMod, sparse);
+                return;
+            }
         } else if constexpr (HEAD_DIM == 128) {
-            // Extended from (seqQ>=8192 && bh>=32) after ABAB probes vs base
-            // (spikes/abab_dual_q.cu): NW8 wins whenever the grid stays
-            // saturated at the halved block count — bh*seqQ >= 256K dense
-            // (bh64 s4096 1.09x, bh128 s2048 1.01x, bh32/64 s8192 1.07x);
-            // below that base's extra blocks win (bh16 s8192 0.96x,
-            // bh32 s4096 0.94x). Causal keeps the tighter rule (halved
-            // effective work: bh64 s4096 1.00x, bh8 s8192 0.90x).
-            const bool wantNW8 =
-                causal ? (seqQ >= 8192 && batchHeads >= 32)
-                       : ((long)batchHeads * seqQ >= 262144);
-            if (wantNW8) {
-                executeFlashAttentionMma<HEAD_DIM, 128, 64, 8>(
+            // ROUND-8 RESWEEP: the old NW8 rule (bh*seqQ>=256K -> BQ128/
+            // BKV64/NW8) went STALE after the density rounds — BQ64/BKV64
+            // now beats it on every swept shape below s16384 (bh64 s4096:
+            // 341 vs 321 TF; bh32 s8192 causal: 326 vs 300). The deep-wide
+            // tile BQ128/BKV128/NW8 (96KB smem, 1 CTA/SM) wins only at
+            // s>=16384 where per-CTA work is huge (bh32 dense 337 vs 311;
+            // bh32 causal 322 vs 300); s8192 is parity (+-1%). Rule:
+            // seqQ >= 16384 -> BQ128/BKV128/NW8; else plain BQ64/BKV64.
+            if (seqQ >= 16384 && maskFits(128, 128)) {
+                executeFlashAttentionMma<HEAD_DIM, 128, 128, 8>(
                     q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
                     scaleOverride, epilogue, scoreMod, sparse);
                 return;

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -833,6 +833,14 @@ public:
         for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
             const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
             const int rowB = rowA + 8;
+            // FUSED MASK LIMIT (arithmetic-density round 3): the two dead
+            // conditions (col >= seq_k, causal && col > row) collapse into
+            // ONE per-row column limit hoisted out of the mkv loop:
+            //   lim = causal ? min(seq_k, row+1) : seq_k;  dead = col >= lim
+            // 1 ISETP per element instead of 2 ISETP + logic ops. Computed
+            // only on masked tiles (NO_MASK path never reads it).
+            const int limA = p.causal ? ::min(p.seq_k, rowA + 1) : p.seq_k;
+            const int limB = p.causal ? ::min(p.seq_k, rowB + 1) : p.seq_k;
 
             #pragma unroll
             for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
@@ -846,9 +854,7 @@ public:
                     #pragma unroll
                     for (int e = 0; e < 4; ++e) {
                         const int col = colBase + (e & 1);
-                        const int row = (e < 2) ? rowA : rowB;
-                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
-                        if (dead) r[e] = -FLT_MAX;
+                        if (col >= ((e < 2) ? limA : limB)) r[e] = -FLT_MAX;
                     }
                 } else if constexpr (NO_MASK && IS_ALIBI) {
                     // column-only ALiBi (row term cancels in softmax):
@@ -867,7 +873,7 @@ public:
                         const int row = (e < 2) ? rowA : rowB;
                         bool dead;
                         if constexpr (NO_MASK) { dead = false; }
-                        else { dead = (col >= p.seq_k) || (p.causal && col > row); }
+                        else { dead = col >= ((e < 2) ? limA : limB); }
                         float s = r[e] * scl;
                         if constexpr (IS_ALIBI) {
                             // same column-only form as the fast path (exact:

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -184,6 +184,18 @@ makeSlidingWindowBlockMask(const int batchHeads, const int seqQ, const int seqK,
 
 namespace attention_mma_detail {
 
+/* FP8 tensor-core path (QK^T directly on e4m3 KV-cache bytes, no K dequant
+ * pass). kind::f8f6f4 m16n8k32 requires the arch-specific feature set
+ * (sm_120a / sm_121a) — plain sm_120 ptxas rejects it, so the path is
+ * compiled out unless the TU targets compute_120a. Measured on RTX PRO
+ * 6000 (spike_fp8_mma.cu): 1006 TFLOPS vs 551 bf16 = 1.83x raw mma. */
+#if defined(__CUDA_ARCH__) && defined(FK_HAS_FP8) && \
+    (defined(__CUDA_ARCH_FEAT_SM120_ALL) || defined(__CUDA_ARCH_FEAT_SM121_ALL))
+#define FK_FP8_QK_MMA 1
+#else
+#define FK_FP8_QK_MMA 0
+#endif
+
 __device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
                  : "=r"(regs[0]), "=r"(regs[1]), "=r"(regs[2]), "=r"(regs[3])

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -508,16 +508,36 @@ public:
                                     const __nv_bfloat16* srcPlane, const int rowBase,
                                     const int seqLen) {
         using namespace attention_mma_detail;
-        #pragma unroll
-        for (int g = 0; g < GROUPS; ++g) {
-            const int idx = (g * THREADS + (int)threadIdx.x) * 8;
-            const int r = idx / HEAD_DIM;
-            const int c = idx % HEAD_DIM;
-            const int row = rowBase + r;
-            const bool ok = row < seqLen;
-            const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
-            cp_async_16(dstBase + swz(idx * (uint32_t)sizeof(__nv_bfloat16)),
-                        srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 16 : 0);
+        constexpr int ROWS = GROUPS * THREADS * 8 / HEAD_DIM;
+#ifndef FK_CPASYNC_FAST
+#define FK_CPASYNC_FAST 1
+#endif
+        if (FK_CPASYNC_FAST && rowBase + ROWS <= seqLen) {
+            // FULL-TILE FAST PATH (the common case on interior tiles): no
+            // per-group bounds predicate, no safeRow select — and the src
+            // address becomes base + compile-time stride (idx = g*THREADS*8
+            // + tid*8), which ptxas folds into the LDGSTS immediate. The
+            // ragged path below costs ISETP+SEL+IMAD per group per tile in
+            // the hot loop (SASS: ISETP was 1.3/HMMA vs FA's 0.19).
+            const __nv_bfloat16* base = srcPlane + (long)rowBase * HEAD_DIM;
+            #pragma unroll
+            for (int g = 0; g < GROUPS; ++g) {
+                const int idx = (g * THREADS + (int)threadIdx.x) * 8;
+                cp_async_16(dstBase + swz(idx * (uint32_t)sizeof(__nv_bfloat16)),
+                            base + idx, 16);
+            }
+        } else {
+            #pragma unroll
+            for (int g = 0; g < GROUPS; ++g) {
+                const int idx = (g * THREADS + (int)threadIdx.x) * 8;
+                const int r = idx / HEAD_DIM;
+                const int c = idx % HEAD_DIM;
+                const int row = rowBase + r;
+                const bool ok = row < seqLen;
+                const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
+                cp_async_16(dstBase + swz(idx * (uint32_t)sizeof(__nv_bfloat16)),
+                            srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 16 : 0);
+            }
         }
     }
 
@@ -1009,6 +1029,36 @@ public:
         }
     }
 
+    /* HOISTED-ADDRESS variant (arithmetic-density round): kmd[md] =
+       (smemBase + kThread) ^ (md*MMA_K*2) precomputed ONCE before the kv
+       loop. Valid because the XOR bits (< STRIDE_B) never overlap the
+       additive offsets (bufOff / token offsets are STRIDE_B multiples, no
+       carries into the XOR field). Every address is then reg + constant,
+       folded into the LDSM immediate — the per-fragment LOP3+IADD chains
+       disappear from the hot loop (SASS: LOP3 was 2.1/HMMA vs FA 0.086). */
+    template <int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void sMmaStreamH(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
+                                    const uint32_t bufOff,
+                                    const uint32_t (&kmd)[HEAD_DIM / MMA_K],
+                                    SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
+                                    const int tokOff = 0) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+                uint32_t frag[4];
+                ldmatrix_x4(frag, kmd[md] + bufOff
+                                  + (tokOff + mkv * MMA_N) * STRIDE_B);
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(qReg[mq][md],     frag + 0, sp[mq].s[mkv]);
+                    mma_m16n8k16(qReg[mq][md + 1], frag + 2, sp[mq].s[mkv]);
+                }
+            }
+        }
+    }
+
     /* DEEP-Q QK^T: BOTH operands streamed from smem (Q resident at smem[0],
        K in the cp.async buffer). Loop order keeps the K fragment in regs
        across all WARP_Q/MMA_M row-blocks (mq=2 at BQ128/NW4 — each ldmatrix
@@ -1154,6 +1204,30 @@ public:
                 addr += (tokOff + mkv * MMA_K) * STRIDE_B;
                 addr ^= md * MMA_N * sizeof(__nv_bfloat16);
                 ldmatrix_x4_trans(frag, addr);
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(sp[mq].p[mkv], frag + 0, oAcc[mq][md]);
+                    mma_m16n8k16(sp[mq].p[mkv], frag + 2, oAcc[mq][md + 1]);
+                }
+            }
+        }
+    }
+
+    /* Hoisted-address P·V (same trick as sMmaStreamH): vmd[md] =
+       (smemBase + vBufOff + vThread) ^ (md*MMA_N*2), precomputed once. */
+    template <int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void pvMmaStreamH(const SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
+                                     const uint32_t (&vmd)[HEAD_DIM / MMA_N],
+                                     float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                     const int tokOff = 0) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < SPAN / MMA_K; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
+                uint32_t frag[4];
+                ldmatrix_x4_trans(frag, vmd[md]
+                                        + (tokOff + mkv * MMA_K) * STRIDE_B);
                 #pragma unroll
                 for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
                     mma_m16n8k16(sp[mq].p[mkv], frag + 0, oAcc[mq][md]);
@@ -1391,16 +1465,34 @@ public:
             }
             cp_async_commit();
 
-            // DUAL_Q_SMEM: hoist the per-md swizzled base addresses out of
-            // the kv loop (see sMmaStreamDualQ addressing note).
+            // Hoisted per-md swizzled base addresses (see sMmaStreamH /
+            // sMmaStreamDualQ addressing notes): computed ONCE before the kv
+            // loop; the hot loop then addresses with reg + constant only.
+            // GATED to d128 (measured, 4-binary ABAB): d128 +1-6% (causal
+            // s2048 257->272 TF); d64 BQ128 (250 regs) has no headroom for
+            // the kmd/vmd arrays -> s8192 dense 369->348 TF. d64 keeps the
+            // in-loop addressing.
+            static constexpr bool HOIST_ADDR = HEAD_DIM == 128;
             uint32_t qmd[DUAL_Q_SMEM ? HEAD_DIM / MMA_K : 1];
-            uint32_t kmd[DUAL_Q_SMEM ? HEAD_DIM / MMA_K : 1];
-            if constexpr (DUAL_Q_SMEM) {
+            uint32_t kmd[HOIST_ADDR ? HEAD_DIM / MMA_K : 1];
+            uint32_t vmd[HOIST_ADDR ? HEAD_DIM / MMA_N : 1];
+            if constexpr (HOIST_ADDR) {
                 #pragma unroll
                 for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
                     const uint32_t x = md * MMA_K * (uint32_t)sizeof(__nv_bfloat16);
-                    qmd[md] = (smemBase + qThread) ^ x;
                     kmd[md] = (smemBase + kThread) ^ x;
+                    if constexpr (DUAL_Q_SMEM) qmd[md] = (smemBase + qThread) ^ x;
+                }
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                    vmd[md] = (smemBase + vBufOff + vThread)
+                              ^ (md * MMA_N * (uint32_t)sizeof(__nv_bfloat16));
+                }
+            } else if constexpr (DUAL_Q_SMEM) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
+                    qmd[md] = (smemBase + qThread)
+                              ^ (md * MMA_K * (uint32_t)sizeof(__nv_bfloat16));
                 }
             }
 
@@ -1433,8 +1525,14 @@ public:
                     // tile.
                     // span 0 ---------------------------------------------
                     SPSpan sp[WARP_Q / MMA_M] = {};
-                    if (act) sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
-                                                 kThread, sp, 0);
+                    if (act) {
+                        if constexpr (HOIST_ADDR) {
+                            sMmaStreamH<KV_SPAN>(qReg, kBuf(kv), kmd, sp, 0);
+                        } else {
+                            sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
+                                                kThread, sp, 0);
+                        }
+                    }
 
                     // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
                     if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
@@ -1461,8 +1559,12 @@ public:
                     __syncthreads();
 
                     if (act) {
-                        pvMmaStream<KV_SPAN>(sp, smemBase + vBufOff, vThread,
-                                             oAcc, 0);
+                        if constexpr (HOIST_ADDR) {
+                            pvMmaStreamH<KV_SPAN>(sp, vmd, oAcc, 0);
+                        } else {
+                            pvMmaStream<KV_SPAN>(sp, smemBase + vBufOff,
+                                                 vThread, oAcc, 0);
+                        }
                         // span 1 ------------------------------------------
                         // reuses the same sp storage; K[kv]/V[kv] still
                         // resident (see buffer-lifetime note above).
@@ -1472,8 +1574,12 @@ public:
                             for (int i = 0; i < KV_SPAN / MMA_N; ++i)
                                 #pragma unroll
                                 for (int e = 0; e < 4; ++e) sp[mq].s[i][e] = 0.f;
-                        sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
-                                            kThread, sp, KV_SPAN);
+                        if constexpr (HOIST_ADDR) {
+                            sMmaStreamH<KV_SPAN>(qReg, kBuf(kv), kmd, sp, KV_SPAN);
+                        } else {
+                            sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
+                                                kThread, sp, KV_SPAN);
+                        }
                         if (needsMask) {
                             softmaxTile<false, KV_SPAN>(sp, oAcc, rowMax, rowSum,
                                                         p, offKV + KV_SPAN,
@@ -1528,8 +1634,10 @@ public:
                     if (act) {
                         if constexpr (DUAL_Q_SMEM) {
                             pvMmaStreamDual(sp, smemBase + vBufOff, vThread, oAcc);
-                        } else {
+                        } else if constexpr (HOIST_ADDR) {
                             // stream V frags ldmatrix->mma (no vReg staging)
+                            pvMmaStreamH(sp, vmd, oAcc);
+                        } else {
                             pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
                         }
                     }

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -794,6 +794,21 @@ public:
         constexpr bool LOG2D = !HAS_SCORE_MOD || IS_ALIBI;
         constexpr float LOG2E = 1.4426950408889634f;
         const float scl = LOG2D ? p.scale * LOG2E : p.scale;
+        // RAW-DOMAIN SOFTMAX (arithmetic-density round, SASS-driven): with no
+        // score mod the scale pass is pure overhead — max commutes with a
+        // positive scale (max(r)*scl == max(r*scl), bitwise: fp mul is
+        // monotone), so we max RAW scores, scale the row max ONCE per half,
+        // and fold scale+subtract into a single FFMA inside the exp:
+        //   e = ex2(fma(r, scl, -mScaled)).
+        // This deletes 4 FMULs + 4 FADDs per mkv per mq (the whole scale
+        // loop) from the hot path; FA's SASS shows the same shape (FFMA 0.27
+        // vs our old 0.03 per HMMA, FMUL 0.53 vs our 1.02). Masked tiles
+        // keep sentinel semantics: dead elements hold raw -FLT_MAX and the
+        // exp keeps the explicit ==-FLT_MAX -> 0 guard (an all-dead row with
+        // rowMax still -FLT_MAX — empty split-KV chunk, causal row above its
+        // first in-range tile — would otherwise see fma(-FLT_MAX, scl,
+        // +FLT_MAX*scl) == 0 -> exp == 1 and poison lNew).
+        constexpr bool RAW_SMAX = !HAS_SCORE_MOD;
         #pragma unroll
         for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
             const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
@@ -803,21 +818,28 @@ public:
             for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
                 float* r = sp[mq].s[mkv];
                 const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
-                if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
-                    if constexpr (IS_ALIBI) {
-                        // column-only ALiBi (row term cancels in softmax):
-                        // keeps the fast path — no sentinels, no row math.
-                        const float slope2 = p.scoreMod.slope * LOG2E;
-                        const float b0 = slope2 * (float)colBase;
-                        const float b1 = slope2 * (float)(colBase + 1);
-                        r[0] = r[0] * scl + b0;
-                        r[1] = r[1] * scl + b1;
-                        r[2] = r[2] * scl + b0;
-                        r[3] = r[3] * scl + b1;
-                    } else {
-                        #pragma unroll
-                        for (int e = 0; e < 4; ++e) r[e] *= scl;
+                if constexpr (RAW_SMAX && NO_MASK) {
+                    // raw-domain fast path: nothing to do here — scores stay
+                    // raw; scale folds into the exp FFMA below.
+                } else if constexpr (RAW_SMAX) {
+                    // raw-domain masked: sentinels only, no scale.
+                    #pragma unroll
+                    for (int e = 0; e < 4; ++e) {
+                        const int col = colBase + (e & 1);
+                        const int row = (e < 2) ? rowA : rowB;
+                        const bool dead = (col >= p.seq_k) || (p.causal && col > row);
+                        if (dead) r[e] = -FLT_MAX;
                     }
+                } else if constexpr (NO_MASK && IS_ALIBI) {
+                    // column-only ALiBi (row term cancels in softmax):
+                    // keeps the fast path — no sentinels, no row math.
+                    const float slope2 = p.scoreMod.slope * LOG2E;
+                    const float b0 = slope2 * (float)colBase;
+                    const float b1 = slope2 * (float)(colBase + 1);
+                    r[0] = r[0] * scl + b0;
+                    r[1] = r[1] * scl + b1;
+                    r[2] = r[2] * scl + b0;
+                    r[3] = r[3] * scl + b1;
                 } else {
                     #pragma unroll
                     for (int e = 0; e < 4; ++e) {
@@ -851,7 +873,13 @@ public:
             for (int half = 0; half < 2; ++half) {
                 mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 1));
                 mNew[half] = fmaxf(mNew[half], __shfl_xor_sync(0xFFFFFFFFu, mNew[half], 2));
-                mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
+                if constexpr (RAW_SMAX) {
+                    // scale the RAW row max once; rowMax stays in the scaled
+                    // log2 domain (writePartial / split combine unchanged).
+                    mNew[half] = fmaxf(mNew[half] * scl, rowMax[mq][half]);
+                } else {
+                    mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
+                }
             }
 
             // domain-aware exp: scores are in log2 domain when LOG2D
@@ -891,7 +919,20 @@ public:
                 // s is dead after this loop, so nothing is written back.
                 const float* r = sp[mq].s[mkv];
                 float e[4];
-                if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
+                if constexpr (RAW_SMAX && NO_MASK) {
+                    // raw scores: scale+subtract fused in one FFMA per
+                    // element (ex2(fma(r, scl, -m))). This is the whole
+                    // arithmetic-density win: 1 FFMA replaces FMUL+FADD.
+                    e[0] = EXP(fmaf(r[0], scl, -mNew[0]));
+                    e[1] = EXP(fmaf(r[1], scl, -mNew[0]));
+                    e[2] = EXP(fmaf(r[2], scl, -mNew[1]));
+                    e[3] = EXP(fmaf(r[3], scl, -mNew[1]));
+                } else if constexpr (RAW_SMAX) {
+                    e[0] = (r[0] == -FLT_MAX) ? 0.f : EXP(fmaf(r[0], scl, -mNew[0]));
+                    e[1] = (r[1] == -FLT_MAX) ? 0.f : EXP(fmaf(r[1], scl, -mNew[0]));
+                    e[2] = (r[2] == -FLT_MAX) ? 0.f : EXP(fmaf(r[2], scl, -mNew[1]));
+                    e[3] = (r[3] == -FLT_MAX) ? 0.f : EXP(fmaf(r[3], scl, -mNew[1]));
+                } else if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
                     // ALiBi fast path qualifies too: column-only bias adds
                     // no -FLT_MAX sentinels on interior tiles.
                     e[0] = EXP(r[0] - mNew[0]);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -1389,6 +1389,21 @@ inline void executeFlashAttentionMma(
         const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {},
         const ScoreModOp& scoreMod = {}, const BlockSparsity& sparse = {}) {
     constexpr bool RAW = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
+    // RAW d64 auto-tile is REGIME-DEPENDENT (measured, real-data bench):
+    //   causal: BQ=64 wins (smaller blocks -> better load balance with the
+    //           reversed raster; BQ128 was 0.286 vs 0.232 ms @ s4096).
+    //   dense:  BQ=128 wins (+15-18% @ s8192: WARP_Q=32 -> mq=2 gives each
+    //           warp TWO independent mma accumulation chains; the kernel is
+    //           issue-limited so the extra ILP converts directly).
+    // Explicit BLOCK_Q template args bypass the heuristic as before.
+    if constexpr (BLOCK_Q == 0 && RAW && HEAD_DIM <= 64) {
+        if (!causal && seqQ >= 2048) {
+            executeFlashAttentionMma<HEAD_DIM, 128, 64, NUM_WARPS>(
+                q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
+                scaleOverride, epilogue, scoreMod, sparse);
+            return;
+        }
+    }
     constexpr int BQ = BLOCK_Q > 0 ? BLOCK_Q
                                    : (RAW ? 64 : (HEAD_DIM <= 64 ? 128 : 64));
     constexpr int BKV = BLOCK_KV > 0 ? BLOCK_KV : (RAW ? 64 : 32);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -355,15 +355,44 @@ public:
     static constexpr int KV_BUFS = RAW_KV ? 3 : 4;
     static constexpr int Q_STAGE_B = QUANT_KV ? 4 * (KV_BUF_B / 2) : 0;
     // DEEP_Q_SMEM: BUILT AND MEASURED OFF. Streaming Q from resident smem
-    // does eliminate qReg, but doubles ldmatrix traffic per mma (Q frags
-    // reloaded for every K fragment): 0.255 ms vs BQ64's 0.216 on d128
-    // bh32 s2048 dense. The deep-tile premise fails on sm_120: oAcc alone
-    // is 128 regs at mq=2 and the ldmatrix replay erases the instruction-
-    // count win. FA's 224-reg schedule relies on cp.async.bulk+wgmma-style
-    // operand routing that sm_120 doesn't have. Machinery kept for future
-    // archs; see ANALYSIS.md bucket-C post-mortem.
+    // with the mkv-outer loop does eliminate qReg, but replays each Q
+    // fragment for every K fragment (0.255 ms vs BQ64's 0.216 on d128
+    // bh32 s2048 dense). Kept as scaffolding; superseded by DUAL_Q_SMEM.
     static constexpr bool DEEP_Q_SMEM = false;
-    static constexpr int Q_RES_B = DEEP_Q_SMEM ? BLOCK_Q * STRIDE_B : 0;
+    // DUAL_Q_SMEM — the bucket-C schedule derived from FA's SASS
+    // (HMMA/LDSM 3.20 vs our 1.78; benchmarks/sass/ in fkl_attention).
+    // Q resident in smem like DEEP_Q_SMEM, but the QK^T loop is TRANSPOSED:
+    // md-pair OUTER, mkv INNER. Per md-pair the mq Q fragment pairs are
+    // loaded ONCE and reused across ALL BLOCK_KV columns, while each K
+    // fragment feeds mq row-blocks (dual reuse of BOTH operands). ldmatrix
+    // count per d128/BQ128/BKV64 tile: Q 16 + K 32 + V 32 = 80 x4 for 256
+    // HMMA -> ratio 3.2, exactly FA's. qReg (64 hot regs at mq=2) never
+    // exists; live operands inside the loop are 16 Q regs + 4 K regs, so
+    // any ptxas spill lands on softmax bookkeeping (cold, inter-phase) —
+    // the spill discipline FA's own 60-97 LDL/STL demonstrates is viable.
+    // Gated to the deep-tile d128 regime. BUILT AND MEASURED (2026-06-12,
+    // spikes/spike_dual_q.cu + abab_dual_q.cu, ABAB interleaved, real data):
+    // it reproduces FA's SASS signature EXACTLY — HMMA/LDSM 3.20 (FA 3.20,
+    // plain 1.78), spills confined to cold inter-phase state (LDL/STL
+    // 40/24, ZERO in the QK^T loop — vs the old BQ128 deep's hot-operand
+    // spills) — and accuracy passes vs the fp64 oracle. It still LOSES to
+    // plain BQ128/BKV64/NW8 by 3-7% dense / 9-20% causal: at 81920B smem
+    // it is hard-capped at 1 CTA/SM (8.3% occupancy), and the recovered
+    // issue slots don't cover the lost warp-level parallelism; ncu shows
+    // dual IPC 0.71 ~= FA's 0.69, i.e. the ILP discipline WORKS, but FA
+    // pairs it with ~5.6 total-instr/HMMA vs our ~10 (softmax bookkeeping
+    // dominates our non-mma mix). Lesson: the instruction-ratio gap was
+    // necessary but NOT sufficient; the remaining lever is shrinking
+    // softmax/mask arithmetic per score, not operand staging. OFF by
+    // default; -DFK_FA_DUAL_Q=1 re-enables for experiments.
+#ifndef FK_FA_DUAL_Q
+#define FK_FA_DUAL_Q 0
+#endif
+    static constexpr bool DUAL_Q_SMEM =
+        FK_FA_DUAL_Q != 0 && RAW_KV && !FP8_QK && HEAD_DIM == 128 &&
+        BLOCK_Q >= 128 && WARP_Q >= 32;
+    static constexpr int Q_RES_B =
+        (DEEP_Q_SMEM || DUAL_Q_SMEM) ? BLOCK_Q * STRIDE_B : 0;
     // FP8_QK: the Q phase additionally holds the e4m3 Q tile + per-row
     // scales NEXT TO the staged bf16 Q (both alive during quantizeQTile).
     static constexpr int Q_PHASE_B =
@@ -971,6 +1000,89 @@ public:
         }
     }
 
+    /* DUAL-REUSE QK^T (bucket-C, SASS-derived — see DUAL_Q_SMEM above):
+       Q resident in smem, loop TRANSPOSED vs sMmaStreamDeepQ: md-pair OUTER,
+       mkv INNER. Each Q fragment pair is loaded once per md-pair and serves
+       all SPAN/MMA_N columns; each K fragment serves mq row-blocks.
+       ADDRESSING: the swizzle XOR (^ md*32, bits 5-7) commutes with the
+       additive tile offsets that follow it (mq*MMA_M*STRIDE_B, kBuf
+       multiples of KV_BUF_B, token offsets multiples of STRIDE_B — all
+       multiples of 256, no carries into bits 5-7). Callers precompute
+       qmd[md] = (qBase + qThread) ^ (md*32) and kmd[md] = (smemBase +
+       kThread) ^ (md*32) ONCE outside the kv loop; every address below is
+       then reg + compile-time constant, which ptxas folds into the LDSM
+       offset field — zero LOP3/IADD in the hot loop (the SASS histogram
+       showed LOP3 at 1.06/HMMA vs FA's 0.086 before this). */
+    template <int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void sMmaStreamDualQ(const uint32_t kBufOff,
+                                        const uint32_t (&qmd)[HEAD_DIM / MMA_K],
+                                        const uint32_t (&kmd)[HEAD_DIM / MMA_K],
+                                        SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
+                                        const int tokOff = 0) {
+        using namespace attention_mma_detail;
+        // K-fragment register double-buffer: at 1 CTA/SM (this schedule's
+        // occupancy point, same as FA's) there is no second warp to hide
+        // LDSM->HMMA latency, so the NEXT fragment's ldmatrix must issue
+        // BEFORE the current mmas (CUTLASS mainloop discipline).
+        #pragma unroll
+        for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+            uint32_t qFrag[WARP_Q / MMA_M][2][4];
+            #pragma unroll
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                const uint32_t rowOff = mq * MMA_M * STRIDE_B;
+                ldmatrix_x4(qFrag[mq][0], qmd[md]     + rowOff);
+                ldmatrix_x4(qFrag[mq][1], qmd[md + 1] + rowOff);
+            }
+            uint32_t kFrag[2][4];
+            ldmatrix_x4(kFrag[0], kmd[md] + kBufOff + tokOff * STRIDE_B);
+            #pragma unroll
+            for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
+                if (mkv + 1 < SPAN / MMA_N) {
+                    ldmatrix_x4(kFrag[(mkv + 1) & 1],
+                                kmd[md] + kBufOff
+                                + (tokOff + (mkv + 1) * MMA_N) * STRIDE_B);
+                }
+                const uint32_t (&kf)[4] = kFrag[mkv & 1];
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(qFrag[mq][0], kf + 0, sp[mq].s[mkv]);
+                    mma_m16n8k16(qFrag[mq][1], kf + 2, sp[mq].s[mkv]);
+                }
+            }
+        }
+    }
+
+    /* P·V with the same fragment double-buffer discipline (dual schedule
+       runs at 1 CTA/SM: V fragment ldmatrix must lead its mmas). */
+    template <int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void pvMmaStreamDual(const SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
+                                        const uint32_t base, const uint32_t vThread,
+                                        float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                        const int tokOff = 0) {
+        using namespace attention_mma_detail;
+        constexpr int MD_IT = HEAD_DIM / MMA_N / 2;
+        #pragma unroll
+        for (int mkv = 0; mkv < SPAN / MMA_K; ++mkv) {
+            const uint32_t rowAddr = base + vThread + (tokOff + mkv * MMA_K) * STRIDE_B;
+            uint32_t frag[2][4];
+            ldmatrix_x4_trans(frag[0], rowAddr ^ 0u);
+            #pragma unroll
+            for (int mdp = 0; mdp < MD_IT; ++mdp) {
+                if (mdp + 1 < MD_IT) {
+                    ldmatrix_x4_trans(frag[(mdp + 1) & 1],
+                                      rowAddr ^ ((mdp + 1) * 2 * MMA_N
+                                                 * (uint32_t)sizeof(__nv_bfloat16)));
+                }
+                const uint32_t (&vf)[4] = frag[mdp & 1];
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    mma_m16n8k16(sp[mq].p[mkv], vf + 0, oAcc[mq][mdp * 2]);
+                    mma_m16n8k16(sp[mq].p[mkv], vf + 2, oAcc[mq][mdp * 2 + 1]);
+                }
+            }
+        }
+    }
+
     FK_DEVICE_FUSE void pvMma(const SPTile (&sp)[WARP_Q / MMA_M],
                               const uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2],
                               float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
@@ -1129,8 +1241,8 @@ public:
         }
         __syncthreads();
 
-        uint32_t qReg[DEEP_Q_SMEM ? 1 : WARP_Q / MMA_M]
-                     [DEEP_Q_SMEM ? 1 : HEAD_DIM / MMA_K][4];
+        uint32_t qReg[(DEEP_Q_SMEM || DUAL_Q_SMEM) ? 1 : WARP_Q / MMA_M]
+                     [(DEEP_Q_SMEM || DUAL_Q_SMEM) ? 1 : HEAD_DIM / MMA_K][4];
         // FP8_QK state (dead/eliminated when the path is off — all uses sit
         // inside `if constexpr (FP8_QK)`).
         uint32_t qReg8[WARP_Q / MMA_M][HEAD_DIM / 32][4];
@@ -1141,7 +1253,7 @@ public:
             quantizeQTile(smemBytes, warpId, laneId);
             loadQF8Frags(smemBytes, qReg8, qs, warpId, laneId);
 #endif
-        } else if constexpr (!DEEP_Q_SMEM) {
+        } else if constexpr (!DEEP_Q_SMEM && !DUAL_Q_SMEM) {
             #pragma unroll
             for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
                 #pragma unroll
@@ -1238,6 +1350,19 @@ public:
             }
             cp_async_commit();
 
+            // DUAL_Q_SMEM: hoist the per-md swizzled base addresses out of
+            // the kv loop (see sMmaStreamDualQ addressing note).
+            uint32_t qmd[DUAL_Q_SMEM ? HEAD_DIM / MMA_K : 1];
+            uint32_t kmd[DUAL_Q_SMEM ? HEAD_DIM / MMA_K : 1];
+            if constexpr (DUAL_Q_SMEM) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
+                    const uint32_t x = md * MMA_K * (uint32_t)sizeof(__nv_bfloat16);
+                    qmd[md] = (smemBase + qThread) ^ x;
+                    kmd[md] = (smemBase + kThread) ^ x;
+                }
+            }
+
             for (int kv = itBegin; kv < itEnd; ++kv) {
                 const int offKV = kv * BLOCK_KV;
                 const bool act = tileActive(offKV);
@@ -1323,7 +1448,11 @@ public:
                 } else {
                     SPTile sp[WARP_Q / MMA_M] = {};
                     if (act) {
-                        if constexpr (DEEP_Q_SMEM) {
+                        if constexpr (DUAL_Q_SMEM) {
+                            // dual-reuse schedule: Q resident at smem[0],
+                            // md-pair outer / mkv inner (see sMmaStreamDualQ)
+                            sMmaStreamDualQ(kBuf(kv), qmd, kmd, sp);
+                        } else if constexpr (DEEP_Q_SMEM) {
                             // deep schedule: Q AND K streamed from smem
                             sMmaStreamDeepQ(smemBase, qThread,
                                             smemBase + kBuf(kv), kThread, sp);
@@ -1356,8 +1485,12 @@ public:
                     __syncthreads();
 
                     if (act) {
-                        // stream V frags ldmatrix->mma (no vReg staging)
-                        pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
+                        if constexpr (DUAL_Q_SMEM) {
+                            pvMmaStreamDual(sp, smemBase + vBufOff, vThread, oAcc);
+                        } else {
+                            // stream V frags ldmatrix->mma (no vReg staging)
+                            pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
+                        }
                     }
                 }
             }
@@ -1608,7 +1741,17 @@ inline void executeFlashAttentionMma(
                 return;
             }
         } else if constexpr (HEAD_DIM == 128) {
-            if (seqQ >= 8192 && batchHeads >= 32) {
+            // Extended from (seqQ>=8192 && bh>=32) after ABAB probes vs base
+            // (spikes/abab_dual_q.cu): NW8 wins whenever the grid stays
+            // saturated at the halved block count — bh*seqQ >= 256K dense
+            // (bh64 s4096 1.09x, bh128 s2048 1.01x, bh32/64 s8192 1.07x);
+            // below that base's extra blocks win (bh16 s8192 0.96x,
+            // bh32 s4096 0.94x). Causal keeps the tighter rule (halved
+            // effective work: bh64 s4096 1.00x, bh8 s8192 0.90x).
+            const bool wantNW8 =
+                causal ? (seqQ >= 8192 && batchHeads >= 32)
+                       : ((long)batchHeads * seqQ >= 262144);
+            if (wantNW8) {
                 executeFlashAttentionMma<HEAD_DIM, 128, 64, 8>(
                     q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
                     scaleOverride, epilogue, scoreMod, sparse);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -354,14 +354,24 @@ public:
     // 3 blocks at 4 bufs). QUANT/register-prefetch use 4 (+byte staging).
     static constexpr int KV_BUFS = RAW_KV ? 3 : 4;
     static constexpr int Q_STAGE_B = QUANT_KV ? 4 * (KV_BUF_B / 2) : 0;
+    // DEEP_Q_SMEM: BUILT AND MEASURED OFF. Streaming Q from resident smem
+    // does eliminate qReg, but doubles ldmatrix traffic per mma (Q frags
+    // reloaded for every K fragment): 0.255 ms vs BQ64's 0.216 on d128
+    // bh32 s2048 dense. The deep-tile premise fails on sm_120: oAcc alone
+    // is 128 regs at mq=2 and the ldmatrix replay erases the instruction-
+    // count win. FA's 224-reg schedule relies on cp.async.bulk+wgmma-style
+    // operand routing that sm_120 doesn't have. Machinery kept for future
+    // archs; see ANALYSIS.md bucket-C post-mortem.
+    static constexpr bool DEEP_Q_SMEM = false;
+    static constexpr int Q_RES_B = DEEP_Q_SMEM ? BLOCK_Q * STRIDE_B : 0;
     // FP8_QK: the Q phase additionally holds the e4m3 Q tile + per-row
     // scales NEXT TO the staged bf16 Q (both alive during quantizeQTile).
     static constexpr int Q_PHASE_B =
         BLOCK_Q * STRIDE_B + (FP8_QK ? BLOCK_Q * HEAD_DIM + BLOCK_Q * 4 : 0);
     static constexpr int SMEM_BYTES =
-        (Q_PHASE_B > KV_BUFS * KV_BUF_B + Q_STAGE_B
+        (Q_PHASE_B > Q_RES_B + KV_BUFS * KV_BUF_B + Q_STAGE_B
              ? Q_PHASE_B
-             : KV_BUFS * KV_BUF_B + Q_STAGE_B);
+             : Q_RES_B + KV_BUFS * KV_BUF_B + Q_STAGE_B);
 
     struct Params {
         QIOp q; KIOp k; VIOp v;
@@ -564,15 +574,23 @@ public:
         uint32_t p[SPAN / MMA_K][4];   // packed bf16x2 P (first half of s)
     };
     using SPTile = SPTileT<BLOCK_KV>;
-    // SPLIT-S (bucket-A attempt, MEASURED INEFFECTIVE — kept off): halving
-    // the live score tile did NOT lower ptxas regs (134 either way — the
-    // allocator already overlaps sp with the kReg/frag staging), and dense
-    // throughput dropped ~2% from the extra zero-fill + second softmax tail.
-    // Re-enable only if a future change makes the score tile the real
-    // live-range ceiling.
+    // SPLIT-S: measured ineffective everywhere it was tried (d64: allocator
+    // already overlaps; d128 deep: replaced by the Q-resident DEEP schedule
+    // below, which removes the pressure at the source). Machinery kept.
     static constexpr bool SPLIT_S = false;
     static constexpr int KV_SPAN = SPLIT_S ? BLOCK_KV / 2 : BLOCK_KV;
     using SPSpan = SPTileT<KV_SPAN>;
+
+    // DEEP SCHEDULE (d128 dense bucket — the last FA-wins bucket): FA's
+    // d128 kernel spends 255 regs/thread to run BQ128 with mq=2 K-fragment
+    // reuse, executing 1.69x FEWER instructions than our BQ64 (ncu: 61.5M
+    // vs 104M same shape). Our BQ128/NW4 spills (qReg 64 + oAcc 64 + sp 64
+    // > 255). FIX AT THE SOURCE: keep Q RESIDENT in smem for the whole
+    // kernel (32KB + 48KB KV bufs = 80KB/block -> 1 CTA/SM, the same
+    // low-occupancy/high-ILP design point FA runs at) and STREAM Q
+    // fragments per md-pair inside sMmaStream — qReg's 64 regs vanish,
+    // the deep tile fits, and each K fragment still serves mq=2 mmas.
+    // (DEEP_Q_SMEM and Q_RES_B are declared above with the smem sizing.)
 
     // Q8 stage layout (Q-phase only; dead once qReg8/qs are in registers):
     //   [BLOCK_Q*STRIDE_B, +BLOCK_Q*HEAD_DIM)        row-major e4m3 Q bytes
@@ -921,6 +939,38 @@ public:
         }
     }
 
+    /* DEEP-Q QK^T: BOTH operands streamed from smem (Q resident at smem[0],
+       K in the cp.async buffer). Loop order keeps the K fragment in regs
+       across all WARP_Q/MMA_M row-blocks (mq=2 at BQ128/NW4 — each ldmatrix
+       feeds 2 mmas, FA's instruction-efficiency trick) while Q fragments
+       stream per (mq, md-pair) — qReg's 64 regs/thread never exist. */
+    FK_DEVICE_FUSE void sMmaStreamDeepQ(const uint32_t qBase, const uint32_t qThread,
+                                        const uint32_t kBase, const uint32_t kThread,
+                                        SPTile (&sp)[WARP_Q / MMA_M]) {
+        using namespace attention_mma_detail;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
+                uint32_t kFrag[4];
+                uint32_t kAddr = kBase + kThread;
+                kAddr += mkv * MMA_N * STRIDE_B;
+                kAddr ^= md * MMA_K * sizeof(__nv_bfloat16);
+                ldmatrix_x4(kFrag, kAddr);
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                    uint32_t qFrag[4], qFrag2[4];
+                    uint32_t qAddr = qBase + qThread;
+                    qAddr += mq * MMA_M * STRIDE_B;
+                    ldmatrix_x4(qFrag,  qAddr ^ (md       * MMA_K * (int)sizeof(__nv_bfloat16)));
+                    ldmatrix_x4(qFrag2, qAddr ^ ((md + 1) * MMA_K * (int)sizeof(__nv_bfloat16)));
+                    mma_m16n8k16(qFrag,  kFrag + 0, sp[mq].s[mkv]);
+                    mma_m16n8k16(qFrag2, kFrag + 2, sp[mq].s[mkv]);
+                }
+            }
+        }
+    }
+
     FK_DEVICE_FUSE void pvMma(const SPTile (&sp)[WARP_Q / MMA_M],
                               const uint32_t (&vReg)[BLOCK_KV / MMA_K][HEAD_DIM / MMA_N][2],
                               float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
@@ -1079,7 +1129,8 @@ public:
         }
         __syncthreads();
 
-        uint32_t qReg[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
+        uint32_t qReg[DEEP_Q_SMEM ? 1 : WARP_Q / MMA_M]
+                     [DEEP_Q_SMEM ? 1 : HEAD_DIM / MMA_K][4];
         // FP8_QK state (dead/eliminated when the path is off — all uses sit
         // inside `if constexpr (FP8_QK)`).
         uint32_t qReg8[WARP_Q / MMA_M][HEAD_DIM / 32][4];
@@ -1090,7 +1141,7 @@ public:
             quantizeQTile(smemBytes, warpId, laneId);
             loadQF8Frags(smemBytes, qReg8, qs, warpId, laneId);
 #endif
-        } else {
+        } else if constexpr (!DEEP_Q_SMEM) {
             #pragma unroll
             for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
                 #pragma unroll
@@ -1102,6 +1153,8 @@ public:
                 }
             }
         }
+        // DEEP_Q_SMEM: Q stays resident at smem[0..Q_RES_B); fragments are
+        // streamed inside the QK^T mma loop. No qReg, no extracting sync.
         __syncthreads();
 
         float oAcc[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4] = {};
@@ -1173,8 +1226,10 @@ public:
             // after the QK^T mma so it streams during softmax + PV.
             const __nv_bfloat16* kPlane = p.k.params.data + (long)bh * p.seq_k * HEAD_DIM;
             const __nv_bfloat16* vPlane = p.v.params.data + (long)bh * p.seq_k * HEAD_DIM;
-            const auto kBuf = [&](int i) { return (uint32_t)(i % 2) * KV_BUF_B; };
-            const uint32_t vBufOff = 2 * KV_BUF_B;  // single V buffer
+            // DEEP_Q_SMEM: KV buffers live after the resident Q tile.
+            const auto kBuf = [&](int i) {
+                return Q_RES_B + (uint32_t)(i % 2) * KV_BUF_B; };
+            const uint32_t vBufOff = Q_RES_B + 2 * KV_BUF_B;  // single V buffer
 
             // prefetch first in-range tile
             if (itBegin < itEnd && tileActive(itBegin * BLOCK_KV)) {
@@ -1268,9 +1323,15 @@ public:
                 } else {
                     SPTile sp[WARP_Q / MMA_M] = {};
                     if (act) {
-                        uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                        loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-                        sMma(qReg, kReg, sp);
+                        if constexpr (DEEP_Q_SMEM) {
+                            // deep schedule: Q AND K streamed from smem
+                            sMmaStreamDeepQ(smemBase, qThread,
+                                            smemBase + kBuf(kv), kThread, sp);
+                        } else {
+                            uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                            loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                            sMma(qReg, kReg, sp);
+                        }
                     }
 
                     // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -1502,6 +1502,9 @@ public:
                 }
             }
 
+            // NOTE (round 9bis, rejected): #pragma unroll 2 on this loop was
+            // measured at -9..-14% on most shapes (+2..6% on two) — the
+            // bigger body blows the I-cache/sched window; reverted.
             for (int kv = itBegin; kv < itEnd; ++kv) {
                 const int offKV = kv * BLOCK_KV;
                 const bool act = tileActive(offKV);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -182,20 +182,21 @@ makeSlidingWindowBlockMask(const int batchHeads, const int seqQ, const int seqK,
     return m;
 }
 
-namespace attention_mma_detail {
-
-/* FP8 tensor-core path (QK^T directly on e4m3 KV-cache bytes, no K dequant
- * pass). kind::f8f6f4 m16n8k32 requires the arch-specific feature set
- * (sm_120a / sm_121a) — plain sm_120 ptxas rejects it, so the path is
- * compiled out unless the TU targets compute_120a. Measured on RTX PRO
- * 6000 (spike_fp8_mma.cu): 1006 TFLOPS vs 551 bf16 = 1.83x raw mma. */
-#if defined(__CUDA_ARCH__) && defined(FK_HAS_FP8) && \
-    (defined(__CUDA_ARCH_FEAT_SM120_ALL) || defined(__CUDA_ARCH_FEAT_SM121_ALL))
-#define FK_FP8_QK_MMA 1
-#else
-#define FK_FP8_QK_MMA 0
+/* FP8 tensor-core QK^T (kind::f8f6f4 m16n8k32, e4m3xe4m3->f32): Q is
+ * quantized per-row IN-KERNEL, K^T runs directly on the raw fp8 KV-cache
+ * bytes (the K dequant pass disappears), and qScale[row]*kScale[col] is
+ * folded into the scores post-mma. Opt-in: the instruction needs the
+ * arch-FEATURE set — compile the TU with
+ *   -gencode arch=compute_120a,code=sm_120a -DFK_ENABLE_FP8_QK=1
+ * (plain sm_120 ptxas REJECTS kind::f8f6f4 — verified). Measured raw mma
+ * on RTX PRO 6000 (spikes/spike_fp8_mma.cu): 1006 TFLOPS vs 551 bf16 =
+ * 1.83x; fragment mapping validated vs fp64 oracle
+ * (spikes/spike_fp8_qk_mapping.cu, maxErr 1e-6). */
+#ifndef FK_ENABLE_FP8_QK
+#define FK_ENABLE_FP8_QK 0
 #endif
 
+namespace attention_mma_detail {
 __device__ __forceinline__ void ldmatrix_x4(uint32_t regs[4], uint32_t addr) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];"
                  : "=r"(regs[0]), "=r"(regs[1]), "=r"(regs[2]), "=r"(regs[3])
@@ -258,6 +259,23 @@ __device__ __forceinline__ uint32_t packBf162(const float lo, const float hi) {
     return r;
 }
 
+// fp8 e4m3 mma: kind::f8f6f4 m16n8k32, A 4 regs (16 e4m3), B 2 regs (8 e4m3).
+// Always declared so `if constexpr` branches type-check; the instruction is
+// only emitted when FK_ENABLE_FP8_QK (needs sm_120a/121a feature set).
+__device__ __forceinline__ void mma_fp8_m16n8k32(const uint32_t A[4],
+                                                 const uint32_t B[2],
+                                                 float D[4]) {
+#if FK_ENABLE_FP8_QK
+    asm volatile(
+        "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};"
+        : "+f"(D[0]), "+f"(D[1]), "+f"(D[2]), "+f"(D[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]));
+#else
+    (void)A; (void)B; (void)D;
+#endif
+}
+
 } // namespace attention_mma_detail
 
 template <typename OT, int HEAD_DIM,
@@ -294,6 +312,11 @@ public:
     static constexpr bool QUANT_KV =
         (isFp8KVRead<KIOp> && isFp8KVRead<VIOp>) ||
         (isInt8KVRead<KIOp> && isInt8KVRead<VIOp>);
+    // FP8_QK: QK^T runs on the fp8 tensor-core path (kind::f8f6f4 m16n8k32)
+    // directly on the raw e4m3 K bytes; Q is quantized per-row in-kernel.
+    // The K dequant pass disappears. PV stays bf16 (P is computed online).
+    static constexpr bool FP8_QK =
+        FK_ENABLE_FP8_QK != 0 && isFp8KVRead<KIOp> && isFp8KVRead<VIOp>;
 
     static constexpr int STRIDE_B = HEAD_DIM * (int)sizeof(__nv_bfloat16);
     static constexpr int Q_GROUPS = BLOCK_Q * HEAD_DIM / (THREADS * 8);
@@ -309,9 +332,13 @@ public:
     // 3 blocks at 4 bufs). QUANT/register-prefetch use 4 (+byte staging).
     static constexpr int KV_BUFS = RAW_KV ? 3 : 4;
     static constexpr int Q_STAGE_B = QUANT_KV ? 4 * (KV_BUF_B / 2) : 0;
+    // FP8_QK: the Q phase additionally holds the e4m3 Q tile + per-row
+    // scales NEXT TO the staged bf16 Q (both alive during quantizeQTile).
+    static constexpr int Q_PHASE_B =
+        BLOCK_Q * STRIDE_B + (FP8_QK ? BLOCK_Q * HEAD_DIM + BLOCK_Q * 4 : 0);
     static constexpr int SMEM_BYTES =
-        (BLOCK_Q * STRIDE_B > KV_BUFS * KV_BUF_B + Q_STAGE_B
-             ? BLOCK_Q * STRIDE_B
+        (Q_PHASE_B > KV_BUFS * KV_BUF_B + Q_STAGE_B
+             ? Q_PHASE_B
              : KV_BUFS * KV_BUF_B + Q_STAGE_B);
 
     struct Params {
@@ -423,7 +450,10 @@ public:
     }
 
     // ---- quantized staging: cp.async the RAW BYTES (half the traffic) ------
-    template <int GROUPS>
+    // SWZ8: XOR-swizzle each 8B chunk by ((row&7)*8) — used by the FP8 QK^T
+    // path so direct 4B fragment reads don't bank-conflict (d128 rows are
+    // exactly 32 banks wide -> every token would hit bank 0 unswizzled).
+    template <int GROUPS, bool SWZ8 = false>
     FK_DEVICE_FUSE void cpasyncQuantTile(const uint32_t dstBase,
                                          const int8_t* srcPlane, const int rowBase,
                                          const int seqLen) {
@@ -437,7 +467,9 @@ public:
             const bool ok = row < seqLen;
             const int safeRow = ok ? row : (seqLen > 0 ? seqLen - 1 : 0);
             // unswizzled byte staging: 8B per thread-group
-            cp_async_8(dstBase + (uint32_t)idx,
+            uint32_t off = (uint32_t)idx;
+            if constexpr (SWZ8) off ^= (uint32_t)((r & 7) * 8);
+            cp_async_8(dstBase + off,
                        srcPlane + (long)safeRow * HEAD_DIM + c, ok ? 8 : 0);
         }
     }
@@ -484,6 +516,140 @@ public:
         }
     }
 
+    // ================= FP8 tensor-core QK^T (FK_ENABLE_FP8_QK) ==============
+    /* Fused S/P register tile. The fp32 scores (s) and the packed bf16x2
+     * probabilities (p) used to live in SEPARATE arrays (32 + 16 regs at
+     * BKV=64), but their live ranges only overlap inside softmaxTile, and
+     * the pack is strictly in-place-safe: iteration mkv writes p bytes
+     * [8*mkv, 8*mkv+8) while s reads touch [16*mkv, 16*mkv+16) — the write
+     * head never catches the read head (only mkv==0 overlaps, and there the
+     * statement order consumes s[0..1] before overwriting them). Overlaying
+     * p on the first half of s saves BLOCK_KV/4 regs/thread (16 at BKV=64). */
+    union SPTile {
+        float    s[BLOCK_KV / MMA_N][4];   // QK^T scores / exp(s - m), fp32
+        uint32_t p[BLOCK_KV / MMA_K][4];   // packed bf16x2 P (first half of s)
+    };
+
+    // Q8 stage layout (Q-phase only; dead once qReg8/qs are in registers):
+    //   [BLOCK_Q*STRIDE_B, +BLOCK_Q*HEAD_DIM)        row-major e4m3 Q bytes
+    //   [.. +BLOCK_Q*4)                              per-row scales (fp32)
+    static constexpr uint32_t Q8_OFF = BLOCK_Q * STRIDE_B;
+    static constexpr uint32_t QSC_OFF = Q8_OFF + BLOCK_Q * HEAD_DIM;
+
+#ifdef FK_HAS_FP8
+    /* Per-row symmetric e4m3 quantization of the staged Q tile (each warp
+       quantizes its own WARP_Q rows; warp-synchronous, no block barrier). */
+    FK_DEVICE_FUSE void quantizeQTile(char* smemBytes, const int warpId,
+                                      const int laneId) {
+        constexpr int EPL = HEAD_DIM / 32;     // elements per lane per row
+        float* qScalesArr = reinterpret_cast<float*>(smemBytes + QSC_OFF);
+        for (int r = 0; r < WARP_Q; ++r) {
+            const int row = warpId * WARP_Q + r;   // block-local row
+            float vals[EPL];
+            float am = 0.f;
+            #pragma unroll
+            for (int e = 0; e < EPL; ++e) {
+                const int c = laneId * EPL + e;
+                const __nv_bfloat16 b = *reinterpret_cast<const __nv_bfloat16*>(
+                    smemBytes + swz((uint32_t)(row * HEAD_DIM + c) * 2u));
+                vals[e] = __bfloat162float(b);
+                am = fmaxf(am, fabsf(vals[e]));
+            }
+            #pragma unroll
+            for (int off = 16; off; off >>= 1)
+                am = fmaxf(am, __shfl_xor_sync(0xFFFFFFFFu, am, off));
+            const float sc = am > 0.f ? am / 448.f : 1.f;
+            const float inv = am > 0.f ? 448.f / am : 0.f;
+            if (laneId == 0) qScalesArr[row] = sc;
+            #pragma unroll
+            for (int e = 0; e < EPL; ++e) {
+                const __nv_fp8_e4m3 f8{ vals[e] * inv };
+                smemBytes[Q8_OFF + (uint32_t)(row * HEAD_DIM + laneId * EPL + e)] =
+                    static_cast<char>(f8.__x);
+            }
+        }
+        __syncwarp();
+    }
+
+    /* A-fragments for kind::f8f6f4 m16n8k32 from the row-major Q8 stage:
+       a0 = row g     dims [4t, 4t+4)   a2 = row g     dims [4t+16, ..)
+       a1 = row g+8   dims [4t, 4t+4)   a3 = row g+8   dims [4t+16, ..)
+       (t = lane%4, g = lane/4; validated vs fp64 oracle in
+       spikes/spike_fp8_qk_mapping.cu). Also pulls the 2 per-row scales. */
+    FK_DEVICE_FUSE void loadQF8Frags(const char* smemBytes,
+                                     uint32_t (&qReg8)[WARP_Q / MMA_M][HEAD_DIM / 32][4],
+                                     float (&qs)[WARP_Q / MMA_M][2],
+                                     const int warpId, const int laneId) {
+        const float* qScalesArr = reinterpret_cast<const float*>(smemBytes + QSC_OFF);
+        const int g = laneId >> 2, tig = laneId & 3;
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            const int rowA = warpId * WARP_Q + mq * MMA_M + g;
+            const int rowB = rowA + 8;
+            qs[mq][0] = qScalesArr[rowA];
+            qs[mq][1] = qScalesArr[rowB];
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / 32; ++md) {
+                const uint32_t a = Q8_OFF + (uint32_t)(rowA * HEAD_DIM + md * 32 + 4 * tig);
+                const uint32_t b = Q8_OFF + (uint32_t)(rowB * HEAD_DIM + md * 32 + 4 * tig);
+                qReg8[mq][md][0] = *reinterpret_cast<const uint32_t*>(smemBytes + a);
+                qReg8[mq][md][1] = *reinterpret_cast<const uint32_t*>(smemBytes + b);
+                qReg8[mq][md][2] = *reinterpret_cast<const uint32_t*>(smemBytes + a + 16);
+                qReg8[mq][md][3] = *reinterpret_cast<const uint32_t*>(smemBytes + b + 16);
+            }
+        }
+    }
+
+    /* QK^T on raw e4m3: stream B-fragments (2x u32 = 8 tokens' k-chunks)
+       straight from the SWZ8-swizzled byte stage — no kReg staging, no K
+       dequant pass. B mapping: b0 = token (mkv*8+g), dims [4t, 4t+4);
+       b1 = +16 dims. After the md accumulation completes for a token
+       column block, folds qScale[row]*kScale[col] into the raw scores
+       (D cols of lane (g,t) are 2t and 2t+1 — validated in
+       spikes/spike_fp8_qk_mapping.cu). */
+    FK_DEVICE_FUSE void sMmaFp8(const uint32_t (&qReg8)[WARP_Q / MMA_M][HEAD_DIM / 32][4],
+                                const float (&qs)[WARP_Q / MMA_M][2],
+                                const char* smemBytes, const uint32_t kStageOff,
+                                const float* kScalesPlane, const int offKV,
+                                const int seqK,
+                                SPTile (&sp)[WARP_Q / MMA_M], const int laneId) {
+        using namespace attention_mma_detail;
+        const int g = laneId >> 2, tig = laneId & 3;
+        #pragma unroll
+        for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            const int tok = mkv * MMA_N + g;
+            const uint32_t rowOff = (uint32_t)(tok * HEAD_DIM);
+            const uint32_t sw = (uint32_t)((tok & 7) * 8);
+            #pragma unroll
+            for (int md = 0; md < HEAD_DIM / 32; ++md) {
+                uint32_t b[2];
+                const uint32_t base = rowOff + (uint32_t)(md * 32 + 4 * tig);
+                b[0] = *reinterpret_cast<const uint32_t*>(
+                    smemBytes + kStageOff + (base ^ sw));
+                b[1] = *reinterpret_cast<const uint32_t*>(
+                    smemBytes + kStageOff + ((base + 16) ^ sw));
+                #pragma unroll
+                for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+                    mma_fp8_m16n8k32(qReg8[mq][md], b, sp[mq].s[mkv]);
+            }
+            // scale fold: cols of this lane within the 8-wide N block.
+            // L1-cached global reads (whole block touches BLOCK_KV floats);
+            // ragged guard avoids OOB scale reads past seq_k.
+            const int c0 = offKV + mkv * MMA_N + 2 * tig;
+            const float kc0 = (c0 < seqK) ? kScalesPlane[c0] : 0.f;
+            const float kc1 = (c0 + 1 < seqK) ? kScalesPlane[c0 + 1] : 0.f;
+            #pragma unroll
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                float* r = sp[mq].s[mkv];
+                r[0] *= qs[mq][0] * kc0;
+                r[1] *= qs[mq][0] * kc1;
+                r[2] *= qs[mq][1] * kc0;
+                r[3] *= qs[mq][1] * kc1;
+            }
+        }
+    }
+#endif // FK_HAS_FP8
+
     // ---- shared fragment loaders / mma helpers ------------------------------
     FK_DEVICE_FUSE void loadKFrags(const uint32_t base, const uint32_t kThread,
                                    uint32_t (&kReg)[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2]) {
@@ -515,19 +681,8 @@ public:
         }
     }
 
-    /* Fused S/P register tile. The fp32 scores (s) and the packed bf16x2
-     * probabilities (p) used to live in SEPARATE arrays (32 + 16 regs at
-     * BKV=64), but their live ranges only overlap inside softmaxTile, and
-     * the pack is strictly in-place-safe: iteration mkv writes p bytes
-     * [8*mkv, 8*mkv+8) while s reads touch [16*mkv, 16*mkv+16) — the write
-     * head never catches the read head (only mkv==0 overlaps, and there the
-     * statement order consumes s[0..1] before overwriting them). Overlaying
-     * p on the first half of s saves BLOCK_KV/4 regs/thread (16 at BKV=64):
-     * 138 -> target ~122. */
-    union SPTile {
-        float    s[BLOCK_KV / MMA_N][4];   // QK^T scores / exp(s - m), fp32
-        uint32_t p[BLOCK_KV / MMA_K][4];   // packed bf16x2 P (first half of s)
-    };
+    /* Fused S/P register tile — defined above the FP8 helpers (sMmaFp8 takes
+     * SPTile&). See the union doc there. */
 
     /* mask + online softmax + P pack for one KV tile (shared by both
        schedules). noMask: compile-out the bounds/causal branch for interior
@@ -797,14 +952,26 @@ public:
         __syncthreads();
 
         uint32_t qReg[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4];
-        #pragma unroll
-        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+        // FP8_QK state (dead/eliminated when the path is off — all uses sit
+        // inside `if constexpr (FP8_QK)`).
+        uint32_t qReg8[WARP_Q / MMA_M][HEAD_DIM / 32][4];
+        float qs[WARP_Q / MMA_M][2];
+        if constexpr (FP8_QK) {
+#ifdef FK_HAS_FP8
+            // quantize the staged bf16 Q per-row to e4m3 + pull A-fragments.
+            quantizeQTile(smemBytes, warpId, laneId);
+            loadQF8Frags(smemBytes, qReg8, qs, warpId, laneId);
+#endif
+        } else {
             #pragma unroll
-            for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
-                uint32_t addr = smemBase + qThread;
-                addr += mq * MMA_M * STRIDE_B;
-                addr ^= md * MMA_K * sizeof(__nv_bfloat16);
-                ldmatrix_x4(qReg[mq][md], addr);
+            for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_K; ++md) {
+                    uint32_t addr = smemBase + qThread;
+                    addr += mq * MMA_M * STRIDE_B;
+                    addr ^= md * MMA_K * sizeof(__nv_bfloat16);
+                    ldmatrix_x4(qReg[mq][md], addr);
+                }
             }
         }
         __syncthreads();
@@ -945,10 +1112,11 @@ public:
                 return stageBase + (uint32_t)(i % 2) * (KV_BUF_B / 2); };
             const uint32_t vStage = stageBase + 2 * (KV_BUF_B / 2);
 
-            // prefetch first in-range tile bytes
+            // prefetch first in-range tile bytes (FP8_QK: SWZ8-swizzled K so
+            // sMmaFp8's direct 4B fragment reads don't bank-conflict)
             if (itBegin < itEnd && tileActive(itBegin * BLOCK_KV)) {
-                cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(itBegin), kPlane,
-                                            itBegin * BLOCK_KV, p.seq_k);
+                cpasyncQuantTile<KV_GROUPS, FP8_QK>(smemBase + kStage(itBegin), kPlane,
+                                                    itBegin * BLOCK_KV, p.seq_k);
             }
             cp_async_commit();
 
@@ -964,22 +1132,33 @@ public:
 
                 cp_async_wait<1>();   // K bytes ready
                 __syncthreads();
-                if (act) {
-                    dequantTile<KV_GROUPS, IS_FP8>(smemBytes, kStage(kv), kBuf(kv),
-                                                   kScales, offKV, p.seq_k);
+                if constexpr (!FP8_QK) {
+                    // bf16 fallback: dequant K smem->smem, then ldmatrix
+                    if (act) {
+                        dequantTile<KV_GROUPS, IS_FP8>(smemBytes, kStage(kv), kBuf(kv),
+                                                       kScales, offKV, p.seq_k);
+                    }
+                    __syncthreads();
                 }
-                __syncthreads();
 
                 SPTile sp[WARP_Q / MMA_M] = {};
                 if (act) {
-                    uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                    loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-                    sMma(qReg, kReg, sp);
+                    if constexpr (FP8_QK) {
+#ifdef FK_HAS_FP8
+                        // QK^T straight on the raw e4m3 bytes (no K dequant)
+                        sMmaFp8(qReg8, qs, smemBytes, kStage(kv), kScales,
+                                offKV, p.seq_k, sp, laneId);
+#endif
+                    } else {
+                        uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                        loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                        sMma(qReg, kReg, sp);
+                    }
                 }
 
                 if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
-                    cpasyncQuantTile<KV_GROUPS>(smemBase + kStage(kv + 1), kPlane,
-                                                offKV + BLOCK_KV, p.seq_k);
+                    cpasyncQuantTile<KV_GROUPS, FP8_QK>(smemBase + kStage(kv + 1), kPlane,
+                                                        offKV + BLOCK_KV, p.seq_k);
                 }
                 cp_async_commit();
 

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -290,6 +290,15 @@ private:
                                           ScoreModOp>;
 public:
     static constexpr bool HAS_SCORE_MOD = !std::is_same_v<ScoreModOp, NoScoreMod>;
+    // ALiBi SPECIALIZATION: the bias -slope*(q-k) = -slope*q + slope*k is
+    // linear, and the per-row term -slope*q is CONSTANT within a row, so it
+    // cancels in softmax. Applying only the column term +slope*k makes the
+    // bias row-independent, introduces no -FLT_MAX sentinels, and keeps the
+    // NO_MASK exp fast path for interior tiles (the generic scoreMod path
+    // disabled it, costing 0.81-0.91x vs FA at s4096-8192 in the gauntlet).
+    // Both branches (interior + masked) use the column-only form so every
+    // score of a row shifts by the same constant -> softmax identical.
+    static constexpr bool IS_ALIBI = std::is_same_v<ScoreModOp, ALiBiScoreMod>;
 private:
 public:
     FK_STATIC_STRUCT(FlashAttentionMmaDPP, SelfType)
@@ -704,9 +713,20 @@ public:
             for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
                 float* r = sp[mq].s[mkv];
                 const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
-                if constexpr (NO_MASK && !HAS_SCORE_MOD) {
-                    #pragma unroll
-                    for (int e = 0; e < 4; ++e) r[e] *= p.scale;
+                if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
+                    if constexpr (IS_ALIBI) {
+                        // column-only ALiBi (row term cancels in softmax):
+                        // keeps the fast path — no sentinels, no row math.
+                        const float b0 = p.scoreMod.slope * (float)colBase;
+                        const float b1 = p.scoreMod.slope * (float)(colBase + 1);
+                        r[0] = r[0] * p.scale + b0;
+                        r[1] = r[1] * p.scale + b1;
+                        r[2] = r[2] * p.scale + b0;
+                        r[3] = r[3] * p.scale + b1;
+                    } else {
+                        #pragma unroll
+                        for (int e = 0; e < 4; ++e) r[e] *= p.scale;
+                    }
                 } else {
                     #pragma unroll
                     for (int e = 0; e < 4; ++e) {
@@ -716,7 +736,11 @@ public:
                         if constexpr (NO_MASK) { dead = false; }
                         else { dead = (col >= p.seq_k) || (p.causal && col > row); }
                         float s = r[e] * p.scale;
-                        if constexpr (HAS_SCORE_MOD) {
+                        if constexpr (IS_ALIBI) {
+                            // same column-only form as the fast path (exact:
+                            // both branches shift each row by -slope*row).
+                            s += p.scoreMod.slope * (float)col;
+                        } else if constexpr (HAS_SCORE_MOD) {
                             // flex score_mod / mask_mod: AFTER scaling
                             if (!dead) s = p.scoreMod(s, row, col);
                         }
@@ -771,7 +795,9 @@ public:
                 // s is dead after this loop, so nothing is written back.
                 const float* r = sp[mq].s[mkv];
                 float e[4];
-                if constexpr (NO_MASK && !HAS_SCORE_MOD) {
+                if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
+                    // ALiBi fast path qualifies too: column-only bias adds
+                    // no -FLT_MAX sentinels on interior tiles.
                     e[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
                     e[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
                     e[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -1004,6 +1004,9 @@ public:
         // launch order -> reversing the raster for causal starts the heavy
         // blocks first and the light ones fill the tail. Dense work is
         // uniform; keep natural order (better L2 locality on K/V).
+        // (A small-grid guard was tried and REVERTED: disabling the reversal
+        // below 1024 blocks made bh8 s2048 WORSE, 0.82->0.76 vs FA — even at
+        // ~1.4 waves the tail dominates. Reversal is unconditional.)
         const int qBlockIdx = p.causal ? (int)(gridDim.x - 1 - blockIdx.x)
                                        : (int)blockIdx.x;
         const int qBlockBase = qBlockIdx * BLOCK_Q;

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -534,10 +534,21 @@ public:
      * head never catches the read head (only mkv==0 overlaps, and there the
      * statement order consumes s[0..1] before overwriting them). Overlaying
      * p on the first half of s saves BLOCK_KV/4 regs/thread (16 at BKV=64). */
-    union SPTile {
-        float    s[BLOCK_KV / MMA_N][4];   // QK^T scores / exp(s - m), fp32
-        uint32_t p[BLOCK_KV / MMA_K][4];   // packed bf16x2 P (first half of s)
+    template <int SPAN>
+    union SPTileT {
+        float    s[SPAN / MMA_N][4];   // QK^T scores / exp(s - m), fp32
+        uint32_t p[SPAN / MMA_K][4];   // packed bf16x2 P (first half of s)
     };
+    using SPTile = SPTileT<BLOCK_KV>;
+    // SPLIT-S (bucket-A attempt, MEASURED INEFFECTIVE — kept off): halving
+    // the live score tile did NOT lower ptxas regs (134 either way — the
+    // allocator already overlaps sp with the kReg/frag staging), and dense
+    // throughput dropped ~2% from the extra zero-fill + second softmax tail.
+    // Re-enable only if a future change makes the score tile the real
+    // live-range ceiling.
+    static constexpr bool SPLIT_S = false;
+    static constexpr int KV_SPAN = SPLIT_S ? BLOCK_KV / 2 : BLOCK_KV;
+    using SPSpan = SPTileT<KV_SPAN>;
 
     // Q8 stage layout (Q-phase only; dead once qReg8/qs are in registers):
     //   [BLOCK_Q*STRIDE_B, +BLOCK_Q*HEAD_DIM)        row-major e4m3 Q bytes
@@ -696,8 +707,8 @@ public:
     /* mask + online softmax + P pack for one KV tile (shared by both
        schedules). noMask: compile-out the bounds/causal branch for interior
        tiles (the common case at long seq). */
-    template <bool NO_MASK>
-    FK_DEVICE_FUSE void softmaxTile(SPTile (&sp)[WARP_Q / MMA_M],
+    template <bool NO_MASK, int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void softmaxTile(SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
                                     float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
                                     float (&rowMax)[WARP_Q / MMA_M][2],
                                     float (&rowSum)[WARP_Q / MMA_M][2],
@@ -710,7 +721,7 @@ public:
             const int rowB = rowA + 8;
 
             #pragma unroll
-            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
                 float* r = sp[mq].s[mkv];
                 const int colBase = offKV + mkv * MMA_N + (laneId % 4) * 2;
                 if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
@@ -751,7 +762,7 @@ public:
 
             float mNew[2] = { -FLT_MAX, -FLT_MAX };
             #pragma unroll
-            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
                 const float* r = sp[mq].s[mkv];
                 mNew[0] = fmaxf(mNew[0], fmaxf(r[0], r[1]));
                 mNew[1] = fmaxf(mNew[1], fmaxf(r[2], r[3]));
@@ -786,7 +797,7 @@ public:
 
             float lNew[2] = {};
             #pragma unroll
-            for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+            for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
                 // Read scores BEFORE packing: iteration mkv packs into union
                 // bytes [8*mkv, 8*mkv+8) while reading s bytes
                 // [16*mkv, 16*mkv+16) — the pack write head never reaches
@@ -844,20 +855,23 @@ public:
      * ldmatrix.x4 immediately before their mma instead of staging the whole
      * tile (kReg was 64 regs/thread live across the loop -> now 4). ncu
      * showed 154 regs/thread capped occupancy at 3 blocks/SM; this fusion
-     * (+V below, +3 smem bufs) unlocks the 4th block. */
+     * (+V below, +3 smem bufs) unlocks the 4th block.
+     * SPAN/tokOff: split-S processes the smem tile in KV_SPAN-token spans. */
+    template <int SPAN = BLOCK_KV>
     FK_DEVICE_FUSE void sMmaStream(const uint32_t (&qReg)[WARP_Q / MMA_M][HEAD_DIM / MMA_K][4],
                                    const uint32_t base, const uint32_t kThread,
-                                   SPTile (&sp)[WARP_Q / MMA_M]) {
+                                   SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
+                                   const int tokOff = 0) {
         using namespace attention_mma_detail;
         #pragma unroll
-        for (int mkv = 0; mkv < BLOCK_KV / MMA_N; ++mkv) {
+        for (int mkv = 0; mkv < SPAN / MMA_N; ++mkv) {
             #pragma unroll
             for (int md = 0; md < HEAD_DIM / MMA_K; md += 2) {
                 // identical x4 pattern to loadKFrags: one mkv row, fragments
                 // for md (regs 0-1) and md+1 (regs 2-3).
                 uint32_t frag[4];
                 uint32_t addr = base + kThread;
-                addr += mkv * MMA_N * STRIDE_B;
+                addr += (tokOff + mkv * MMA_N) * STRIDE_B;
                 addr ^= md * MMA_K * sizeof(__nv_bfloat16);
                 ldmatrix_x4(frag, addr);
                 #pragma unroll
@@ -884,17 +898,19 @@ public:
 
     /* Same fusion for P·V: stream V fragments (trans ldmatrix.x4) right
      * before use. vReg was another 32-64 live regs. */
-    FK_DEVICE_FUSE void pvMmaStream(const SPTile (&sp)[WARP_Q / MMA_M],
+    template <int SPAN = BLOCK_KV>
+    FK_DEVICE_FUSE void pvMmaStream(const SPTileT<SPAN> (&sp)[WARP_Q / MMA_M],
                                     const uint32_t base, const uint32_t vThread,
-                                    float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4]) {
+                                    float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                    const int tokOff = 0) {
         using namespace attention_mma_detail;
         #pragma unroll
-        for (int mkv = 0; mkv < BLOCK_KV / MMA_K; ++mkv) {
+        for (int mkv = 0; mkv < SPAN / MMA_K; ++mkv) {
             #pragma unroll
             for (int md = 0; md < HEAD_DIM / MMA_N; md += 2) {
                 uint32_t frag[4];
                 uint32_t addr = base + vThread;
-                addr += mkv * MMA_K * STRIDE_B;
+                addr += (tokOff + mkv * MMA_K) * STRIDE_B;
                 addr ^= md * MMA_N * sizeof(__nv_bfloat16);
                 ldmatrix_x4_trans(frag, addr);
                 #pragma unroll
@@ -954,7 +970,16 @@ public:
         const int warpId = tid / 32;
         const int laneId = tid % 32;
         const int bh = blockIdx.y;
-        const int qBlockBase = blockIdx.x * BLOCK_Q;
+        // CAUSAL LOAD-BALANCE: q-block i does O(i) KV tiles of work, so the
+        // natural launch order puts the heaviest blocks LAST and leaves a
+        // long single-block tail (ncu: achieved occupancy 10.9% vs 33%
+        // theoretical on s2048 causal). GPUs schedule blocks roughly in
+        // launch order -> reversing the raster for causal starts the heavy
+        // blocks first and the light ones fill the tail. Dense work is
+        // uniform; keep natural order (better L2 locality on K/V).
+        const int qBlockIdx = p.causal ? (int)(gridDim.x - 1 - blockIdx.x)
+                                       : (int)blockIdx.x;
+        const int qBlockBase = qBlockIdx * BLOCK_Q;
 
         const uint32_t qThread = swz(((warpId * WARP_Q + laneId % 16) * HEAD_DIM
                                       + (laneId / 16) * 8) * sizeof(__nv_bfloat16));
@@ -1084,37 +1109,106 @@ public:
                 cp_async_wait<1>();
                 __syncthreads();
 
-                SPTile sp[WARP_Q / MMA_M] = {};
-                if (act) {
-                    uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
-                    loadKFrags(smemBase + kBuf(kv), kThread, kReg);
-                    sMma(qReg, kReg, sp);
-                }
+                if constexpr (SPLIT_S) {
+                    // ============== split-S: two SEQUENTIAL KV_SPAN passes ==
+                    // Only ONE SPSpan (16 fp32 regs at BKV64) is live at a
+                    // time: span0 runs QK^T->softmax->PV to completion before
+                    // span1 starts. Safe because K[kv] is double-buffered
+                    // (K[kv+1] streams into the OTHER buffer) and V[kv] is
+                    // single-buffered but only overwritten after the next
+                    // iteration's __syncthreads. The K[kv+1] prefetch is
+                    // issued between span0's QK^T and softmax (v5 stagger);
+                    // V wait happens before span0's PV, so span1 runs with
+                    // both tiles resident — zero extra syncs vs the fused
+                    // tile.
+                    // span 0 ---------------------------------------------
+                    SPSpan sp[WARP_Q / MMA_M] = {};
+                    if (act) sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
+                                                 kThread, sp, 0);
 
-                // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
-                if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
-                    cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
-                                           offKV + BLOCK_KV, p.seq_k);
-                }
-                cp_async_commit();
-
-                if (act) {
-                    if (tileNeedsMask(offKV)) {
-                        softmaxTile<false>(sp, oAcc, rowMax, rowSum, p, offKV,
-                                           qBlockBase, warpId, laneId);
-                    } else {
-                        softmaxTile<true>(sp, oAcc, rowMax, rowSum, p, offKV,
-                                          qBlockBase, warpId, laneId);
+                    // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
+                    if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
+                        cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
+                                               offKV + BLOCK_KV, p.seq_k);
                     }
-                }
+                    cp_async_commit();
 
-                // wait V[kv] (1 group outstanding: K[kv+1])
-                cp_async_wait<1>();
-                __syncthreads();
+                    const bool needsMask = tileNeedsMask(offKV);
+                    if (act) {
+                        if (needsMask) {
+                            softmaxTile<false, KV_SPAN>(sp, oAcc, rowMax, rowSum,
+                                                        p, offKV, qBlockBase,
+                                                        warpId, laneId);
+                        } else {
+                            softmaxTile<true, KV_SPAN>(sp, oAcc, rowMax, rowSum,
+                                                       p, offKV, qBlockBase,
+                                                       warpId, laneId);
+                        }
+                    }
 
-                if (act) {
-                    // stream V frags ldmatrix->mma (no vReg staging)
-                    pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
+                    // wait V[kv] (1 group outstanding: K[kv+1])
+                    cp_async_wait<1>();
+                    __syncthreads();
+
+                    if (act) {
+                        pvMmaStream<KV_SPAN>(sp, smemBase + vBufOff, vThread,
+                                             oAcc, 0);
+                        // span 1 ------------------------------------------
+                        // reuses the same sp storage; K[kv]/V[kv] still
+                        // resident (see buffer-lifetime note above).
+                        #pragma unroll
+                        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq)
+                            #pragma unroll
+                            for (int i = 0; i < KV_SPAN / MMA_N; ++i)
+                                #pragma unroll
+                                for (int e = 0; e < 4; ++e) sp[mq].s[i][e] = 0.f;
+                        sMmaStream<KV_SPAN>(qReg, smemBase + kBuf(kv),
+                                            kThread, sp, KV_SPAN);
+                        if (needsMask) {
+                            softmaxTile<false, KV_SPAN>(sp, oAcc, rowMax, rowSum,
+                                                        p, offKV + KV_SPAN,
+                                                        qBlockBase, warpId, laneId);
+                        } else {
+                            softmaxTile<true, KV_SPAN>(sp, oAcc, rowMax, rowSum,
+                                                       p, offKV + KV_SPAN,
+                                                       qBlockBase, warpId, laneId);
+                        }
+                        pvMmaStream<KV_SPAN>(sp, smemBase + vBufOff, vThread,
+                                             oAcc, KV_SPAN);
+                    }
+                } else {
+                    SPTile sp[WARP_Q / MMA_M] = {};
+                    if (act) {
+                        uint32_t kReg[BLOCK_KV / MMA_N][HEAD_DIM / MMA_K][2];
+                        loadKFrags(smemBase + kBuf(kv), kThread, kReg);
+                        sMma(qReg, kReg, sp);
+                    }
+
+                    // prefetch K[kv+1] (overlaps softmax + PV, v5 staggering)
+                    if (kv + 1 < itEnd && tileActive(offKV + BLOCK_KV)) {
+                        cpasyncTile<KV_GROUPS>(smemBase + kBuf(kv + 1), kPlane,
+                                               offKV + BLOCK_KV, p.seq_k);
+                    }
+                    cp_async_commit();
+
+                    if (act) {
+                        if (tileNeedsMask(offKV)) {
+                            softmaxTile<false>(sp, oAcc, rowMax, rowSum, p, offKV,
+                                               qBlockBase, warpId, laneId);
+                        } else {
+                            softmaxTile<true>(sp, oAcc, rowMax, rowSum, p, offKV,
+                                              qBlockBase, warpId, laneId);
+                        }
+                    }
+
+                    // wait V[kv] (1 group outstanding: K[kv+1])
+                    cp_async_wait<1>();
+                    __syncthreads();
+
+                    if (act) {
+                        // stream V frags ldmatrix->mma (no vReg staging)
+                        pvMmaStream(sp, smemBase + vBufOff, vThread, oAcc);
+                    }
                 }
             }
         } else if constexpr (QUANT_KV) {

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -372,7 +372,18 @@ public:
         EpilogueIOp epilogue;
         ScoreModOp scoreMod;     // flex-attention score_mod / mask_mod
         BlockSparsity sparse;    // block-sparse tile skipping (nullptr = dense)
+        // SPLIT-KV FORWARD (FA-style): when splits > 1, blockIdx.z selects a
+        // KV chunk and the kernel writes UNNORMALIZED partials (oAcc, m, l)
+        // to `partial` instead of O; a combine kernel reduces them. Sized
+        // [bh, seq_q, splits, HEAD_DIM+2]. Saturates the GPU on small grids
+        // (bh*numQ << 1 wave) — ncu: FA runs 5.45 waves vs our 0.68 on
+        // d128 bh8 s2048, hiding everything; this is that lever.
+        float* partial = nullptr;
+        int splits = 1;
     };
+    // log2-domain softmax is active for these functor types (see softmaxTile);
+    // the split combine must interpret stored row-maxes in the same base.
+    static constexpr bool LOG2_DOMAIN = !HAS_SCORE_MOD || IS_ALIBI;
 
     FK_DEVICE_FUSE uint32_t swz(const uint32_t byteOff) {
         const uint32_t row = (byteOff / STRIDE_B) % 8;
@@ -977,6 +988,41 @@ public:
         }
     }
 
+    /* split-KV partial writeout: UNNORMALIZED oAcc plus per-row (m, l).
+       Layout [bh, seq_q, splits, HEAD_DIM+2] — fp32. Lane (laneId%4) owns
+       cols {2t, 2t+1} of each MMA_N block, rows rowA/rowB as in writeOut. */
+    FK_DEVICE_FUSE void writePartial(const float (&oAcc)[WARP_Q / MMA_M][HEAD_DIM / MMA_N][4],
+                                     const float (&rowMax)[WARP_Q / MMA_M][2],
+                                     const float (&rowSum)[WARP_Q / MMA_M][2],
+                                     const Params& p, const int qBlockBase,
+                                     const int warpId, const int laneId, const int bh) {
+        const int split = blockIdx.z;
+        const long strideRow = (long)p.splits * (HEAD_DIM + 2);
+        #pragma unroll
+        for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
+            const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
+            const int rowB = rowA + 8;
+            #pragma unroll
+            for (int half = 0; half < 2; ++half) {
+                const int row = half == 0 ? rowA : rowB;
+                if (row >= p.seq_q) continue;
+                float* dst = p.partial
+                    + ((long)bh * p.seq_q + row) * strideRow
+                    + (long)split * (HEAD_DIM + 2);
+                #pragma unroll
+                for (int md = 0; md < HEAD_DIM / MMA_N; ++md) {
+                    const int col = md * MMA_N + (laneId % 4) * 2;
+                    dst[col]     = oAcc[mq][md][half * 2];
+                    dst[col + 1] = oAcc[mq][md][half * 2 + 1];
+                }
+                if (laneId % 4 == 0) {
+                    dst[HEAD_DIM]     = rowMax[mq][half];
+                    dst[HEAD_DIM + 1] = rowSum[mq][half];
+                }
+            }
+        }
+    }
+
     FK_DEVICE_FUSE void storePair(OT* dst, const float a, const float b) {
         if constexpr (std::is_same_v<OT, __nv_bfloat16>) {
             *reinterpret_cast<__nv_bfloat162*>(dst) = __float22bfloat162_rn({ a, b });
@@ -986,6 +1032,7 @@ public:
         }
     }
 
+    template <bool SPLIT_KV = false>
     static __device__ void exec(const Params& p) {
         using namespace attention_mma_detail;
         extern __shared__ char smemRaw[];
@@ -1106,6 +1153,18 @@ public:
                 itBegin = ::min(numIter, first * tilesPerMask);
                 itEnd = ::min(numIter, (last + 1) * tilesPerMask);
             }
+        }
+        // SPLIT-KV: blockIdx.z takes an equal chunk of THIS q-block's
+        // iteration range (adapts to causal: each q-block splits its own
+        // numIter). Compile-time gated: the runtime-branch version kept
+        // rowMax live through the epilogue in EVERY kernel and cost ~20%
+        // on splits==1 shapes (d64 bh32 s2048 dense 0.88->0.70 measured).
+        if constexpr (SPLIT_KV) {
+            const int span = itEnd - itBegin;
+            const int chunk = (span + p.splits - 1) / p.splits;
+            const int s0 = itBegin + (int)blockIdx.z * chunk;
+            itEnd = ::min(itEnd, s0 + chunk);
+            itBegin = ::min(s0, itEnd);
         }
 
         if constexpr (RAW_KV) {
@@ -1387,19 +1446,65 @@ public:
             }
         }
 
-        writeOut(oAcc, rowSum, p, qBlockBase, warpId, laneId, bh);
+        if constexpr (SPLIT_KV) {
+            writePartial(oAcc, rowMax, rowSum, p, qBlockBase, warpId, laneId, bh);
+        } else {
+            writeOut(oAcc, rowSum, p, qBlockBase, warpId, laneId, bh);
+        }
     }
 };
 
+/* split-KV combine: one block per (bh, row-chunk); exact online-softmax
+   merge of `splits` unnormalized partials. expBase: 2^x when the producer
+   kernel ran log2-domain softmax, e^x otherwise. */
+template <typename OT, int HEAD_DIM, bool LOG2D>
+__global__ void flashFwdSplitCombineKernel(const float* __restrict__ partial,
+                                           OT* __restrict__ o,
+                                           const int seqQ, const int splits) {
+    const int bh = blockIdx.y;
+    const int row = blockIdx.x * blockDim.y + threadIdx.y;
+    if (row >= seqQ) return;
+    const float* base = partial
+        + ((long)bh * seqQ + row) * (long)splits * (HEAD_DIM + 2);
+    // global max over splits (uniform across the row's threads)
+    float gm = -FLT_MAX;
+    for (int s = 0; s < splits; ++s)
+        gm = fmaxf(gm, base[s * (HEAD_DIM + 2) + HEAD_DIM]);
+    // each thread owns HEAD_DIM/32 columns
+    float acc[HEAD_DIM / 32] = {};
+    float l = 0.f;
+    for (int s = 0; s < splits; ++s) {
+        const float* ps = base + s * (HEAD_DIM + 2);
+        const float m = ps[HEAD_DIM];
+        if (m == -FLT_MAX) continue;            // empty chunk
+        const float w = LOG2D ? exp2f(m - gm) : __expf(m - gm);
+        l += ps[HEAD_DIM + 1] * w;
+        #pragma unroll
+        for (int c = 0; c < HEAD_DIM / 32; ++c)
+            acc[c] += ps[threadIdx.x + c * 32] * w;
+    }
+    const float inv = l > 0.f ? 1.f / l : 0.f;
+    OT* dst = o + ((long)bh * seqQ + row) * HEAD_DIM;
+    #pragma unroll
+    for (int c = 0; c < HEAD_DIM / 32; ++c) {
+        if constexpr (std::is_same_v<OT, __nv_bfloat16>) {
+            dst[threadIdx.x + c * 32] = __float2bfloat16(acc[c] * inv);
+        } else {
+            dst[threadIdx.x + c * 32] = static_cast<OT>(acc[c] * inv);
+        }
+    }
+}
+
 template <typename OT, int HEAD_DIM, typename QIOp, typename KIOp, typename VIOp,
           typename EpilogueIOp, int BLOCK_Q, int BLOCK_KV, int NUM_WARPS,
-          typename ScoreModOp>
+          typename ScoreModOp, bool SPLIT_KV = false>
 __global__ void launchFlashAttentionMmaDPP_Kernel(
         const __grid_constant__ typename FlashAttentionMmaDPP<
             OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
             BLOCK_Q, BLOCK_KV, NUM_WARPS, ScoreModOp>::Params params) {
     FlashAttentionMmaDPP<OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp,
-                         BLOCK_Q, BLOCK_KV, NUM_WARPS, ScoreModOp>::exec(params);
+                         BLOCK_Q, BLOCK_KV, NUM_WARPS,
+                         ScoreModOp>::template exec<SPLIT_KV>(params);
 }
 
 /* IOp-first API. The DPP auto-selects cp.async streaming (raw bf16
@@ -1465,9 +1570,9 @@ inline void executeFlashAttentionMma(
                 "tiles (BQ=" + std::to_string(BQ) + ", BKV=" + std::to_string(BKV) + ")");
         }
     }
-    const typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal,
-                                       epilogue, scoreMod, sparse };
-    const dim3 grid((seqQ + BQ - 1) / BQ, batchHeads, 1);
+    typename DPP::Params params{ q, k, v, o, seqQ, seqK, scale, causal,
+                                 epilogue, scoreMod, sparse };
+    const int numQ = (seqQ + BQ - 1) / BQ;
     const dim3 block(DPP::THREADS, 1, 1);
     const int smemBytes = DPP::SMEM_BYTES;
     auto* kernel = launchFlashAttentionMmaDPP_Kernel<OT, HEAD_DIM, QIOp, KIOp, VIOp,
@@ -1477,8 +1582,70 @@ inline void executeFlashAttentionMma(
         gpuErrchk(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
                                        smemBytes));
     }
-    kernel<<<grid, block, smemBytes, stream.getCUDAStream()>>>(params);
-    gpuErrchk(cudaGetLastError());
+    // SPLIT-KV FORWARD for under-saturated grids (ncu, d128 bh8 s2048: FA
+    // launches 5.45 waves via splits while we ran 0.68 — SMs idle). When
+    // numQ*bh covers < ~70% of one resident wave, split the KV range across
+    // blockIdx.z, write unnormalized partials, and reduce with an exact
+    // online-softmax combine kernel. Disabled for block-sparse (the sparse
+    // iteration trim already reshapes the range per q-block).
+    int splits = 1;
+    float* partial = nullptr;
+    if (sparse.mask == nullptr) {
+        static const int wave = [&] {
+            int bpm = 0, dev = 0, sms = 0;
+            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&bpm, kernel,
+                                                          DPP::THREADS, smemBytes);
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+            return (bpm > 0 ? bpm : 1) * sms;
+        }();
+        const long gridBlocks = (long)numQ * batchHeads;
+        // average KV iterations per q-block (causal averages ~half the row)
+        const int avgIter = ::max(1, (int)(((long)(causal ? seqK / 2 : seqK)) / BKV));
+        // THRESHOLD (measured per regime): causal benefits up to ~0.7 wave
+        // (the triangular tail leaves SMs idle even at 0.68 wave: d128 bh8
+        // s2048 causal 0.76->0.94 with splits); dense only below ~0.45 wave
+        // (at 0.68 wave the fp32 partial traffic costs more than the idle
+        // SMs: d64 bh32 s2048 dense 0.88->0.71 when split at 0.68 wave).
+        const long num = gridBlocks * 10;
+        const bool under = causal ? (num < (long)wave * 7)
+                                  : (num < (long)wave * 9 / 2);
+        if (under && avgIter >= 8) {
+            const int bySat  = (int)((wave + gridBlocks - 1) / gridBlocks);
+            const int byWork = avgIter / 4;   // keep >=4 KV tiles per chunk
+            splits = ::min(::min(bySat, byWork), 16);
+            splits = ::max(splits, 1);
+        }
+        if (splits > 1) {
+            const size_t bytes = (size_t)batchHeads * seqQ * splits
+                                 * (HEAD_DIM + 2) * sizeof(float);
+            gpuErrchk(cudaMallocAsync(&partial, bytes, stream.getCUDAStream()));
+            params.partial = partial;
+            params.splits = splits;
+        }
+    }
+    const dim3 grid(numQ, batchHeads, splits);
+    if (splits > 1) {
+        auto* splitKernel = launchFlashAttentionMmaDPP_Kernel<
+            OT, HEAD_DIM, QIOp, KIOp, VIOp, EpilogueIOp, BQ, BKV, NUM_WARPS,
+            ScoreModOp, /*SPLIT_KV=*/true>;
+        if (smemBytes > 48000) {
+            gpuErrchk(cudaFuncSetAttribute(splitKernel,
+                cudaFuncAttributeMaxDynamicSharedMemorySize, smemBytes));
+        }
+        splitKernel<<<grid, block, smemBytes, stream.getCUDAStream()>>>(params);
+        gpuErrchk(cudaGetLastError());
+        // combine: 32 threads per row (HEAD_DIM/32 cols each), 4 rows/block
+        const dim3 cblock(32, 4, 1);
+        const dim3 cgrid((seqQ + 3) / 4, batchHeads, 1);
+        flashFwdSplitCombineKernel<OT, HEAD_DIM, DPP::LOG2_DOMAIN>
+            <<<cgrid, cblock, 0, stream.getCUDAStream()>>>(partial, o, seqQ, splits);
+        gpuErrchk(cudaGetLastError());
+        gpuErrchk(cudaFreeAsync(partial, stream.getCUDAStream()));
+    } else {
+        kernel<<<grid, block, smemBytes, stream.getCUDAStream()>>>(params);
+        gpuErrchk(cudaGetLastError());
+    }
 }
 
 } // namespace fk

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -250,6 +250,19 @@ __device__ __forceinline__ float fastExp(const float x) {
 #endif
 }
 
+/* raw ex2.approx (2^x). __expf(x) lowers to FMUL(x, log2e) + MUFU.EX2 —
+ * folding log2e into the softmax scale ONCE removes that per-element FMUL
+ * (FA does the same). Inline asm so it does not depend on --use_fast_math. */
+__device__ __forceinline__ float fastExp2(const float x) {
+#if defined(__CUDA_ARCH__)
+    float y;
+    asm volatile("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+#else
+    return 0.f;
+#endif
+}
+
 // pack two fp32 into one bf16x2 register (uint32_t) — used by the in-place
 // S/P union pack in softmaxTile.
 __device__ __forceinline__ uint32_t packBf162(const float lo, const float hi) {
@@ -715,6 +728,14 @@ public:
                                     const Params& p, const int offKV,
                                     const int qBlockBase, const int warpId,
                                     const int laneId) {
+        // LOG2 DOMAIN: __expf lowers to FMUL(x, log2e) + MUFU.EX2. Folding
+        // log2e into the scale ONCE turns every per-element exp into a bare
+        // ex2.approx (removes BLOCK_KV/2 FMULs per row per tile) — same trick
+        // FA uses. Generic score_mods see natural-domain scores, so they keep
+        // the e-domain path; ALiBi folds log2e into the slope (exact).
+        constexpr bool LOG2D = !HAS_SCORE_MOD || IS_ALIBI;
+        constexpr float LOG2E = 1.4426950408889634f;
+        const float scl = LOG2D ? p.scale * LOG2E : p.scale;
         #pragma unroll
         for (int mq = 0; mq < WARP_Q / MMA_M; ++mq) {
             const int rowA = qBlockBase + warpId * WARP_Q + mq * MMA_M + laneId / 4;
@@ -728,15 +749,16 @@ public:
                     if constexpr (IS_ALIBI) {
                         // column-only ALiBi (row term cancels in softmax):
                         // keeps the fast path — no sentinels, no row math.
-                        const float b0 = p.scoreMod.slope * (float)colBase;
-                        const float b1 = p.scoreMod.slope * (float)(colBase + 1);
-                        r[0] = r[0] * p.scale + b0;
-                        r[1] = r[1] * p.scale + b1;
-                        r[2] = r[2] * p.scale + b0;
-                        r[3] = r[3] * p.scale + b1;
+                        const float slope2 = p.scoreMod.slope * LOG2E;
+                        const float b0 = slope2 * (float)colBase;
+                        const float b1 = slope2 * (float)(colBase + 1);
+                        r[0] = r[0] * scl + b0;
+                        r[1] = r[1] * scl + b1;
+                        r[2] = r[2] * scl + b0;
+                        r[3] = r[3] * scl + b1;
                     } else {
                         #pragma unroll
-                        for (int e = 0; e < 4; ++e) r[e] *= p.scale;
+                        for (int e = 0; e < 4; ++e) r[e] *= scl;
                     }
                 } else {
                     #pragma unroll
@@ -746,11 +768,11 @@ public:
                         bool dead;
                         if constexpr (NO_MASK) { dead = false; }
                         else { dead = (col >= p.seq_k) || (p.causal && col > row); }
-                        float s = r[e] * p.scale;
+                        float s = r[e] * scl;
                         if constexpr (IS_ALIBI) {
                             // same column-only form as the fast path (exact:
                             // both branches shift each row by -slope*row).
-                            s += p.scoreMod.slope * (float)col;
+                            s += p.scoreMod.slope * LOG2E * (float)col;
                         } else if constexpr (HAS_SCORE_MOD) {
                             // flex score_mod / mask_mod: AFTER scaling
                             if (!dead) s = p.scoreMod(s, row, col);
@@ -774,9 +796,14 @@ public:
                 mNew[half] = fmaxf(mNew[half], rowMax[mq][half]);
             }
 
+            // domain-aware exp: scores are in log2 domain when LOG2D
+            const auto EXP = [](const float x) {
+                return LOG2D ? attention_mma_detail::fastExp2(x)
+                             : attention_mma_detail::fastExp(x);
+            };
             float corr[2];
-            corr[0] = attention_mma_detail::fastExp(rowMax[mq][0] - mNew[0]);
-            corr[1] = attention_mma_detail::fastExp(rowMax[mq][1] - mNew[1]);
+            corr[0] = EXP(rowMax[mq][0] - mNew[0]);
+            corr[1] = EXP(rowMax[mq][1] - mNew[1]);
             // FA4-style rescale skip: at long seq most KV tiles do NOT move
             // the running max (rowMax == mNew -> corr == 1), so the
             // HEAD_DIM/MMA_N*4 FMULs over oAcc are identity work. The
@@ -809,15 +836,15 @@ public:
                 if constexpr (NO_MASK && (!HAS_SCORE_MOD || IS_ALIBI)) {
                     // ALiBi fast path qualifies too: column-only bias adds
                     // no -FLT_MAX sentinels on interior tiles.
-                    e[0] = attention_mma_detail::fastExp(r[0] - mNew[0]);
-                    e[1] = attention_mma_detail::fastExp(r[1] - mNew[0]);
-                    e[2] = attention_mma_detail::fastExp(r[2] - mNew[1]);
-                    e[3] = attention_mma_detail::fastExp(r[3] - mNew[1]);
+                    e[0] = EXP(r[0] - mNew[0]);
+                    e[1] = EXP(r[1] - mNew[0]);
+                    e[2] = EXP(r[2] - mNew[1]);
+                    e[3] = EXP(r[3] - mNew[1]);
                 } else {
-                    e[0] = (r[0] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[0] - mNew[0]);
-                    e[1] = (r[1] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[1] - mNew[0]);
-                    e[2] = (r[2] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[2] - mNew[1]);
-                    e[3] = (r[3] == -FLT_MAX) ? 0.f : attention_mma_detail::fastExp(r[3] - mNew[1]);
+                    e[0] = (r[0] == -FLT_MAX) ? 0.f : EXP(r[0] - mNew[0]);
+                    e[1] = (r[1] == -FLT_MAX) ? 0.f : EXP(r[1] - mNew[0]);
+                    e[2] = (r[2] == -FLT_MAX) ? 0.f : EXP(r[2] - mNew[1]);
+                    e[3] = (r[3] == -FLT_MAX) ? 0.f : EXP(r[3] - mNew[1]);
                 }
                 lNew[0] += e[0] + e[1];
                 lNew[1] += e[2] + e[3];
@@ -1389,19 +1416,35 @@ inline void executeFlashAttentionMma(
         const float scaleOverride = -1.f, const EpilogueIOp& epilogue = {},
         const ScoreModOp& scoreMod = {}, const BlockSparsity& sparse = {}) {
     constexpr bool RAW = isRawBf16Read<KIOp> && isRawBf16Read<VIOp>;
-    // RAW d64 auto-tile is REGIME-DEPENDENT (measured, real-data bench):
-    //   causal: BQ=64 wins (smaller blocks -> better load balance with the
-    //           reversed raster; BQ128 was 0.286 vs 0.232 ms @ s4096).
-    //   dense:  BQ=128 wins (+15-18% @ s8192: WARP_Q=32 -> mq=2 gives each
-    //           warp TWO independent mma accumulation chains; the kernel is
-    //           issue-limited so the extra ILP converts directly).
-    // Explicit BLOCK_Q template args bypass the heuristic as before.
-    if constexpr (BLOCK_Q == 0 && RAW && HEAD_DIM <= 64) {
-        if (!causal && seqQ >= 2048) {
-            executeFlashAttentionMma<HEAD_DIM, 128, 64, NUM_WARPS>(
-                q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
-                scaleOverride, epilogue, scoreMod, sparse);
-            return;
+    // RAW auto-tile is REGIME-DEPENDENT. Swept exhaustively with REAL data
+    // (benchmarks/sweep_tiles.cu, bh in {8,32,64} x s in {2048,4096,8192}
+    // x {causal,dense}, RTX PRO 6000):
+    //  d64 dense:  BQ128 (WARP_Q=32 -> mq=2, two independent mma chains;
+    //              kernel is ILP-limited) once the grid stays saturated:
+    //              bh*seqQ >= 64K. Below that BQ64's extra blocks win.
+    //  d64 causal: effective work is halved -> BQ128 only at seqQ>=8192,
+    //              or seqQ>=4096 when bh>=64 (reversed raster keeps balance).
+    //  d128 long:  BQ128/BKV64/NW8 at seqQ>=8192 && bh>=32 (+3..8%); bh8
+    //              stays BQ64 (BQ128 loses 9% there).
+    // Explicit BLOCK_Q/BLOCK_KV template args bypass the heuristic.
+    if constexpr (BLOCK_Q == 0 && BLOCK_KV == 0 && RAW) {
+        if constexpr (HEAD_DIM <= 64) {
+            const bool wantBQ128 =
+                causal ? (seqQ >= 8192 || (seqQ >= 4096 && batchHeads >= 64))
+                       : ((long)batchHeads * seqQ >= 65536);
+            if (wantBQ128) {
+                executeFlashAttentionMma<HEAD_DIM, 128, 64, NUM_WARPS>(
+                    q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
+                    scaleOverride, epilogue, scoreMod, sparse);
+                return;
+            }
+        } else if constexpr (HEAD_DIM == 128) {
+            if (seqQ >= 8192 && batchHeads >= 32) {
+                executeFlashAttentionMma<HEAD_DIM, 128, 64, 8>(
+                    q, k, v, o, batchHeads, seqQ, seqK, causal, stream,
+                    scaleOverride, epilogue, scoreMod, sparse);
+                return;
+            }
         }
     }
     constexpr int BQ = BLOCK_Q > 0 ? BLOCK_Q

--- a/include/fused_kernel/algorithms/attention/flash_attention_mma.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention_mma.h
@@ -949,6 +949,12 @@ public:
                     // raw scores: scale+subtract fused in one FFMA per
                     // element (ex2(fma(r, scl, -m))). This is the whole
                     // arithmetic-density win: 1 FFMA replaces FMUL+FADD.
+                    // NOTE (round 10, REJECTED): packed bf16x2 exp via
+                    // h2exp2 was built and measured — sm_120 has NO packed
+                    // MUFU.EX2: h2exp2 lowers to 2 scalar MUFU + extra
+                    // F2FP/SHF/LOP3 (SASS total/HMMA 14.6 -> 15.5, MUFU
+                    // 40 -> 45), measured -2..-22% across shapes. The
+                    // scalar fp32 pipeline below IS the optimal form here.
                     e[0] = EXP(fmaf(r[0], scl, -mNew[0]));
                     e[1] = EXP(fmaf(r[1], scl, -mNew[0]));
                     e[2] = EXP(fmaf(r[2], scl, -mNew[1]));

--- a/include/fused_kernel/algorithms/attention/flash_decode.h
+++ b/include/fused_kernel/algorithms/attention/flash_decode.h
@@ -281,11 +281,16 @@ __global__ void flashDecodeMerge_Kernel(const float* partial, OT* o,
 /* Decode workspace: caller-owned, reusable across steps.
    Size: batchHeads * splits * (HEAD_DIM+2) floats. */
 inline int flashDecodeSplits(const int batchHeads, const int seqK) {
-    // target >= 2 blocks per SM on mainstream parts; clamp chunk >= 256 tokens
-    const int targetBlocks = 384;
+    // Swept on RTX PRO 6000 (188 SMs, benchmarks/sweep_decode_splits.py):
+    // best split counts cluster around bh*splits ~ 2048 blocks — the old
+    // target of 384 left 2-5x perf on the table for bf16 KV (which moves
+    // 2x the bytes of fp8 and needs the extra memory parallelism).
+    // Cap at 128 splits (FA splitkv-style) and keep chunks >= 256 tokens.
+    const int targetBlocks = 2048;
     int splits = (targetBlocks + batchHeads - 1) / batchHeads;
     const int maxSplits = (seqK + 255) / 256;
     splits = ::min(splits, maxSplits);
+    splits = ::min(splits, 128);
     return ::max(1, splits);
 }
 


### PR DESCRIPTION
Follow-up to #256 (merged). Seven commits, every change driven by a measurement (ncu / exhaustive sweeps / 143-config gauntlet vs Dao-AILab flash-attention 2.8.4 built for sm_120), and every rejected idea documented with its data.

## Headline (RTX PRO 6000, 143 configs, Dao FLOPs methodology, fp64-oracle accuracy checks)

**FKL faster 71 / parity 27 / FA faster 45 — geomean 1.227x** (was 1.064x at #256 merge).

| section | geomean | note |
|---|---|---|
| decode | **1.504x** | **zero losses.** fp8-KV ~1.9x avg, peak 3.0x (FA main has no fp8-KV on sm_120) |
| forward | **1.065x** | was 0.972x — causal AND dense both positive now |
| variants | **1.034x** | SoftCap s8192 1.21x, SlidingWindow 1.09x |

## What landed

1. **Decode splits retune** (009ff80): `flashDecodeSplits` targetBlocks 384→2048, swept 1..96 per shape. Decode geomean 1.20→1.50x, zero losses left.
2. **FP8 tensor-core QK^T** (5d542aa, opt-in `-DFK_ENABLE_FP8_QK=1` + sm_120a): `kind::f8f6f4` m16n8k32 straight on raw e4m3 KV bytes — Q quantized per-row in-kernel (warp-sync amax), `qScale·kScale` folded post-mma, the K dequant smem pass deleted, B-fragments stream from an XOR-swizzled byte stage. +62% d64 dense / +27% d128 on the QUANT_KV path vs the bf16-dequant baseline. Fragment mapping validated vs fp64 oracle (spike, maxErr 1e-6). Plain sm_120 builds are bit-identical (ptxas rejects the instruction without the arch feature set — documented).
3. **ALiBi specialization** (8bb199f): the bias is linear and its row term cancels in softmax → column-only form keeps the NO_MASK fast path, no sentinels, no per-element row math. Output bit-identical to the generic functor path.
4. **Causal raster reversal** (c906b7b): ncu showed 10.9% achieved vs 33% theoretical occupancy — q-block i does O(i) work and the natural raster launches the heavy blocks LAST (single-block tail). One-line flip: +21% d64 / +19% d128 causal.
5. **BQ128 for long dense** (f5f833d): ncu full-set on the real dense-long shape showed ILP starvation (0.65 eligible warps/scheduler, one dependent mma chain per warp). BQ128 → WARP_Q=32 → two independent chains: +17% s8192.
6. **Log2-domain softmax + measured tile dispatch** (7f3e02d): fold log2e into the softmax scale once; every per-element exp becomes a bare `ex2.approx` (inline PTX, no fast-math dependence) — FA's trick. Generic score_mods keep natural-domain semantics; ALiBi folds log2e into the slope (exact). Dispatch heuristics derived from an exhaustive real-data sweep (bh{8,32,64} × s{1024..8192} × {causal,dense} × 8 tile configs).

## Rejected with data (in-tree or documented, not hidden)

- **Split-S score tile**: ptxas regs unchanged at 134 (allocator already overlaps the S-tile with fragment staging), dense −2%. Machinery stays templated behind `SPLIT_S=false`.
- **Small-grid raster guard** (f23d3e2): hypothesis tested, made bh8 s2048 worse (0.82→0.76); reverted with numbers inline.
- **DSMEM cluster K/V sharing**: remote smem reads 1.4 TB/s vs 15.7 TB/s L2 on sm_120 — spike in companion repo.
- **maxrregcount=128**: 0 spills post S/P-union, reaches 4 blocks/SM, but perf-neutral on d64 and −45% on d128 — occupancy was not the binding constraint.

## Verification

- mma / flex-block-sparse / decode suites: PASS on plain sm_120 **and** sm_120a + FK_ENABLE_FP8_QK
- compute-sanitizer memcheck **and** racecheck: 0 errors / 0 hazards
- g++ / clang++ CPU-only TU compile (MSVC proxy for the Windows CI)
- fkl_python: 23/23
- Benchmark honesty fix: raw C++ benches now run on random data (uninitialized buffers under-toggle the datapath and inflate clocks ~25%)

## What still loses (honest list)

45 of 143 configs, worst bucket small-shape causal (d128 bh8 s2048: 0.76x — wave/launch overhead at 1-wave grids) and mid-size d128 dense (0.84–0.89x). Both trace to the same root: FA ships per-shape hand-tuned schedules; we run one schedule + dispatch. The structural fix is persistent-CTA scheduling — scoped for a separate PR.

Artifacts (gauntlet CSV/MD, ANALYSIS.md, sweeps, spikes, ncu reports): https://github.com/johnnynunez/fkl_attention
