### PR TITLE
collective: warp/block reductions as composable FKL primitives

### DIFF
--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2026 Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,9 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/collective/collective.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
+#include <fused_kernel/algorithms/collective/reduce.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -1,0 +1,664 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REDUCE_H
+#define FK_COLLECTIVE_REDUCE_H
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename ComputeIOp>
+struct AtomicReduceWriteParams {
+    RawPtr<ND::_1D, T> output;
+    ComputeIOp compute;
+};
+
+template <typename AtomicWriteIOp, typename = void>
+struct AtomicReduceWriteTraits {
+    static constexpr bool VALID = false;
+    using ComputeType = void;
+};
+
+template <typename AtomicWriteIOp>
+struct AtomicReduceWriteTraits<AtomicWriteIOp,
+    std::void_t<typename AtomicWriteIOp::Operation::AtomicReduceWriteTag>> {
+    static constexpr bool VALID = true;
+    using ComputeType =
+        typename AtomicWriteIOp::Operation::AtomicReduceWriteTag;
+};
+
+/**
+ * Atomic grid-reduction epilogue. The destination must be initialized to the
+ * neutral identity of ComputeIOp before launch.
+ */
+template <typename T, typename ComputeIOp>
+struct AtomicReduceWrite {
+private:
+    using SelfType = AtomicReduceWrite<T, ComputeIOp>;
+    using Parent = WriteOperation<
+        T, AtomicReduceWriteParams<T, ComputeIOp>, T,
+        TF::DISABLED, SelfType>;
+
+public:
+    FK_STATIC_STRUCT(AtomicReduceWrite, SelfType)
+    DECLARE_WRITE_PARENT
+    using AtomicReduceWriteTag = ComputeIOp;
+
+    FK_DEVICE_FUSE void exec(const Point thread, const InputType input,
+                             const ParamsType& params) {
+#if defined(__CUDA_ARCH__)
+        static_assert(sizeof(T) == sizeof(unsigned int),
+                      "AtomicReduceWrite CAS supports 32-bit value types");
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "AtomicReduceWrite requires a trivially copyable type");
+
+        T* const address = PtrAccessor<ND::_1D>::template point<T, T>(
+            thread, params.output);
+        auto* const bitsAddress = reinterpret_cast<unsigned int*>(address);
+        unsigned int oldBits = atomicCAS(bitsAddress, 0u, 0u);
+        unsigned int assumedBits;
+        do {
+            assumedBits = oldBits;
+            T current;
+            __builtin_memcpy(&current, &assumedBits, sizeof(T));
+            const T next = make_tuple(current, input) | params.compute;
+            unsigned int nextBits;
+            __builtin_memcpy(&nextBits, &next, sizeof(T));
+            oldBits = atomicCAS(bitsAddress, assumedBits, nextBits);
+        } while (oldBits != assumedBits);
+#else
+        (void)thread;
+        (void)input;
+        (void)params;
+#endif
+    }
+
+    FK_HOST_FUSE InstantiableType build(const Ptr<ND::_1D, T>& ptr,
+                                         const ComputeIOp& compute) {
+        return {{{ptr.ptr(), compute}}};
+    }
+};
+
+template <typename T, int BLOCK_SIZE = 256>
+struct ReduceDPPDetails {
+    static_assert(BLOCK_SIZE > 0, "ReduceDPP block size must be positive");
+
+    using ValueType = T;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+
+    int rows;
+    int width;
+    // Must be the neutral element of the supplied compute IOp.
+    T identity;
+    int rowOffset{0};
+};
+
+/**
+ * Parameters for simultaneous row reductions over one shared input read.
+ * Each compute entry is Tuple<transform IOp, reduce IOp>; each result is
+ * emitted through the Write IOp at the same tuple index.
+ */
+template <typename T, int REDUCTIONS, int BLOCK_SIZE = 256>
+struct MultiReduceDPPDetails {
+    static_assert(REDUCTIONS > 1,
+                  "MultiReduceDPP requires at least two reductions");
+    static_assert(BLOCK_SIZE > 0,
+                  "MultiReduceDPP block size must be positive");
+
+    using ValueType = T;
+    static constexpr int REDUCTION_COUNT = REDUCTIONS;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+
+    int rows;
+    int width;
+    // Each value must be the neutral element of its reduction IOp.
+    T identities[REDUCTIONS];
+    int rowOffset{0};
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceWarpDPP;
+
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceBlockDPP;
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&, T*) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceDPP;
+
+template <ParArch PA, typename DPPDetails>
+struct MultiReduceDPP;
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::CPU, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    FK_HOST_FUSE void exec(const Details& details,
+                           const ReadIOp& input,
+                           const ComputeIOp& compute,
+                           const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS > 0,
+                      "ReduceDPP block size must be positive");
+
+        for (int localRow = 0; localRow < details.rows; ++localRow) {
+            const int row = details.rowOffset + localRow;
+            T accumulator = details.identity;
+            for (int x = 0; x < details.width; ++x) {
+                const T value = static_cast<T>(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                accumulator = make_tuple(accumulator, value) | compute;
+            }
+            WriteIOp::Operation::exec(Point{row, 0, 0}, accumulator, output);
+        }
+    }
+};
+
+template <typename DPPDetails>
+struct MultiReduceDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = MultiReduceDPP<ParArch::CPU, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+    static constexpr int N = Details::REDUCTION_COUNT;
+
+    template <size_t I, typename ComputeIOps>
+    FK_HOST_FUSE void accumulateOne(T (&accumulators)[N],
+                                    const T value,
+                                    const ComputeIOps& computes) {
+        const auto& pipeline = get<I>(computes);
+        using Pipeline = std::decay_t<decltype(pipeline)>;
+        static_assert(isTuple_v<Pipeline> && Pipeline::size == 2,
+                      "Each MultiReduce compute pipeline is Tuple<transform, reduce>");
+        const T transformed = static_cast<T>(value | get<0>(pipeline));
+        accumulators[I] = make_tuple(accumulators[I], transformed) |
+                          get<1>(pipeline);
+    }
+
+    template <typename ComputeIOps, size_t... Is>
+    FK_HOST_FUSE void accumulateAll(T (&accumulators)[N],
+                                    const T value,
+                                    const ComputeIOps& computes,
+                                    std::index_sequence<Is...>) {
+        (accumulateOne<Is>(accumulators, value, computes), ...);
+    }
+
+    template <size_t I, typename WriteIOps>
+    FK_HOST_FUSE void writeOne(const int row,
+                               const T (&accumulators)[N],
+                               const WriteIOps& outputs) {
+        const auto& output = get<I>(outputs);
+        using Output = std::decay_t<decltype(output)>;
+        static_assert(isAnyWriteType<Output>,
+                      "Every MultiReduce output must be a Write IOp");
+        Output::Operation::exec(Point{row, 0, 0}, accumulators[I], output);
+    }
+
+    template <typename WriteIOps, size_t... Is>
+    FK_HOST_FUSE void writeAll(const int row,
+                               const T (&accumulators)[N],
+                               const WriteIOps& outputs,
+                               std::index_sequence<Is...>) {
+        (writeOne<Is>(row, accumulators, outputs), ...);
+    }
+
+public:
+    FK_STATIC_STRUCT(MultiReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp, typename ComputeIOps, typename WriteIOps>
+    FK_HOST_FUSE void exec(const Details& details,
+                           const ReadIOp& input,
+                           const ComputeIOps& computes,
+                           const WriteIOps& outputs) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "MultiReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isTuple_v<ComputeIOps> &&
+                      std::decay_t<ComputeIOps>::size == N,
+                      "MultiReduceDPP needs one compute pipeline per accumulator");
+        static_assert(isTuple_v<WriteIOps> &&
+                      std::decay_t<WriteIOps>::size == N,
+                      "MultiReduceDPP needs one Write IOp per accumulator");
+
+        for (int localRow = 0; localRow < details.rows; ++localRow) {
+            const int row = details.rowOffset + localRow;
+            T accumulators[N];
+            for (int i = 0; i < N; ++i) {
+                accumulators[i] = details.identities[i];
+            }
+            for (int x = 0; x < details.width; ++x) {
+                const T value = static_cast<T>(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                accumulateAll(accumulators, value, computes,
+                              std::make_index_sequence<N>{});
+            }
+            writeAll(row, accumulators, outputs,
+                     std::make_index_sequence<N>{});
+        }
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceGridDPP;
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp, typename ReadIOp, typename WriteIOp>
+    FK_HOST_FUSE void exec(const DPPDetails&, const T value,
+                           const ComputeIOp& compute,
+                           const ReadIOp& accumulatorInput,
+                           const WriteIOp& accumulatorOutput) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "CPU ReduceGridDPP accumulator input must be a Read IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CPU ReduceGridDPP accumulator output must be a Write IOp");
+        const Point point{0, 0, 0};
+        const T current = static_cast<T>(
+            ReadIOp::Operation::exec(point, accumulatorInput));
+        const T next = make_tuple(current, value) | compute;
+        WriteIOp::Operation::exec(point, next, accumulatorOutput);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails&, T value,
+                          const ComputeIOp& compute) {
+#if defined(__CUDA_ARCH__)
+        constexpr unsigned int FULL_WARP_MASK = 0xffffffffu;
+        const int lane = static_cast<int>(threadIdx.x) & 31;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            const T peer = __shfl_down_sync(FULL_WARP_MASK, value, offset);
+            if (lane + offset < 32) {
+                value = make_tuple(value, peer) | compute;
+            }
+        }
+#else
+        (void)compute;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails& details, T value,
+                          const ComputeIOp& compute, T* warpScratch) {
+#if defined(__CUDA_ARCH__)
+        constexpr int WARP_SIZE = 32;
+        constexpr int NUM_WARPS =
+            (DPPDetails::BLOCK_THREADS + WARP_SIZE - 1) / WARP_SIZE;
+        const int lane = static_cast<int>(threadIdx.x) & (WARP_SIZE - 1);
+        const int warp = static_cast<int>(threadIdx.x) / WARP_SIZE;
+
+        value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+            details, value, compute);
+        if (lane == 0) warpScratch[warp] = value;
+        __syncthreads();
+
+        if (warp == 0) {
+            value = lane < NUM_WARPS ? warpScratch[lane] : details.identity;
+            value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute);
+        }
+#else
+        (void)details;
+        (void)compute;
+        (void)warpScratch;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    // Deliberately not FK_DEVICE_FUSE: CUDA rejects a function-local
+    // __shared__ declaration inside the macro's constexpr function.
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    static __device__ __forceinline__ void exec(const Details& details,
+                                                const ReadIOp& input,
+                                                const ComputeIOp& compute,
+                                                const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS >= 32 &&
+                      Details::BLOCK_THREADS <= 1024 &&
+                      Details::BLOCK_THREADS % 32 == 0,
+                      "ReduceDPP block size must be a warp multiple in [32, 1024]");
+
+        constexpr int NUM_WARPS = Details::BLOCK_THREADS / 32;
+        __shared__ T warpScratch[NUM_WARPS];
+
+        const int localRow = static_cast<int>(blockIdx.x);
+        if (localRow >= details.rows) return;
+        const int row = details.rowOffset + localRow;
+        const int tid = static_cast<int>(threadIdx.x);
+        T accumulator = details.identity;
+        for (int x = tid; x < details.width; x += Details::BLOCK_THREADS) {
+            const T value = static_cast<T>(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            accumulator = make_tuple(accumulator, value) | compute;
+        }
+
+        const T result =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, Details>::exec(
+                details, accumulator, compute, warpScratch);
+        if (tid == 0) {
+            WriteIOp::Operation::exec(Point{row, 0, 0}, result, output);
+        }
+    }
+};
+
+template <typename DPPDetails>
+struct MultiReduceDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = MultiReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+    static constexpr int N = Details::REDUCTION_COUNT;
+    static constexpr int NUM_WARPS = Details::BLOCK_THREADS / 32;
+
+    template <size_t I, typename ComputeIOps>
+    FK_DEVICE_FUSE void accumulateOne(T (&accumulators)[N],
+                                      const T value,
+                                      const ComputeIOps& computes) {
+        const auto& pipeline = get<I>(computes);
+        using Pipeline = std::decay_t<decltype(pipeline)>;
+        static_assert(isTuple_v<Pipeline> && Pipeline::size == 2,
+                      "Each MultiReduce compute pipeline is Tuple<transform, reduce>");
+        const T transformed = static_cast<T>(value | get<0>(pipeline));
+        accumulators[I] = make_tuple(accumulators[I], transformed) |
+                          get<1>(pipeline);
+    }
+
+    template <typename ComputeIOps, size_t... Is>
+    FK_DEVICE_FUSE void accumulateAll(T (&accumulators)[N],
+                                      const T value,
+                                      const ComputeIOps& computes,
+                                      std::index_sequence<Is...>) {
+        (accumulateOne<Is>(accumulators, value, computes), ...);
+    }
+
+    template <size_t I, typename ComputeIOps>
+    FK_DEVICE_FUSE void reduceOne(const Details& details,
+                                  T (&accumulators)[N],
+                                  const ComputeIOps& computes,
+                                  T (&warpScratch)[N][NUM_WARPS]) {
+        const auto& pipeline = get<I>(computes);
+        using ScalarDetails = ReduceDPPDetails<T, Details::BLOCK_THREADS>;
+        const ScalarDetails scalarDetails{
+            details.rows, details.width, details.identities[I], details.rowOffset};
+        accumulators[I] =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, ScalarDetails>::exec(
+                scalarDetails, accumulators[I], get<1>(pipeline), warpScratch[I]);
+    }
+
+    template <typename ComputeIOps, size_t... Is>
+    FK_DEVICE_FUSE void reduceAll(const Details& details,
+                                  T (&accumulators)[N],
+                                  const ComputeIOps& computes,
+                                  T (&warpScratch)[N][NUM_WARPS],
+                                  std::index_sequence<Is...>) {
+        // Left-to-right fold keeps every block-wide barrier in the same order
+        // for all threads while each accumulator uses disjoint scratch.
+        (reduceOne<Is>(details, accumulators, computes, warpScratch), ...);
+    }
+
+    template <size_t I, typename WriteIOps>
+    FK_DEVICE_FUSE void writeOne(const int row,
+                                 const T (&accumulators)[N],
+                                 const WriteIOps& outputs) {
+        const auto& output = get<I>(outputs);
+        using Output = std::decay_t<decltype(output)>;
+        static_assert(isAnyWriteType<Output>,
+                      "Every MultiReduce output must be a Write IOp");
+        Output::Operation::exec(Point{row, 0, 0}, accumulators[I], output);
+    }
+
+    template <typename WriteIOps, size_t... Is>
+    FK_DEVICE_FUSE void writeAll(const int row,
+                                 const T (&accumulators)[N],
+                                 const WriteIOps& outputs,
+                                 std::index_sequence<Is...>) {
+        (writeOne<Is>(row, accumulators, outputs), ...);
+    }
+
+public:
+    FK_STATIC_STRUCT(MultiReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    // Deliberately not FK_DEVICE_FUSE: CUDA rejects function-local shared
+    // storage inside the macro's constexpr function.
+    template <typename ReadIOp, typename ComputeIOps, typename WriteIOps>
+    static __device__ __forceinline__ void exec(
+            const Details& details, const ReadIOp& input,
+            const ComputeIOps& computes, const WriteIOps& outputs) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "MultiReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isTuple_v<ComputeIOps> &&
+                      std::decay_t<ComputeIOps>::size == N,
+                      "MultiReduceDPP needs one compute pipeline per accumulator");
+        static_assert(isTuple_v<WriteIOps> &&
+                      std::decay_t<WriteIOps>::size == N,
+                      "MultiReduceDPP needs one Write IOp per accumulator");
+        static_assert(Details::BLOCK_THREADS >= 32 &&
+                      Details::BLOCK_THREADS <= 1024 &&
+                      Details::BLOCK_THREADS % 32 == 0,
+                      "MultiReduceDPP block size must be a warp multiple in [32, 1024]");
+
+        __shared__ T warpScratch[N][NUM_WARPS];
+        const int localRow = static_cast<int>(blockIdx.x);
+        if (localRow >= details.rows) return;
+        const int row = details.rowOffset + localRow;
+        const int tid = static_cast<int>(threadIdx.x);
+        T accumulators[N];
+        #pragma unroll
+        for (int i = 0; i < N; ++i) {
+            accumulators[i] = details.identities[i];
+        }
+
+        for (int x = tid; x < details.width; x += Details::BLOCK_THREADS) {
+            const T value = static_cast<T>(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            accumulateAll(accumulators, value, computes,
+                          std::make_index_sequence<N>{});
+        }
+        reduceAll(details, accumulators, computes, warpScratch,
+                  std::make_index_sequence<N>{});
+        if (tid == 0) {
+            writeAll(row, accumulators, outputs,
+                     std::make_index_sequence<N>{});
+        }
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp, typename AtomicWriteIOp>
+    FK_DEVICE_FUSE void exec(const DPPDetails& details, const T value,
+                             const ComputeIOp& compute, T* warpScratch,
+                             const AtomicWriteIOp& atomicOutput) {
+        static_assert(isAnyWriteType<AtomicWriteIOp>,
+                      "ReduceGridDPP output must be a Write IOp");
+        using AtomicTraits = AtomicReduceWriteTraits<AtomicWriteIOp>;
+        static_assert(AtomicTraits::VALID,
+                      "ReduceGridDPP output must be AtomicReduceWrite");
+        static_assert(std::is_same_v<
+                          typename AtomicTraits::ComputeType, ComputeIOp>,
+                      "ReduceGridDPP compute and atomic output must match");
+        const T blockPartial =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute, warpScratch);
+        if (threadIdx.x == 0) {
+            AtomicWriteIOp::Operation::exec(
+                Point{0, 0, 0}, blockPartial, atomicOutput);
+        }
+    }
+};
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+__global__ void launchReduceDPPKernel(
+        const __grid_constant__ DPPDetails details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        const __grid_constant__ WriteIOp output) {
+    ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+        details, input, compute, output);
+}
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+inline void executeReduce(const DPPDetails& details,
+                          const ReadIOp& input,
+                          const ComputeIOp& compute,
+                          const WriteIOp& output,
+                          Stream_<ParArch::GPU_NVIDIA>& stream) {
+    static_assert(std::is_trivially_copyable_v<DPPDetails>,
+                  "ReduceDPP Details must be trivially copyable");
+    if (details.rows <= 0) return;
+    launchReduceDPPKernel<<<details.rows, DPPDetails::BLOCK_THREADS, 0,
+                           stream.getCUDAStream()>>>(
+        details, input, compute, output);
+    gpuErrchk(cudaGetLastError());
+}
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOps, typename WriteIOps>
+__global__ void launchMultiReduceDPPKernel(
+        const __grid_constant__ DPPDetails details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOps computes,
+        const __grid_constant__ WriteIOps outputs) {
+    MultiReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+        details, input, computes, outputs);
+}
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOps, typename WriteIOps>
+inline void executeMultiReduce(
+        const DPPDetails& details, const ReadIOp& input,
+        const ComputeIOps& computes, const WriteIOps& outputs,
+        Stream_<ParArch::GPU_NVIDIA>& stream) {
+    static_assert(std::is_trivially_copyable_v<DPPDetails>,
+                  "MultiReduceDPP Details must be trivially copyable");
+    if (details.rows <= 0) return;
+    launchMultiReduceDPPKernel<<<
+        details.rows, DPPDetails::BLOCK_THREADS, 0,
+        stream.getCUDAStream()>>>(details, input, computes, outputs);
+    gpuErrchk(cudaGetLastError());
+}
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REDUCE_H

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -1,0 +1,515 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <fused_kernel/algorithms/algorithms.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace fk;
+
+namespace {
+
+using CompileDetails = ReduceDPPDetails<float, 128>;
+static_assert(ReduceWarpDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceBlockDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceGridDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(ReduceWarpDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceBlockDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceGridDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+static_assert(std::is_trivially_copyable_v<CompileDetails>);
+using MultiCompileDetails = MultiReduceDPPDetails<float, 2, 128>;
+static_assert(MultiReduceDPP<ParArch::CPU, MultiCompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(MultiReduceDPP<ParArch::GPU_NVIDIA,
+                            MultiCompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+static_assert(std::is_trivially_copyable_v<MultiCompileDetails>);
+
+template <typename ComputeIOp>
+bool runCpuCase(const ComputeIOp& compute,
+                const std::array<float, 3>& identity,
+                const std::array<float, 3>& expected) {
+    constexpr int ROWS = 3;
+    constexpr int WIDTH = 7;
+    constexpr int BLOCK_SIZE = 64;
+
+    std::array<float, ROWS * WIDTH> input{
+         1.f, -2.f,  3.f,  4.f, -5.f,  6.f,  7.f,
+        -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f,
+         0.5f, 1.5f, -2.f, 8.f,  3.f, -1.f, 2.f
+    };
+    std::array<float, ROWS> output{123.f, 123.f, 123.f};
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, ROWS, WIDTH * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(ROWS, ROWS * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(outputPtr);
+
+    using Details = ReduceDPPDetails<float, BLOCK_SIZE>;
+    for (int row = 0; row < ROWS; ++row) {
+        const Details details{1, WIDTH, identity[row], row};
+        ReduceDPP<ParArch::CPU, Details>::exec(details, read, compute, write);
+    }
+
+    for (int row = 0; row < ROWS; ++row) {
+        if (std::fabs(output[row] - expected[row]) > 1e-6f) {
+            std::printf("CPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, output[row], expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testCpuReductionIOps() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+
+    const bool sumOk = runCpuCase(sum, {0.f, 0.f, 0.f}, {14.f, -42.f, 12.f});
+    const bool minOk = runCpuCase(min,
+        {std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity()},
+        {-5.f, -9.f, -2.f});
+    const bool maxOk = runCpuCase(max,
+        {-std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity()},
+        {7.f, -3.f, 8.f});
+    return sumOk && minOk && maxOk;
+}
+
+bool testCpuGridTierAndFusion() {
+    std::array<float, 3> input{1.f, 2.f, 3.f};
+    std::array<float, 1> output{0.f};
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(3, 1, 3 * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(1, sizeof(float))};
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Add<float>::build(1.f));
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = Mul<float>::build(2.f)
+        .then(PerThreadWrite<ND::_1D, float>::build(outputPtr));
+
+    using Details = ReduceDPPDetails<float, 32>;
+    const Details details{1, 3, 0.f, 0};
+    ReduceDPP<ParArch::CPU, Details>::exec(
+        details, read, sum, write);
+    if (std::fabs(output[0] - 18.f) > 1e-6f) {
+        std::printf("CPU fused row reduction got=%f expected=18\n", output[0]);
+        return false;
+    }
+
+    std::array<float, 1> gridAccumulator{0.f};
+    const RawPtr<ND::_1D, float> gridPtr{
+        gridAccumulator.data(), PtrDims<ND::_1D>(1, sizeof(float))};
+    const auto gridRead = PerThreadRead<ND::_1D, float>::build(gridPtr);
+    const auto gridWrite = PerThreadWrite<ND::_1D, float>::build(gridPtr);
+    for (const float value : input) {
+        ReduceGridDPP<ParArch::CPU, Details>::exec(
+            details, value, sum, gridRead, gridWrite);
+    }
+    if (std::fabs(gridAccumulator[0] - 6.f) > 1e-6f) {
+        std::printf("CPU grid partial reduction got=%f expected=6\n",
+                    gridAccumulator[0]);
+        return false;
+    }
+    return true;
+}
+
+bool testCpuMultiAccumulatorReduction() {
+    constexpr int TOTAL_ROWS = 4;
+    constexpr int ROWS = 3;
+    constexpr int ROW_OFFSET = 1;
+    constexpr int WIDTH = 7;
+    constexpr int REDUCTIONS = 2;
+    std::array<float, TOTAL_ROWS * WIDTH> input{};
+    std::array<float, TOTAL_ROWS> maxOutput{};
+    std::array<float, TOTAL_ROWS> sumOutput{};
+    std::array<float, TOTAL_ROWS> expectedMax{};
+    std::array<float, TOTAL_ROWS> expectedSum{};
+
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        expectedMax[row] = -std::numeric_limits<float>::infinity();
+        expectedSum[row] = 0.f;
+        for (int x = 0; x < WIDTH; ++x) {
+            const float raw = static_cast<float>(row * 11 + x * 3 - 9);
+            input[row * WIDTH + x] = raw;
+            const float sharedRead = raw + 0.5f;
+            expectedMax[row] = std::fmax(expectedMax[row], sharedRead * 2.f);
+            expectedSum[row] += sharedRead - 1.f;
+        }
+        expectedMax[row] += 10.f;
+        expectedSum[row] *= 0.25f;
+    }
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, TOTAL_ROWS,
+                                      WIDTH * sizeof(float))};
+    const RawPtr<ND::_1D, float> maxPtr{
+        maxOutput.data(), PtrDims<ND::_1D>(TOTAL_ROWS,
+                                          TOTAL_ROWS * sizeof(float))};
+    const RawPtr<ND::_1D, float> sumPtr{
+        sumOutput.data(), PtrDims<ND::_1D>(TOTAL_ROWS,
+                                          TOTAL_ROWS * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Add<float>::build(0.5f));
+    const auto computes = make_tuple(
+        make_tuple(Mul<float>::build(2.f),
+                   Max<float, float, float, UnaryType>::build()),
+        make_tuple(Add<float>::build(-1.f),
+                   Add<float, float, float, UnaryType>::build()));
+    const auto outputs = make_tuple(
+        Add<float>::build(10.f).then(
+            PerThreadWrite<ND::_1D, float>::build(maxPtr)),
+        Mul<float>::build(0.25f).then(
+            PerThreadWrite<ND::_1D, float>::build(sumPtr)));
+
+    using Details = MultiReduceDPPDetails<float, REDUCTIONS, 64>;
+    const Details details{ROWS, WIDTH,
+        {-std::numeric_limits<float>::infinity(), 0.f}, ROW_OFFSET};
+    MultiReduceDPP<ParArch::CPU, Details>::exec(
+        details, read, computes, outputs);
+
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        if (std::fabs(maxOutput[row] - expectedMax[row]) > 1e-6f ||
+            std::fabs(sumOutput[row] - expectedSum[row]) > 1e-6f) {
+            std::printf("CPU multi reduction row=%d max=%f/%f sum=%f/%f\n",
+                        row, maxOutput[row], expectedMax[row],
+                        sumOutput[row], expectedSum[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <int BLOCK_SIZE, typename ReadIOp, typename ComputeIOp,
+          typename AtomicWriteIOp>
+__global__ void gridReduceDPPTestKernel(
+        const __grid_constant__ ReduceDPPDetails<float, BLOCK_SIZE> details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        const __grid_constant__ AtomicWriteIOp atomicOutput) {
+    __shared__ float warpScratch[BLOCK_SIZE / 32];
+    const int x = static_cast<int>(blockIdx.x) * BLOCK_SIZE +
+                  static_cast<int>(threadIdx.x);
+    float value = details.identity;
+    if (x < details.width) {
+        value = ReadIOp::Operation::exec(Point{x, 0, 0}, input);
+    }
+    ReduceGridDPP<ParArch::GPU_NVIDIA,
+                  ReduceDPPDetails<float, BLOCK_SIZE>>::exec(
+        details, value, compute, warpScratch, atomicOutput);
+}
+
+template <int BLOCK_SIZE, typename ComputeIOp, typename HostCombine>
+bool runGpuGridVariant(const char* name, const ComputeIOp& compute,
+                       const float identity, const HostCombine& hostCombine) {
+    constexpr int WIDTH = 4096 + 37;
+    Ptr1D<float> input(WIDTH);
+    Ptr1D<float> accumulator(1);
+    float expected = identity;
+    for (int x = 0; x < WIDTH; ++x) {
+        const float value = static_cast<float>(((x * 17) % 101) - 50) * 0.125f;
+        input.at(Point{x, 0, 0}) = value;
+        expected = hostCombine(expected, value);
+    }
+    accumulator.at(Point{0, 0, 0}) = identity;
+
+    Stream stream;
+    input.upload(stream);
+    accumulator.upload(stream);
+    const auto read = PerThreadRead<ND::_1D, float>::build(input);
+    const auto atomicOutput =
+        AtomicReduceWrite<float, ComputeIOp>::build(accumulator, compute);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{1, WIDTH, identity, 0};
+    constexpr int BLOCKS = (WIDTH + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    gridReduceDPPTestKernel<BLOCK_SIZE><<<BLOCKS, BLOCK_SIZE, 0,
+        stream.getCUDAStream()>>>(
+        details, read, compute, atomicOutput);
+    gpuErrchk(cudaGetLastError());
+    accumulator.download(stream);
+    stream.sync();
+
+    const float got = accumulator.at(Point{0, 0, 0});
+    const float tolerance = 1e-4f * std::fmax(1.f, std::fabs(expected));
+    if (std::fabs(got - expected) > tolerance) {
+        std::printf("GPU grid %s got=%f expected=%f blocks=%d\n",
+                    name, got, expected, BLOCKS);
+        return false;
+    }
+    return true;
+}
+
+bool testGpuGridReduction() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuGridVariant<128>("sum", sum, 0.f,
+               [](float a, float b) { return a + b; }) &&
+           runGpuGridVariant<128>("max", max,
+               -std::numeric_limits<float>::infinity(),
+               [](float a, float b) { return std::fmax(a, b); });
+}
+
+template <int BLOCK_SIZE, typename ComputeIOp>
+bool runGpuVariant(const char* name, const int width, const float identity,
+                   const ComputeIOp& compute) {
+    constexpr int ROWS = 3;
+    const int allocationWidth = width > 0 ? width : 1;
+    Ptr2D<float> input(allocationWidth, ROWS);
+    Ptr1D<float> output(ROWS);
+    std::array<float, ROWS> expected{};
+
+    for (int row = 0; row < ROWS; ++row) {
+        expected[row] = identity;
+        for (int x = 0; x < allocationWidth; ++x) {
+            const float value = static_cast<float>(((x * 5 + row * 13) % 37) - 18);
+            input.at(Point{x, row, 0}) = value;
+            if (x < width) expected[row] = make_tuple(expected[row], value) | compute;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{ROWS, width, identity, 0};
+    executeReduce(details, read, compute, write, stream);
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU %s B=%d W=%d row=%d got=%f expected=%f\n",
+                        name, BLOCK_SIZE, width, row, got, expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testGpuVariants() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuVariant<32>("sum-empty", 0, 0.f, sum) &&
+           runGpuVariant<32>("sum-subwarp", 17, 0.f, sum) &&
+           runGpuVariant<32>("sum-warp", 32, 0.f, sum) &&
+           runGpuVariant<32>("sum", 33, 0.f, sum) &&
+           runGpuVariant<64>("max", 129,
+               -std::numeric_limits<float>::infinity(), max) &&
+           runGpuVariant<128>("sum", 257, 0.f, sum) &&
+           runGpuVariant<256>("min", 257,
+               std::numeric_limits<float>::infinity(), min);
+}
+
+bool testGpuRowReductionIOps() {
+    constexpr int TOTAL_ROWS = 5;
+    constexpr int ROWS = 4;
+    constexpr int ROW_OFFSET = 1;
+    constexpr int WIDTH = 257;
+    constexpr int BLOCK_SIZE = 128;
+
+    Ptr2D<float> input(WIDTH, TOTAL_ROWS);
+    Ptr1D<float> output(TOTAL_ROWS);
+    std::array<float, TOTAL_ROWS> expected{};
+    output.at(Point{0, 0, 0}) = 777.f;
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        for (int x = 0; x < WIDTH; ++x) {
+            const float value = static_cast<float>(((x * 7 + row * 11) % 29) - 14);
+            input.at(Point{x, row, 0}) = value;
+            expected[row] += value;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{
+        ROWS, WIDTH, 0.f, ROW_OFFSET};
+    executeReduce(details, read, sum, write, stream);
+
+    output.download(stream);
+    stream.sync();
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, expected[row]);
+            return false;
+        }
+    }
+
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+    output.upload(stream);
+    const auto fusedRead = read.then(Add<float>::build(1.f));
+    const auto fusedWrite = Mul<float>::build(2.f).then(write);
+    executeReduce(details, fusedRead, sum, fusedWrite, stream);
+    output.download(stream);
+    stream.sync();
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        const float fusedExpected = (expected[row] + WIDTH) * 2.f;
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - fusedExpected) > 1e-4f) {
+            std::printf("GPU fused reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, fusedExpected);
+            return false;
+        }
+    }
+
+    const ReduceDPPDetails<float, BLOCK_SIZE> emptyDetails{
+        0, WIDTH, 0.f, 0};
+    executeReduce(emptyDetails, read, sum, write, stream);
+    output.download(stream);
+    stream.sync();
+    if (output.at(Point{0, 0, 0}) != 777.f) {
+        std::printf("GPU zero-row/offset sentinel modified\n");
+        return false;
+    }
+    return true;
+}
+
+bool testGpuMultiAccumulatorReduction() {
+    constexpr int TOTAL_ROWS = 5;
+    constexpr int ROWS = 4;
+    constexpr int ROW_OFFSET = 1;
+    constexpr int WIDTH = 257;
+    constexpr int REDUCTIONS = 2;
+    constexpr int BLOCK_SIZE = 128;
+    Ptr2D<float> input(WIDTH, TOTAL_ROWS);
+    Ptr1D<float> maxOutput(TOTAL_ROWS);
+    Ptr1D<float> sumOutput(TOTAL_ROWS);
+    std::array<float, TOTAL_ROWS> expectedMax{};
+    std::array<float, TOTAL_ROWS> expectedSum{};
+    maxOutput.at(Point{0, 0, 0}) = 777.f;
+    sumOutput.at(Point{0, 0, 0}) = -777.f;
+
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        expectedMax[row] = -std::numeric_limits<float>::infinity();
+        expectedSum[row] = 0.f;
+        for (int x = 0; x < WIDTH; ++x) {
+            const float raw = static_cast<float>(((x * 7 + row * 13) % 59) - 29);
+            input.at(Point{x, row, 0}) = raw;
+            const float sharedRead = raw + 0.5f;
+            expectedMax[row] = std::fmax(expectedMax[row], sharedRead * 2.f);
+            expectedSum[row] += sharedRead - 1.f;
+        }
+        expectedMax[row] += 10.f;
+        expectedSum[row] *= 0.25f;
+        maxOutput.at(Point{row, 0, 0}) = 999.f;
+        sumOutput.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    maxOutput.upload(stream);
+    sumOutput.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input)
+        .then(Add<float>::build(0.5f));
+    const auto computes = make_tuple(
+        make_tuple(Mul<float>::build(2.f),
+                   Max<float, float, float, UnaryType>::build()),
+        make_tuple(Add<float>::build(-1.f),
+                   Add<float, float, float, UnaryType>::build()));
+    const auto outputs = make_tuple(
+        Add<float>::build(10.f).then(
+            PerThreadWrite<ND::_1D, float>::build(maxOutput)),
+        Mul<float>::build(0.25f).then(
+            PerThreadWrite<ND::_1D, float>::build(sumOutput)));
+
+    using Details = MultiReduceDPPDetails<float, REDUCTIONS, BLOCK_SIZE>;
+    const Details details{ROWS, WIDTH,
+        {-std::numeric_limits<float>::infinity(), 0.f}, ROW_OFFSET};
+    executeMultiReduce(details, read, computes, outputs, stream);
+    maxOutput.download(stream);
+    sumOutput.download(stream);
+    stream.sync();
+
+    for (int row = ROW_OFFSET; row < ROW_OFFSET + ROWS; ++row) {
+        const float gotMax = maxOutput.at(Point{row, 0, 0});
+        const float gotSum = sumOutput.at(Point{row, 0, 0});
+        if (std::fabs(gotMax - expectedMax[row]) > 1e-4f ||
+            std::fabs(gotSum - expectedSum[row]) > 1e-4f) {
+            std::printf("GPU multi reduction row=%d max=%f/%f sum=%f/%f\n",
+                        row, gotMax, expectedMax[row], gotSum, expectedSum[row]);
+            return false;
+        }
+    }
+
+    const Details emptyDetails{0, WIDTH,
+        {-std::numeric_limits<float>::infinity(), 0.f}, 0};
+    executeMultiReduce(emptyDetails, read, computes, outputs, stream);
+    maxOutput.download(stream);
+    sumOutput.download(stream);
+    stream.sync();
+    if (maxOutput.at(Point{0, 0, 0}) != 777.f ||
+        sumOutput.at(Point{0, 0, 0}) != -777.f) {
+        std::printf("GPU multi zero-row/offset sentinel modified\n");
+        return false;
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuReductionIOps();
+    ok = testCpuGridTierAndFusion() && ok;
+    ok = testCpuMultiAccumulatorReduction() && ok;
+#if defined(__NVCC__)
+    ok = testGpuGridReduction() && ok;
+    ok = testGpuVariants() && ok;
+    ok = testGpuRowReductionIOps() && ok;
+    ok = testGpuMultiAccumulatorReduction() && ok;
+#endif
+    if (ok) std::printf("ReduceDPP CPU/GPU IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}


### PR DESCRIPTION
1|## Summary
2|
3|Adds composable collective reduction DPPs with CPU and NVIDIA GPU specializations:
4|
5|- `ReduceWarpDPP`: standard compute IOp reduction within one full warp.
6|- `ReduceBlockDPP`: warp partials combined through shared scratch.
7|- `ReduceGridDPP`: block partials combined through an explicit accumulator IOp contract.
8|- `ReduceDPP`: one row per block, with separate Read / compute / Write IOps.
9|- `MultiReduceDPP`: several reductions over one shared input read using `Tuple<Tuple<transform, reduce>...>` and one Write IOp per result.
10|
11|The PR also exports the collective header through `algorithms.h` and registers CPU/CUDA tests.
12|
13|## DPP / IOp contract
14|
15|- `Details` contains only dimensions, row offset, block size and neutral identities.
16|- Input values are obtained exclusively through Read/ReadBack IOps.
17|- Every reduction and transform is performed through passed standard compute IOps.
18|- Row and multi-accumulator results are emitted exclusively through passed Write IOps.
19|- GPU grid reduction uses `AtomicReduceWrite`, a standard Write Operation that encapsulates the destination and the same reduction IOp; `ReduceGridDPP` receives no raw global output pointer.
20|- CPU grid reduction reads and writes its accumulator through explicit Read and Write IOps.
21|- Raw pointers are limited to internal shared-memory scratch where applicable.
22|- CUDA launch kernels only forward arguments to the DPP.
23|
24|## Multi-accumulator form
25|
26|A single Read IOp feeds independent pipelines such as:
27|
28|```cpp
29|make_tuple(
30|    make_tuple(transform0, reduce0),
31|    make_tuple(transform1, reduce1))
32|```
33|
34|The test exercises fused shared-read, independent max/sum transforms, independent fused outputs, ragged width (`257` with 128 threads), non-zero `rowOffset`, and zero-row launch guards.
35|
36|## Verification
37|
38|Fresh local verification on an RTX PRO 6000 Blackwell, CUDA 13.3 / `sm_120`:
39|
40|- g++ Release build + `test_collective_reduce_cpp`: PASS
41|- clang++ Release build + `test_collective_reduce_cpp`: PASS
42|- nvcc Release build + `test_collective_reduce_cu`: PASS
43|- block sizes: 32, 64, 128 and 256
44|- widths: 0, 17, 32, 33, 129 and 257
45|- reducers: Add, Min and Max
46|- row and multi-row reduction with fused prologue/epilogue IOps
47|- multi-accumulator max + sum over one shared read
48|- multi-block grid Add and Max through `AtomicReduceWrite`
49|- non-zero `rowOffset` and zero-row no-launch/no-write sentinels
50|
51|Compute Sanitizer on the CUDA binary:
52|
53|- memcheck: 0 errors
54|- racecheck: 0 hazards
55|- initcheck: 0 errors
56|- synccheck: 0 errors
57|
58|Mutation checks:
59|
60|- changing a multi-accumulator transform (`Add(-1)` → `Add(+1)`) is caught by the CPU oracle;
61|- bypassing the grid atomic combine (`next = input`) is caught by the multi-block GPU oracle.
62|
63|No performance claim is made by this PR; this revision is focused on the composable DPP/IOp contract and correctness.
64|