### PR TITLE
Add bitwise, math, and two-source element-wise operations

### DIFF
--- a/include/fused_kernel/algorithms/basic_ops/arithmetic.h
+++ b/include/fused_kernel/algorithms/basic_ops/arithmetic.h
@@ -17,6 +17,7 @@
 
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/core/utils/vector_utils.h>
+#include <fused_kernel/core/data/tuple.h>
 
 namespace fk {
     template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
@@ -48,42 +49,90 @@ namespace fk {
         }
     };
 
-    template <typename I, typename P = I, typename O = I>
-    struct Sub {
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct Sub;
+
+    template <typename I, typename P, typename O>
+    struct Sub<I, P, O, BinaryType> {
     private:
-        using SelfType = Sub<I, P, O>;
+        using SelfType = Sub<I, P, O, BinaryType>;
     public:
         FK_STATIC_STRUCT(Sub, SelfType)
-        using Parent = BinaryOperation<I, P, O, Sub<I, P, O>>;
+        using Parent = BinaryOperation<I, P, O, Sub<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
         FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input - params;
         }
     };
 
-    template <typename I, typename P = I, typename O = I>
-    struct Mul {
+    template <typename I1, typename I2, typename O>
+    struct Sub<I1, I2, O, UnaryType> {
     private:
-        using SelfType = Mul<I, P, O>;
+        using SelfType = Sub<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(Sub, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, Sub<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) - get<1>(input);
+        }
+    };
+
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct Mul;
+
+    template <typename I, typename P, typename O>
+    struct Mul<I, P, O, BinaryType> {
+    private:
+        using SelfType = Mul<I, P, O, BinaryType>;
     public:
         FK_STATIC_STRUCT(Mul, SelfType)
-        using Parent = BinaryOperation<I, P, O, Mul<I, P, O>>;
+        using Parent = BinaryOperation<I, P, O, Mul<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
         FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input * params;
         }
     };
 
-    template <typename I, typename P = I, typename O = I>
-    struct Div {
+    template <typename I1, typename I2, typename O>
+    struct Mul<I1, I2, O, UnaryType> {
     private:
-        using SelfType = Div<I, P, O>;
+        using SelfType = Mul<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(Mul, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, Mul<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) * get<1>(input);
+        }
+    };
+
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct Div;
+
+    template <typename I, typename P, typename O>
+    struct Div<I, P, O, BinaryType> {
+    private:
+        using SelfType = Div<I, P, O, BinaryType>;
     public:
         FK_STATIC_STRUCT(Div, SelfType)
-        using Parent = BinaryOperation<I, P, O, Div<I, P, O>>;
+        using Parent = BinaryOperation<I, P, O, Div<I, P, O, BinaryType>>;
         DECLARE_BINARY_PARENT
         FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
             return input / params;
+        }
+    };
+
+    template <typename I1, typename I2, typename O>
+    struct Div<I1, I2, O, UnaryType> {
+    private:
+        using SelfType = Div<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(Div, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, Div<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) / get<1>(input);
         }
     };
 } // namespace fk

--- a/include/fused_kernel/algorithms/basic_ops/basic_ops.h
+++ b/include/fused_kernel/algorithms/basic_ops/basic_ops.h
@@ -17,9 +17,11 @@
 
 #include <fused_kernel/algorithms/basic_ops/algebraic.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/bitwise.h>
 #include <fused_kernel/algorithms/basic_ops/cast.h>
 #include <fused_kernel/algorithms/basic_ops/vector_ops.h>
 #include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/math.h>
 #include <fused_kernel/algorithms/basic_ops/set.h>
 #include <fused_kernel/algorithms/basic_ops/static_loop.h>
 

--- a/include/fused_kernel/algorithms/basic_ops/bitwise.h
+++ b/include/fused_kernel/algorithms/basic_ops/bitwise.h
@@ -1,0 +1,157 @@
+/* Copyright 2023-2026 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_BITWISE
+#define FK_BITWISE
+
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/utils/vector_utils.h>
+
+namespace fk {
+    // Bitwise AND. Binary form ANDs with a constant; Unary form ANDs two inputs
+    // packed in a Tuple (e.g. two images read per-thread).
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct BwAnd;
+
+    template <typename I, typename P, typename O>
+    struct BwAnd<I, P, O, BinaryType> {
+    private:
+        using SelfType = BwAnd<I, P, O, BinaryType>;
+    public:
+        FK_STATIC_STRUCT(BwAnd, SelfType)
+        using Parent = BinaryOperation<I, P, O, BwAnd<I, P, O, BinaryType>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return input & params;
+        }
+    };
+
+    template <typename I1, typename I2, typename O>
+    struct BwAnd<I1, I2, O, UnaryType> {
+    private:
+        using SelfType = BwAnd<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(BwAnd, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, BwAnd<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) & get<1>(input);
+        }
+    };
+
+    // Bitwise OR.
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct BwOr;
+
+    template <typename I, typename P, typename O>
+    struct BwOr<I, P, O, BinaryType> {
+    private:
+        using SelfType = BwOr<I, P, O, BinaryType>;
+    public:
+        FK_STATIC_STRUCT(BwOr, SelfType)
+        using Parent = BinaryOperation<I, P, O, BwOr<I, P, O, BinaryType>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return input | params;
+        }
+    };
+
+    template <typename I1, typename I2, typename O>
+    struct BwOr<I1, I2, O, UnaryType> {
+    private:
+        using SelfType = BwOr<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(BwOr, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, BwOr<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) | get<1>(input);
+        }
+    };
+
+    // Bitwise XOR.
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct BwXor;
+
+    template <typename I, typename P, typename O>
+    struct BwXor<I, P, O, BinaryType> {
+    private:
+        using SelfType = BwXor<I, P, O, BinaryType>;
+    public:
+        FK_STATIC_STRUCT(BwXor, SelfType)
+        using Parent = BinaryOperation<I, P, O, BwXor<I, P, O, BinaryType>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return input ^ params;
+        }
+    };
+
+    template <typename I1, typename I2, typename O>
+    struct BwXor<I1, I2, O, UnaryType> {
+    private:
+        using SelfType = BwXor<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(BwXor, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, BwXor<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return get<0>(input) ^ get<1>(input);
+        }
+    };
+
+    // Bitwise NOT (unary, single input).
+    template <typename I, typename O = I>
+    struct BwNot {
+    private:
+        using SelfType = BwNot<I, O>;
+    public:
+        FK_STATIC_STRUCT(BwNot, SelfType)
+        using Parent = UnaryOperation<I, O, BwNot<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return ~input;
+        }
+    };
+
+    // Left shift by a compile-time-or-runtime constant amount.
+    template <typename I, typename P = I, typename O = I>
+    struct ShiftLeft {
+    private:
+        using SelfType = ShiftLeft<I, P, O>;
+    public:
+        FK_STATIC_STRUCT(ShiftLeft, SelfType)
+        using Parent = BinaryOperation<I, P, O, ShiftLeft<I, P, O>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return input << params;
+        }
+    };
+
+    // Right shift by a constant amount.
+    template <typename I, typename P = I, typename O = I>
+    struct ShiftRight {
+    private:
+        using SelfType = ShiftRight<I, P, O>;
+    public:
+        FK_STATIC_STRUCT(ShiftRight, SelfType)
+        using Parent = BinaryOperation<I, P, O, ShiftRight<I, P, O>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return input >> params;
+        }
+    };
+} // namespace fk
+
+#endif

--- a/include/fused_kernel/algorithms/basic_ops/math.h
+++ b/include/fused_kernel/algorithms/basic_ops/math.h
@@ -1,0 +1,129 @@
+/* Copyright 2023-2026 Oscar Amoros Huguet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_MATH
+#define FK_MATH
+
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/vector_utils.h>
+#include <fused_kernel/core/constexpr_libs/constexpr_cmath.h>
+#include <fused_kernel/core/constexpr_libs/constexpr_vector_exec.h>
+#include <cmath>
+
+namespace fk {
+    // Per-channel unary math, applied across vector components via cxp::Exec.
+    namespace math_detail {
+        struct AbsFunc {
+            using InstanceType = UnaryType;
+            template <typename ST> FK_HOST_DEVICE_FUSE auto exec(const ST& s) {
+                if constexpr (std::is_signed_v<ST>) return s < ST(0) ? static_cast<ST>(-s) : s;
+                else return s;
+            }
+        };
+        struct SqrFunc {
+            using InstanceType = UnaryType;
+            template <typename ST> FK_HOST_DEVICE_FUSE auto exec(const ST& s) { return s * s; }
+        };
+        struct SqrtFunc {
+            using InstanceType = UnaryType;
+            template <typename ST> FK_HOST_DEVICE_FUSE auto exec(const ST& s) {
+                return ::sqrtf(static_cast<float>(s));
+            }
+        };
+        struct LnFunc {
+            using InstanceType = UnaryType;
+            template <typename ST> FK_HOST_DEVICE_FUSE auto exec(const ST& s) {
+                return ::logf(static_cast<float>(s));
+            }
+        };
+        struct ExpFunc {
+            using InstanceType = UnaryType;
+            template <typename ST> FK_HOST_DEVICE_FUSE auto exec(const ST& s) {
+                return ::expf(static_cast<float>(s));
+            }
+        };
+    } // namespace math_detail
+
+    // |x| per channel.
+    template <typename I, typename O = I>
+    struct Abs {
+    private:
+        using SelfType = Abs<I, O>;
+    public:
+        FK_STATIC_STRUCT(Abs, SelfType)
+        using Parent = UnaryOperation<I, O, Abs<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::AbsFunc>::exec(input);
+        }
+    };
+
+    // x*x per channel.
+    template <typename I, typename O = I>
+    struct Sqr {
+    private:
+        using SelfType = Sqr<I, O>;
+    public:
+        FK_STATIC_STRUCT(Sqr, SelfType)
+        using Parent = UnaryOperation<I, O, Sqr<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::SqrFunc>::exec(input);
+        }
+    };
+
+    // sqrt(x) per channel, computed in float.
+    template <typename I, typename O = I>
+    struct Sqrt {
+    private:
+        using SelfType = Sqrt<I, O>;
+    public:
+        FK_STATIC_STRUCT(Sqrt, SelfType)
+        using Parent = UnaryOperation<I, O, Sqrt<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::SqrtFunc>::exec(input);
+        }
+    };
+
+    // natural log per channel, computed in float.
+    template <typename I, typename O = I>
+    struct Ln {
+    private:
+        using SelfType = Ln<I, O>;
+    public:
+        FK_STATIC_STRUCT(Ln, SelfType)
+        using Parent = UnaryOperation<I, O, Ln<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::LnFunc>::exec(input);
+        }
+    };
+
+    // exp(x) per channel, computed in float.
+    template <typename I, typename O = I>
+    struct Exp {
+    private:
+        using SelfType = Exp<I, O>;
+    public:
+        FK_STATIC_STRUCT(Exp, SelfType)
+        using Parent = UnaryOperation<I, O, Exp<I, O>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::ExpFunc>::exec(input);
+        }
+    };
+} // namespace fk
+
+#endif

--- a/include/fused_kernel/algorithms/basic_ops/math.h
+++ b/include/fused_kernel/algorithms/basic_ops/math.h
@@ -19,6 +19,7 @@
 #include <fused_kernel/core/utils/vector_utils.h>
 #include <fused_kernel/core/constexpr_libs/constexpr_cmath.h>
 #include <fused_kernel/core/constexpr_libs/constexpr_vector_exec.h>
+#include <fused_kernel/core/data/tuple.h>
 #include <cmath>
 
 namespace fk {
@@ -122,6 +123,47 @@ namespace fk {
         DECLARE_UNARY_PARENT
         FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
             return cxp::Exec<math_detail::ExpFunc>::exec(input);
+        }
+    };
+
+    // |a - b| per channel. Binary form uses a constant; two-input Unary form
+    // takes a Tuple of two inputs (e.g. two images).
+    namespace math_detail {
+        struct AbsDiffFunc {
+            using InstanceType = BinaryType;
+            template <typename ST1, typename ST2> FK_HOST_DEVICE_FUSE auto exec(const ST1& a, const ST2& b) {
+                const auto d = a - b;
+                return d < decltype(d)(0) ? -d : d;
+            }
+        };
+    } // namespace math_detail
+
+    template <typename I1, typename I2 = I1, typename O = I1, typename IT = BinaryType>
+    struct AbsDiff;
+
+    template <typename I, typename P, typename O>
+    struct AbsDiff<I, P, O, BinaryType> {
+    private:
+        using SelfType = AbsDiff<I, P, O, BinaryType>;
+    public:
+        FK_STATIC_STRUCT(AbsDiff, SelfType)
+        using Parent = BinaryOperation<I, P, O, AbsDiff<I, P, O, BinaryType>>;
+        DECLARE_BINARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input, const ParamsType& params) {
+            return cxp::Exec<math_detail::AbsDiffFunc>::exec(input, params);
+        }
+    };
+
+    template <typename I1, typename I2, typename O>
+    struct AbsDiff<I1, I2, O, UnaryType> {
+    private:
+        using SelfType = AbsDiff<I1, I2, O, UnaryType>;
+    public:
+        FK_STATIC_STRUCT(AbsDiff, SelfType)
+        using Parent = UnaryOperation<Tuple<I1, I2>, O, AbsDiff<I1, I2, O, UnaryType>>;
+        DECLARE_UNARY_PARENT
+        FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+            return cxp::Exec<math_detail::AbsDiffFunc>::exec(get<0>(input), get<1>(input));
         }
     };
 } // namespace fk

--- a/include/fused_kernel/algorithms/basic_ops/memory_operations.h
+++ b/include/fused_kernel/algorithms/basic_ops/memory_operations.h
@@ -575,6 +575,58 @@ namespace fk {
         }
     };
 
+    // Reads two sources at the same Point and returns a Tuple<T, T>, intended to
+    // feed the two-input Unary form of binary operators (Add/Sub/Mul/Div, BwAnd/
+    // BwOr/BwXor). This enables image-by-image element-wise operations as a single
+    // fused kernel. Thread fusion is disabled to keep the dual-pointer read simple.
+    template <ND D, typename T>
+    struct DualSourceReadParams {
+        RawPtr<D, T> src1;
+        RawPtr<D, T> src2;
+    };
+
+    template <ND D, typename T>
+    struct DualSourceRead {
+    private:
+        using Parent = ReadOperation<T, DualSourceReadParams<D, T>, Tuple<T, T>,
+                                     TF::DISABLED, DualSourceRead<D, T>>;
+        using SelfType = DualSourceRead<D, T>;
+    public:
+        FK_STATIC_STRUCT(DualSourceRead, SelfType)
+        DECLARE_READ_PARENT
+        FK_HOST_DEVICE_FUSE auto exec(const Point thread, const ParamsType& params) -> Tuple<T, T> {
+            const T a = *PtrAccessor<D>::template cr_point<T, T>(thread, params.src1);
+            const T b = *PtrAccessor<D>::template cr_point<T, T>(thread, params.src2);
+            return { a, b };
+        }
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {
+            return opData.params.src1.dims.width;
+        }
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {
+            if constexpr (D == ND::_1D) {
+                return 1;
+            } else {
+                return opData.params.src1.dims.height;
+            }
+        }
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {
+            if constexpr (D == ND::_1D || D == ND::_2D) {
+                return 1;
+            } else {
+                return opData.params.src1.dims.planes;
+            }
+        }
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {
+            return opData.params.src1.dims.pitch;
+        }
+        FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) };
+        }
+        FK_HOST_FUSE InstantiableType build(const Ptr<D, T>& src1, const Ptr<D, T>& src2) {
+            return { { DualSourceReadParams<D, T>{ src1.ptr(), src2.ptr() } } };
+        }
+    };
+
 } //namespace fk
 
 #endif // FK_MEMORY_OPERATIONS


### PR DESCRIPTION
## Summary

Adds new element-wise operations and a two-source read to `algorithms/basic_ops`, following the existing functor style.

### `bitwise.h` (new)
- `BwAnd`, `BwOr`, `BwXor` — Binary form (with constant) + two-input Unary form (Tuple of two inputs).
- `BwNot` — unary complement.
- `ShiftLeft`, `ShiftRight` — shift by a constant.

Built on the vector bitwise/shift operators already in `core/utils/vector_utils.h` (`&`, `|`, `^`, `~`, `<<`, `>>`).

### `math.h` (new)
- `Abs`, `Sqr`, `Sqrt`, `Ln`, `Exp` — per-channel unary math via `cxp::Exec`. `Sqrt`/`Ln`/`Exp` use the CUDA float intrinsics.

### `arithmetic.h` (extended)
- `Sub`, `Mul`, `Div` gain a `UnaryType` specialization operating on `Tuple<I1, I2>`, mirroring the existing `Add` pattern. This enables image-by-image element-wise arithmetic. The default template argument stays `BinaryType`, so existing `Sub<T>` / `Mul<T>` / `Div<T>` usage is fully unchanged.

### `memory_operations.h` (extended)
- `DualSourceRead` reads two sources at the same `Point` and returns `Tuple<T, T>`, feeding the Unary binary operators so a two-image operation executes as a single fused kernel.

## Motivation

These functors are needed to express NPP-equivalent bitwise, math, and two-image operations in the FastNPP wrapper library (companion PR there). FKL previously provided arithmetic-with-constant, logical (Max/Min/Equal) and cast operations, but no bitwise, transcendental math, or two-source element-wise paths; this fills that gap.

## Verification

- Full `basic_ops.h` aggregator compiles cleanly (CUDA 13.3, GCC 11.5, `sm_120`); existing binary `Add/Sub/Mul/Div<T>` usage confirmed still compiling.
- Each functor cross-checked numerically against the matching NVIDIA NPP call on real image data:
  - Bitwise (AndC/OrC/XorC/Not, 8u): bit-exact.
  - Math (Abs/Sqr/Sqrt/Ln/Exp, 32f): matches NPP exactly (max abs diff 0.00e+00).
  - Two-image Add/Sub/Mul/Div (32f) via DualSourceRead: bit-exact.