### PR TITLE
softmax: reduce row state via collective blockReduceSmem

### DIFF
--- a/include/fused_kernel/algorithms/attention/flash_attention.h
+++ b/include/fused_kernel/algorithms/attention/flash_attention.h
@@ -188,7 +188,7 @@ public:
         return attnToF32(IOp::Operation::exec(Point{ x, y, z }, iop));
     }
 
-    FK_COOP_DEVICE_FUSE exec(const Params& p) {
+    FK_DEVICE_STATIC void exec(const Params& p) {
         // Tiles hold POST-prologue fp32: the prologue runs once per element.
         __shared__ float kTile[BLOCK_N][HEAD_DIM];
         __shared__ float vTile[BLOCK_N][HEAD_DIM];

--- a/include/fused_kernel/algorithms/attention/softmax.h
+++ b/include/fused_kernel/algorithms/attention/softmax.h
@@ -15,191 +15,268 @@
 #ifndef FK_ATTENTION_SOFTMAX_H
 #define FK_ATTENTION_SOFTMAX_H
 
-/* SoftmaxDPP: numerically-stable row-wise softmax as a single cooperative
- * DPP (one DPP per kernel, per the current FKL execution model).
- *
- * Not a TransformDPP: softmax needs a row REDUCTION (cross-thread
- * cooperation), so this is a cooperative DPP kind with block-level
- * shared-memory state. Online softmax (Milakov & Gimelshein, 2018):
- * each thread scans a strided slice keeping a running (max m, sum l);
- * states merge associatively; a second pass writes exp(x-m)/l.
- * Two reads + one write per element, no global intermediates, immune to
- * overflow for any input range.
- *
- * PROLOGUE FUSION: the DPP takes the input as a Read or ReadBack IOp
- * (the prologue) and reads each data element through that IOp, so any
- * fused preprocessing chain (read.then(Mul...).then(Cast...)) runs
- * in-register at load time, on BOTH passes, with zero extra traffic.
- * Element addressing: thread.x = column, thread.y = row, thread.z = 0.
- */
-
-#include <fused_kernel/core/data/ptr_nd.h>
-#include <fused_kernel/core/execution_model/stream.h>
-#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/reduce.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/execution_model/stream.h>
 #include <fused_kernel/core/utils/utils.h>
 
 #include <cfloat>
 #include <cmath>
+#include <type_traits>
 #if defined(__NVCC__)
 #include <cuda_fp16.h>
 #endif
 
 namespace fk {
 
-/* Portable math shims for the attention DPPs. Three compiler worlds:
- *  - device code: __expf-class intrinsics are fine inside kernels but the
- *    shared host/device helpers below must compile on the HOST pass too;
- *  - g++ CPU-only TUs: std::expf is NOT declared by libstdc++ (<cmath>
- *    only guarantees ::expf) — broke utest_*_cpp on the g++-13 runners;
- *  - MSVC: __builtin_expf does not exist (C3861), and calling ::fmaxf
- *    inside a constexpr function is rejected (C3615).
- * Solution: never reference expf/fmaxf by unqualified name. attnMaxF is
- * a constexpr ternary (legal everywhere); attnExpF is a NON-constexpr
- * host+device inline that maps to the right primitive per target. */
 FK_HOST_DEVICE_CNST float attnMaxF(const float a, const float b) {
-    return a > b ? a : (b >= a ? b : (a == a ? a : b));  // NaN -> other arg
+    return a > b ? a : (b >= a ? b : (a == a ? a : b));
 }
 
-#if defined(__NVCC__)
-__host__ __device__ __forceinline__ float attnExpF(const float x) {
-#if defined(__CUDA_ARCH__)
-    return ::expf(x);     // device fast path (correctly-rounded enough here)
-#else
-    return ::expf(x);     // host pass of nvcc/clang-cuda
-#endif
-}
-#else
-inline float attnExpF(const float x) { return ::expf(x); }  // pure CPU TU
-#endif
-
-// Cooperative-DPP exec bodies use __shared__ + barriers: they cannot be
-// constexpr (FK_DEVICE_FUSE). Plain static device inline qualifier:
-#define FK_COOP_DEVICE_FUSE static __device__ __forceinline__ void
-
-template <typename T>
-FK_HOST_DEVICE_CNST float attnToF32(const T& v) {
-#if defined(__NVCC__)
-    if constexpr (std::is_same_v<T, __half>) { return __half2float(v); } else
-#endif
-    { return static_cast<float>(v); }
+FK_HOST_DEVICE_STATIC float attnExpF(const float x) {
+    return ::expf(x);
 }
 
 template <typename T>
-FK_HOST_DEVICE_CNST T attnFromF32(const float& v) {
+FK_HOST_DEVICE_CNST float attnToF32(const T& value) {
 #if defined(__NVCC__)
-    if constexpr (std::is_same_v<T, __half>) { return __float2half(v); } else
+    if constexpr (std::is_same_v<T, __half>) {
+        return __half2float(value);
+    } else
 #endif
-    { return static_cast<T>(v); }
+    {
+        return static_cast<float>(value);
+    }
+}
+
+template <typename T>
+FK_HOST_DEVICE_CNST T attnFromF32(const float value) {
+#if defined(__NVCC__)
+    if constexpr (std::is_same_v<T, __half>) {
+        return __float2half(value);
+    } else
+#endif
+    {
+        return static_cast<T>(value);
+    }
 }
 
 struct OnlineSoftmaxState {
-    float m;  // running max
-    float l;  // running sum of exp(x - m)
+    float maximum;
+    float denominator;
 };
 
-// NOT constexpr: attnExpF maps to ::expf (non-constexpr on MSVC/clang).
-#if defined(__NVCC__)
-__host__ __device__ __forceinline__
-#else
-inline
-#endif
-OnlineSoftmaxState mergeSoftmaxStates(const OnlineSoftmaxState& a,
-                                                          const OnlineSoftmaxState& b) {
-    const float m = attnMaxF(a.m, b.m);
-    const float la = a.l == 0.f ? 0.f : a.l * attnExpF(a.m - m);
-    const float lb = b.l == 0.f ? 0.f : b.l * attnExpF(b.m - m);
-    return { m, la + lb };
+FK_HOST_DEVICE_STATIC OnlineSoftmaxState mergeSoftmaxStates(
+        const OnlineSoftmaxState& lhs, const OnlineSoftmaxState& rhs) {
+    const float maximum = attnMaxF(lhs.maximum, rhs.maximum);
+    const float lhsDenominator = lhs.denominator == 0.f
+        ? 0.f
+        : lhs.denominator * attnExpF(lhs.maximum - maximum);
+    const float rhsDenominator = rhs.denominator == 0.f
+        ? 0.f
+        : rhs.denominator * attnExpF(rhs.maximum - maximum);
+    return {maximum, lhsDenominator + rhsDenominator};
 }
 
-#if defined(__NVCC__)
+template <typename I1 = OnlineSoftmaxState,
+          typename I2 = I1,
+          typename O = I1,
+          typename IType = UnaryType>
+struct MergeSoftmaxState;
 
-/* InIOp is an INSTANTIABLE Read or ReadBack IOp (possibly a fusion
- * read.then(compute...)): the prologue. Every element enters the
- * algorithm through InIOp::Operation::exec(thread, iop). */
-template <typename InIOp, typename OT, int BLOCK_SIZE = 256>
-struct SoftmaxDPP {
+template <typename I1, typename I2, typename O>
+struct MergeSoftmaxState<I1, I2, O, UnaryType> {
 private:
-    using SelfType = SoftmaxDPP<InIOp, OT, BLOCK_SIZE>;
+    using SelfType = MergeSoftmaxState<I1, I2, O, UnaryType>;
+
+public:
+    FK_STATIC_STRUCT(MergeSoftmaxState, SelfType)
+    using Parent = UnaryOperation<Tuple<I1, I2>, O, SelfType>;
+    DECLARE_UNARY_PARENT
+
+    FK_HOST_DEVICE_STATIC OutputType exec(const InputType input) {
+        return mergeSoftmaxStates(get<0>(input), get<1>(input));
+    }
+};
+
+template <typename T, int BLOCK_SIZE = 256>
+struct SoftmaxDPPDetails {
+    static_assert(BLOCK_SIZE >= 32 && BLOCK_SIZE <= 1024 &&
+                  BLOCK_SIZE % 32 == 0,
+                  "SoftmaxDPP block size must be a warp multiple in [32, 1024]");
+
+    using ScalarType = T;
+    using ValueType = OnlineSoftmaxState;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+
+    int rows;
+    int width;
+    OnlineSoftmaxState identity{-FLT_MAX, 0.f};
+    int rowOffset{0};
+};
+
+template <ParArch PA, typename DPPDetails>
+struct SoftmaxDPP;
+
+template <typename DPPDetails>
+struct SoftmaxDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = SoftmaxDPP<ParArch::CPU, DPPDetails>;
+    using Scalar = typename DPPDetails::ScalarType;
+    using State = typename DPPDetails::ValueType;
+
 public:
     FK_STATIC_STRUCT(SoftmaxDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
 
-    static_assert(isAnyReadType<InIOp>, "Softmax prologue must be a Read or ReadBack IOp");
+    template <typename ReadIOp, typename WriteIOp, typename MergeIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const ReadIOp& input,
+                             const WriteIOp& output,
+                             const MergeIOp& merge) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "SoftmaxDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "SoftmaxDPP output must be a Write IOp");
+        static_assert(opIs<UnaryType, MergeIOp>,
+                      "SoftmaxDPP merge must be an instantiable Unary IOp");
 
-    struct Params {
-        InIOp input;             // prologue Read/ReadBack IOp
-        RawPtr<ND::_2D, OT> output;
-        int width;               // row length
-    };
-
-    FK_DEVICE_FUSE float readElem(const InIOp& iop, const int x, const int y) {
-        return attnToF32(InIOp::Operation::exec(Point{ x, y, 0 }, iop));
-    }
-
-    FK_COOP_DEVICE_FUSE exec(const Params& p) {
-        __shared__ OnlineSoftmaxState states[BLOCK_SIZE];
-
-        const int row = blockIdx.x;
-        const int tid = threadIdx.x;
-        const int width = p.width;
-
-        OT* out = PtrAccessor<ND::_2D>::point(Point{0, row, 0}, p.output);
-
-        OnlineSoftmaxState st{ -FLT_MAX, 0.f };
-        for (int x = tid; x < width; x += BLOCK_SIZE) {
-            // PROLOGUE: element read through the IOp (pass 1)
-            const float v = readElem(p.input, x, row);
-            const float m = attnMaxF(st.m, v);
-            st.l = st.l * attnExpF(st.m - m) + attnExpF(v - m);
-            st.m = m;
-        }
-        states[tid] = st;
-        __syncthreads();
-
-        for (int stride = BLOCK_SIZE / 2; stride > 0; stride >>= 1) {
-            if (tid < stride) {
-                states[tid] = mergeSoftmaxStates(states[tid], states[tid + stride]);
+        for (int localRow = 0; localRow < details.rows; ++localRow) {
+            const int row = details.rowOffset + localRow;
+            State state = details.identity;
+            for (int x = 0; x < details.width; ++x) {
+                const float value = attnToF32(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                state = make_tuple(state, State{value, 1.f}) | merge;
             }
-            __syncthreads();
-        }
-        const float m = states[0].m;
-        const float invL = 1.f / states[0].l;
-
-        for (int x = tid; x < width; x += BLOCK_SIZE) {
-            // PROLOGUE: element read through the IOp (pass 2)
-            out[x] = attnFromF32<OT>(attnExpF(readElem(p.input, x, row) - m) * invL);
+            const float inverseDenominator = 1.f / state.denominator;
+            for (int x = 0; x < details.width; ++x) {
+                const float value = attnToF32(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                const Scalar result = attnFromF32<Scalar>(
+                    attnExpF(value - state.maximum) * inverseDenominator);
+                WriteIOp::Operation::exec(Point{x, row, 0}, result, output);
+            }
         }
     }
 };
 
-template <typename InIOp, typename OT, int BLOCK_SIZE>
-__global__ void launchSoftmaxDPP_Kernel(const __grid_constant__ typename SoftmaxDPP<InIOp, OT, BLOCK_SIZE>::Params params) {
-    SoftmaxDPP<InIOp, OT, BLOCK_SIZE>::exec(params);
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct SoftmaxDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = SoftmaxDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using Scalar = typename DPPDetails::ScalarType;
+    using State = typename DPPDetails::ValueType;
+
+    // CUDA rejects function-local __shared__ storage in FK_DEVICE_FUSE's
+    // constexpr function. Keep only this shared-memory runtime body private.
+    template <typename ReadIOp, typename WriteIOp, typename MergeIOp>
+    FK_DEVICE_STATIC void execRuntime(
+            const DPPDetails& details,
+            const ReadIOp& input,
+            const WriteIOp& output,
+            const MergeIOp& merge) {
+        __shared__ State blockScratch[DPPDetails::BLOCK_THREADS];
+
+        const int localRow = static_cast<int>(blockIdx.x);
+        if (localRow >= details.rows) return;
+        const int row = details.rowOffset + localRow;
+        const int tid = static_cast<int>(threadIdx.x);
+
+        State state = details.identity;
+        for (int x = tid; x < details.width; x += DPPDetails::BLOCK_THREADS) {
+            const float value = attnToF32(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            state = make_tuple(state, State{value, 1.f}) | merge;
+        }
+
+        const State reduced =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, state, merge, blockScratch);
+        const float inverseDenominator = 1.f / reduced.denominator;
+        for (int x = tid; x < details.width; x += DPPDetails::BLOCK_THREADS) {
+            const float value = attnToF32(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            const Scalar result = attnFromF32<Scalar>(
+                attnExpF(value - reduced.maximum) * inverseDenominator);
+            WriteIOp::Operation::exec(Point{x, row, 0}, result, output);
+        }
+    }
+
+public:
+    FK_STATIC_STRUCT(SoftmaxDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp, typename WriteIOp, typename MergeIOp>
+    FK_DEVICE_FUSE void exec(const DPPDetails& details,
+                             const ReadIOp& input,
+                             const WriteIOp& output,
+                             const MergeIOp& merge) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "SoftmaxDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "SoftmaxDPP output must be a Write IOp");
+        static_assert(opIs<UnaryType, MergeIOp>,
+                      "SoftmaxDPP merge must be an instantiable Unary IOp");
+        execRuntime(details, input, output, merge);
+    }
+};
+
+template <typename DPPDetails, typename ReadIOp,
+          typename WriteIOp, typename MergeIOp>
+__global__ void launchSoftmaxDPPKernel(
+        const __grid_constant__ DPPDetails details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ WriteIOp output,
+        const __grid_constant__ MergeIOp merge) {
+    SoftmaxDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+        details, input, output, merge);
 }
 
-/* IOp-first API: input is the prologue Read/ReadBack IOp. */
-template <int BLOCK_SIZE = 256, typename InIOp, typename OT>
-inline void executeSoftmax(const InIOp& input, const Ptr2D<OT>& output,
-                           const int rows, const int width,
+template <typename DPPDetails, typename ReadIOp,
+          typename WriteIOp, typename MergeIOp>
+inline void executeSoftmax(const DPPDetails& details,
+                           const ReadIOp& input,
+                           const WriteIOp& output,
+                           const MergeIOp& merge,
                            Stream_<ParArch::GPU_NVIDIA>& stream) {
-    using DPP = SoftmaxDPP<InIOp, OT, BLOCK_SIZE>;
-    const typename DPP::Params params{ input, output.ptr(), width };
-    const dim3 grid(rows, 1, 1);
-    const dim3 block(BLOCK_SIZE, 1, 1);
-    launchSoftmaxDPP_Kernel<InIOp, OT, BLOCK_SIZE><<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    static_assert(std::is_trivially_copyable_v<DPPDetails>,
+                  "SoftmaxDPP Details must be trivially copyable");
+    if (details.rows <= 0 || details.width <= 0) return;
+    launchSoftmaxDPPKernel<<<details.rows, DPPDetails::BLOCK_THREADS, 0,
+                            stream.getCUDAStream()>>>(
+        details, input, output, merge);
     gpuErrchk(cudaGetLastError());
 }
 
-/* Pointer convenience API (back-compat): canonical PerThreadRead prologue. */
-template <typename T, int BLOCK_SIZE = 256>
-inline void executeSoftmax(const Ptr2D<T>& input, const Ptr2D<T>& output,
+template <int BLOCK_SIZE = 256, typename ReadIOp, typename OT>
+inline void executeSoftmax(const ReadIOp& input,
+                           const Ptr2D<OT>& output,
+                           const int rows, const int width,
                            Stream_<ParArch::GPU_NVIDIA>& stream) {
-    const auto inIOp = PerThreadRead<ND::_2D, T>::build(input.ptr());
-    executeSoftmax<BLOCK_SIZE>(inIOp, output,
-                               static_cast<int>(input.dims().height),
-                               static_cast<int>(input.dims().width), stream);
+    const SoftmaxDPPDetails<OT, BLOCK_SIZE> details{rows, width};
+    const auto write = PerThreadWrite<ND::_2D, OT>::build(output);
+    const auto merge = MergeSoftmaxState<>::build();
+    executeSoftmax(details, input, write, merge, stream);
 }
 
+template <typename T, int BLOCK_SIZE = 256>
+inline void executeSoftmax(const Ptr2D<T>& input,
+                           const Ptr2D<T>& output,
+                           Stream_<ParArch::GPU_NVIDIA>& stream) {
+    const SoftmaxDPPDetails<T, BLOCK_SIZE> details{
+        static_cast<int>(input.dims().height),
+        static_cast<int>(input.dims().width)};
+    const auto read = PerThreadRead<ND::_2D, T>::build(input);
+    const auto write = PerThreadWrite<ND::_2D, T>::build(output);
+    const auto merge = MergeSoftmaxState<>::build();
+    executeSoftmax(details, read, write, merge, stream);
+}
 #endif // defined(__NVCC__)
 
 } // namespace fk

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2023 Oscar Amoros Huguet
+/* Copyright 2026 Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,9 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/collective/collective.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
+#include <fused_kernel/algorithms/collective/reduce.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -126,18 +126,18 @@ template <typename DPPDetails>
 struct ReduceGridDPP<ParArch::CPU, DPPDetails> {
 private:
     using SelfType = ReduceGridDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
 
 public:
     FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::CPU;
 
-    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
-    FK_HOST_FUSE void exec(const DPPDetails& details,
-                           const ReadIOp& input,
-                           const ComputeIOp& compute,
-                           const WriteIOp& output) {
-        ReduceDPP<ParArch::CPU, DPPDetails>::exec(
-            details, input, compute, output);
+    template <typename ComputeIOp>
+    FK_HOST_FUSE void exec(const DPPDetails&, const T value,
+                           const ComputeIOp& compute, T*, T* accumulator) {
+        if (accumulator != nullptr) {
+            *accumulator = make_tuple(*accumulator, value) | compute;
+        }
     }
 };
 
@@ -264,18 +264,44 @@ template <typename DPPDetails>
 struct ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails> {
 private:
     using SelfType = ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+    template <typename ComputeIOp>
+    static __device__ __forceinline__ void atomicApply(
+            T* address, const T value, const ComputeIOp& compute) {
+        static_assert(sizeof(T) == sizeof(unsigned int),
+                      "ReduceGridDPP CAS supports 32-bit value types");
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "ReduceGridDPP CAS requires a trivially copyable type");
+
+        auto* bitsAddress = reinterpret_cast<unsigned int*>(address);
+        unsigned int oldBits = atomicCAS(bitsAddress, 0u, 0u);
+        unsigned int assumedBits;
+        do {
+            assumedBits = oldBits;
+            T current;
+            __builtin_memcpy(&current, &assumedBits, sizeof(T));
+            const T next = make_tuple(current, value) | compute;
+            unsigned int nextBits;
+            __builtin_memcpy(&nextBits, &next, sizeof(T));
+            oldBits = atomicCAS(bitsAddress, assumedBits, nextBits);
+        } while (oldBits != assumedBits);
+    }
 
 public:
     FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
 
-    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
-    FK_DEVICE_FUSE void exec(const DPPDetails& details,
-                             const ReadIOp& input,
-                             const ComputeIOp& compute,
-                             const WriteIOp& output) {
-        ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
-            details, input, compute, output);
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE void exec(const DPPDetails& details, const T value,
+                             const ComputeIOp& compute, T* warpScratch,
+                             T* accumulator) {
+        const T blockPartial =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute, warpScratch);
+        if (threadIdx.x == 0) {
+            atomicApply(accumulator, blockPartial, compute);
+        }
     }
 };
 
@@ -286,7 +312,7 @@ __global__ void launchReduceDPPKernel(
         const __grid_constant__ ReadIOp input,
         const __grid_constant__ ComputeIOp compute,
         const __grid_constant__ WriteIOp output) {
-    ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+    ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
         details, input, compute, output);
 }
 

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -183,28 +183,46 @@ public:
 
     template <typename ComputeIOp>
     FK_DEVICE_FUSE T exec(const DPPDetails& details, T value,
-                          const ComputeIOp& compute, T* warpScratch) {
+                          const ComputeIOp& compute, T* scratch) {
 #if defined(__CUDA_ARCH__)
         constexpr int WARP_SIZE = 32;
-        constexpr int NUM_WARPS =
-            (DPPDetails::BLOCK_THREADS + WARP_SIZE - 1) / WARP_SIZE;
-        const int lane = static_cast<int>(threadIdx.x) & (WARP_SIZE - 1);
-        const int warp = static_cast<int>(threadIdx.x) / WARP_SIZE;
+        if constexpr (std::is_arithmetic_v<T> || std::is_enum_v<T>) {
+            constexpr int NUM_WARPS =
+                (DPPDetails::BLOCK_THREADS + WARP_SIZE - 1) / WARP_SIZE;
+            const int lane = static_cast<int>(threadIdx.x) & (WARP_SIZE - 1);
+            const int warp = static_cast<int>(threadIdx.x) / WARP_SIZE;
 
-        value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
-            details, value, compute);
-        if (lane == 0) warpScratch[warp] = value;
-        __syncthreads();
-
-        if (warp == 0) {
-            value = lane < NUM_WARPS ? warpScratch[lane] : details.identity;
             value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
                 details, value, compute);
+            if (lane == 0) scratch[warp] = value;
+            __syncthreads();
+
+            if (warp == 0) {
+                value = lane < NUM_WARPS ? scratch[lane] : details.identity;
+                value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                    details, value, compute);
+            }
+        } else {
+            const int tid = static_cast<int>(threadIdx.x);
+            scratch[tid] = value;
+            __syncthreads();
+
+            int active = DPPDetails::BLOCK_THREADS;
+            while (active > 1) {
+                const int stride = (active + 1) / 2;
+                if (tid < stride && tid + stride < active) {
+                    scratch[tid] = make_tuple(
+                        scratch[tid], scratch[tid + stride]) | compute;
+                }
+                __syncthreads();
+                active = stride;
+            }
+            value = scratch[0];
         }
 #else
         (void)details;
         (void)compute;
-        (void)warpScratch;
+        (void)scratch;
 #endif
         return value;
     }

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -1,0 +1,312 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REDUCE_H
+#define FK_COLLECTIVE_REDUCE_H
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, int BLOCK_SIZE = 256>
+struct ReduceDPPDetails {
+    static_assert(BLOCK_SIZE > 0, "ReduceDPP block size must be positive");
+
+    using ValueType = T;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+
+    int rows;
+    int width;
+    // Must be the neutral element of the supplied compute IOp.
+    T identity;
+    int rowOffset{0};
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceWarpDPP;
+
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceBlockDPP;
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&, T*) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceDPP;
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::CPU, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    FK_HOST_FUSE void exec(const Details& details,
+                           const ReadIOp& input,
+                           const ComputeIOp& compute,
+                           const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS > 0,
+                      "ReduceDPP block size must be positive");
+
+        for (int localRow = 0; localRow < details.rows; ++localRow) {
+            const int row = details.rowOffset + localRow;
+            T accumulator = details.identity;
+            for (int x = 0; x < details.width; ++x) {
+                const T value = static_cast<T>(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                accumulator = make_tuple(accumulator, value) | compute;
+            }
+            WriteIOp::Operation::exec(Point{row, 0, 0}, accumulator, output);
+        }
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceGridDPP;
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::CPU, DPPDetails>;
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    FK_HOST_FUSE void exec(const DPPDetails& details,
+                           const ReadIOp& input,
+                           const ComputeIOp& compute,
+                           const WriteIOp& output) {
+        ReduceDPP<ParArch::CPU, DPPDetails>::exec(
+            details, input, compute, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails&, T value,
+                          const ComputeIOp& compute) {
+#if defined(__CUDA_ARCH__)
+        const unsigned int mask = __activemask();
+        const int lane = static_cast<int>(threadIdx.x) & 31;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            const T peer = __shfl_down_sync(mask, value, offset);
+            if (lane + offset < 32) {
+                value = make_tuple(value, peer) | compute;
+            }
+        }
+#else
+        (void)compute;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails& details, T value,
+                          const ComputeIOp& compute, T* warpScratch) {
+#if defined(__CUDA_ARCH__)
+        constexpr int WARP_SIZE = 32;
+        constexpr int NUM_WARPS =
+            (DPPDetails::BLOCK_THREADS + WARP_SIZE - 1) / WARP_SIZE;
+        const int lane = static_cast<int>(threadIdx.x) & (WARP_SIZE - 1);
+        const int warp = static_cast<int>(threadIdx.x) / WARP_SIZE;
+
+        value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+            details, value, compute);
+        if (lane == 0) warpScratch[warp] = value;
+        __syncthreads();
+
+        if (warp == 0) {
+            value = lane < NUM_WARPS ? warpScratch[lane] : details.identity;
+            value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute);
+        }
+#else
+        (void)details;
+        (void)compute;
+        (void)warpScratch;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    // Deliberately not FK_DEVICE_FUSE: CUDA rejects a function-local
+    // __shared__ declaration inside the macro's constexpr function.
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    static __device__ __forceinline__ void exec(const Details& details,
+                                                const ReadIOp& input,
+                                                const ComputeIOp& compute,
+                                                const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS >= 32 &&
+                      Details::BLOCK_THREADS <= 1024 &&
+                      Details::BLOCK_THREADS % 32 == 0,
+                      "ReduceDPP block size must be a warp multiple in [32, 1024]");
+
+        constexpr int NUM_WARPS = Details::BLOCK_THREADS / 32;
+        __shared__ T warpScratch[NUM_WARPS];
+
+        const int localRow = static_cast<int>(blockIdx.x);
+        if (localRow >= details.rows) return;
+        const int row = details.rowOffset + localRow;
+        const int tid = static_cast<int>(threadIdx.x);
+        T accumulator = details.identity;
+        for (int x = tid; x < details.width; x += Details::BLOCK_THREADS) {
+            const T value = static_cast<T>(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            accumulator = make_tuple(accumulator, value) | compute;
+        }
+
+        const T result =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, Details>::exec(
+                details, accumulator, compute, warpScratch);
+        if (tid == 0) {
+            WriteIOp::Operation::exec(Point{row, 0, 0}, result, output);
+        }
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    FK_DEVICE_FUSE void exec(const DPPDetails& details,
+                             const ReadIOp& input,
+                             const ComputeIOp& compute,
+                             const WriteIOp& output) {
+        ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+            details, input, compute, output);
+    }
+};
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+__global__ void launchReduceDPPKernel(
+        const __grid_constant__ DPPDetails details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        const __grid_constant__ WriteIOp output) {
+    ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+        details, input, compute, output);
+}
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+inline void executeReduce(const DPPDetails& details,
+                          const ReadIOp& input,
+                          const ComputeIOp& compute,
+                          const WriteIOp& output,
+                          Stream_<ParArch::GPU_NVIDIA>& stream) {
+    static_assert(std::is_trivially_copyable_v<DPPDetails>,
+                  "ReduceDPP Details must be trivially copyable");
+    if (details.rows <= 0) return;
+    launchReduceDPPKernel<<<details.rows, DPPDetails::BLOCK_THREADS, 0,
+                           stream.getCUDAStream()>>>(
+        details, input, compute, output);
+    gpuErrchk(cudaGetLastError());
+}
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REDUCE_H

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -39,6 +39,7 @@
 #define FK_HOST_FUSE __host__ __forceinline__ static constexpr
 #define FK_HOST_CNST __host__ __forceinline__ constexpr
 #define FK_HOST_STATIC __host__ __forceinline__ static
+#define FK_DEVICE_STATIC __device__ __forceinline__ static
 #define FK_HOST_INLINE __host__ __forceinline__
 #define FK_HOST_DEVICE_STATIC __host__ __device__ __forceinline__ static
 #define FK_RESTRICT __restrict__
@@ -50,6 +51,7 @@
 #define FK_HOST_FUSE static constexpr __forceinline__
 #define FK_HOST_CNST constexpr __forceinline__
 #define FK_HOST_STATIC static constexpr __forceinline__
+#define FK_DEVICE_STATIC static __forceinline__
 #define FK_HOST_INLINE constexpr __forceinline__
 #define FK_HOST_DEVICE_STATIC static __forceinline__
 #define FK_RESTRICT __restrict__
@@ -61,6 +63,7 @@
 #define FK_HOST_FUSE static constexpr inline
 #define FK_HOST_CNST constexpr inline
 #define FK_HOST_STATIC static inline
+#define FK_DEVICE_STATIC static inline
 #define FK_HOST_INLINE inline
 #define FK_HOST_DEVICE_STATIC static inline
 #ifdef _MSC_VER

--- a/tests/attention/test_softmax_dpp.h
+++ b/tests/attention/test_softmax_dpp.h
@@ -1,0 +1,225 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/attention/softmax.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+constexpr int BLOCK_SIZE = 128;
+using Details = SoftmaxDPPDetails<float, BLOCK_SIZE>;
+using MergeIOp = decltype(MergeSoftmaxState<>::build());
+
+static_assert(SoftmaxDPP<ParArch::CPU, Details>::PAR_ARCH == ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(SoftmaxDPP<ParArch::GPU_NVIDIA, Details>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+static_assert(std::is_trivially_copyable_v<Details>);
+static_assert(opIs<UnaryType, MergeIOp>);
+
+template <typename Transform>
+std::vector<double> softmaxOracle(const std::vector<float>& input,
+                                  const int rows, const int width,
+                                  const Transform& transform,
+                                  const double outputScale) {
+    std::vector<double> expected(input.size());
+    for (int row = 0; row < rows; ++row) {
+        double maximum = -std::numeric_limits<double>::infinity();
+        for (int x = 0; x < width; ++x) {
+            maximum = std::max(maximum,
+                transform(static_cast<double>(input[row * width + x])));
+        }
+        double denominator = 0.0;
+        for (int x = 0; x < width; ++x) {
+            denominator += std::exp(
+                transform(static_cast<double>(input[row * width + x])) - maximum);
+        }
+        for (int x = 0; x < width; ++x) {
+            expected[row * width + x] = outputScale * std::exp(
+                transform(static_cast<double>(input[row * width + x])) - maximum) /
+                denominator;
+        }
+    }
+    return expected;
+}
+
+bool checkResult(const char* name, const std::vector<float>& got,
+                 const std::vector<double>& expected,
+                 const int rows, const int width,
+                 const double expectedRowSum, const double tolerance) {
+    double maxError = 0.0;
+    for (int row = 0; row < rows; ++row) {
+        double rowSum = 0.0;
+        for (int x = 0; x < width; ++x) {
+            const float value = got[row * width + x];
+            if (!std::isfinite(value)) {
+                std::printf("%s non-finite row=%d x=%d value=%f\n",
+                            name, row, x, value);
+                return false;
+            }
+            rowSum += value;
+            maxError = std::max(maxError,
+                std::fabs(static_cast<double>(value) - expected[row * width + x]));
+        }
+        if (std::fabs(rowSum - expectedRowSum) > tolerance * width) {
+            std::printf("%s row=%d sum=%g expected=%g\n",
+                        name, row, rowSum, expectedRowSum);
+            return false;
+        }
+    }
+    if (maxError > tolerance) {
+        std::printf("%s maxError=%g tolerance=%g\n", name, maxError, tolerance);
+        return false;
+    }
+    return true;
+}
+
+std::vector<float> makeInput(const int rows, const int width, const float scale) {
+    std::vector<float> input(rows * width);
+    for (int row = 0; row < rows; ++row) {
+        for (int x = 0; x < width; ++x) {
+            const int code = ((row + 3) * 29 + (x + 5) * 17) % 101;
+            input[row * width + x] = scale * static_cast<float>(code - 50);
+        }
+    }
+    return input;
+}
+
+bool testCpuBaseline(const int rows, const int width, const float inputScale) {
+    const std::vector<float> input = makeInput(rows, width, inputScale);
+    std::vector<float> output(input.size(), -1.f);
+    const RawPtr<ND::_2D, float> inputPtr{
+        const_cast<float*>(input.data()),
+        PtrDims<ND::_2D>(width, rows, width * sizeof(float))};
+    const RawPtr<ND::_2D, float> outputPtr{
+        output.data(), PtrDims<ND::_2D>(width, rows, width * sizeof(float))};
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr);
+    const auto write = PerThreadWrite<ND::_2D, float>::build(outputPtr);
+    const auto merge = MergeSoftmaxState<>::build();
+    const Details details{rows, width};
+    SoftmaxDPP<ParArch::CPU, Details>::exec(details, read, write, merge);
+
+    const auto expected = softmaxOracle(
+        input, rows, width, [](const double x) { return x; }, 1.0);
+    return checkResult("CPU baseline", output, expected,
+                       rows, width, 1.0, 2e-6);
+}
+
+bool testCpuFusedIOps() {
+    constexpr int rows = 3;
+    constexpr int width = 17;
+    const std::vector<float> input = makeInput(rows, width, 0.125f);
+    std::vector<float> output(input.size(), -1.f);
+    const RawPtr<ND::_2D, float> inputPtr{
+        const_cast<float*>(input.data()),
+        PtrDims<ND::_2D>(width, rows, width * sizeof(float))};
+    const RawPtr<ND::_2D, float> outputPtr{
+        output.data(), PtrDims<ND::_2D>(width, rows, width * sizeof(float))};
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Mul<float>::build(1.5f))
+        .then(Add<float>::build(-0.25f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(outputPtr));
+    const auto merge = MergeSoftmaxState<>::build();
+    const Details details{rows, width};
+    SoftmaxDPP<ParArch::CPU, Details>::exec(details, read, write, merge);
+
+    const auto expected = softmaxOracle(
+        input, rows, width, [](const double x) { return 1.5 * x - 0.25; }, 3.0);
+    return checkResult("CPU fused IOps", output, expected,
+                       rows, width, 3.0, 3e-6);
+}
+
+#if defined(__NVCC__)
+template <bool FUSED>
+bool testGpuCase(const char* name, const int rows, const int width,
+                 const float inputScale) {
+    const std::vector<float> hostInput = makeInput(rows, width, inputScale);
+    Ptr2D<float> input(width, rows);
+    Ptr2D<float> output(width, rows);
+    for (int row = 0; row < rows; ++row) {
+        for (int x = 0; x < width; ++x) {
+            input.at(Point{x, row, 0}) = hostInput[row * width + x];
+            output.at(Point{x, row, 0}) = -1.f;
+        }
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto merge = MergeSoftmaxState<>::build();
+    const Details details{rows, width};
+    if constexpr (FUSED) {
+        const auto read = PerThreadRead<ND::_2D, float>::build(input)
+            .then(Mul<float>::build(1.5f))
+            .then(Add<float>::build(-0.25f));
+        const auto write = Mul<float>::build(3.f)
+            .then(PerThreadWrite<ND::_2D, float>::build(output));
+        executeSoftmax(details, read, write, merge, stream);
+    } else {
+        const auto read = PerThreadRead<ND::_2D, float>::build(input);
+        const auto write = PerThreadWrite<ND::_2D, float>::build(output);
+        executeSoftmax(details, read, write, merge, stream);
+    }
+    output.download(stream);
+    stream.sync();
+
+    std::vector<float> got(hostInput.size());
+    for (int row = 0; row < rows; ++row) {
+        for (int x = 0; x < width; ++x) {
+            got[row * width + x] = output.at(Point{x, row, 0});
+        }
+    }
+    const auto expected = FUSED
+        ? softmaxOracle(hostInput, rows, width,
+              [](const double x) { return 1.5 * x - 0.25; }, 3.0)
+        : softmaxOracle(hostInput, rows, width,
+              [](const double x) { return x; }, 1.0);
+    return checkResult(name, got, expected, rows, width,
+                       FUSED ? 3.0 : 1.0, 8e-6);
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuBaseline(3, 7, 0.25f);
+    ok = testCpuBaseline(2, BLOCK_SIZE, 0.125f) && ok;
+    ok = testCpuBaseline(4, BLOCK_SIZE * 2 + 1, 20.f) && ok;
+    ok = testCpuFusedIOps() && ok;
+#if defined(__NVCC__)
+    ok = testGpuCase<false>("GPU width<block", 3, 7, 0.25f) && ok;
+    ok = testGpuCase<false>("GPU width==block", 2, BLOCK_SIZE, 0.125f) && ok;
+    ok = testGpuCase<false>("GPU non-divisible extreme", 4,
+                            BLOCK_SIZE * 2 + 1, 20.f) && ok;
+    ok = testGpuCase<true>("GPU fused IOps", 3, 17, 0.125f) && ok;
+#endif
+    if (ok) std::printf("SoftmaxDPP CPU/GPU IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -1,0 +1,236 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <fused_kernel/algorithms/algorithms.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace fk;
+
+namespace {
+
+template <typename ComputeIOp>
+bool runCpuCase(const ComputeIOp& compute,
+                const std::array<float, 3>& identity,
+                const std::array<float, 3>& expected) {
+    constexpr int ROWS = 3;
+    constexpr int WIDTH = 7;
+    constexpr int BLOCK_SIZE = 64;
+
+    std::array<float, ROWS * WIDTH> input{
+         1.f, -2.f,  3.f,  4.f, -5.f,  6.f,  7.f,
+        -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f,
+         0.5f, 1.5f, -2.f, 8.f,  3.f, -1.f, 2.f
+    };
+    std::array<float, ROWS> output{123.f, 123.f, 123.f};
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, ROWS, WIDTH * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(ROWS, ROWS * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(outputPtr);
+
+    using Details = ReduceDPPDetails<float, BLOCK_SIZE>;
+    for (int row = 0; row < ROWS; ++row) {
+        const Details details{1, WIDTH, identity[row], row};
+        ReduceDPP<ParArch::CPU, Details>::exec(details, read, compute, write);
+    }
+
+    for (int row = 0; row < ROWS; ++row) {
+        if (std::fabs(output[row] - expected[row]) > 1e-6f) {
+            std::printf("CPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, output[row], expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testCpuReductionIOps() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+
+    const bool sumOk = runCpuCase(sum, {0.f, 0.f, 0.f}, {14.f, -42.f, 12.f});
+    const bool minOk = runCpuCase(min,
+        {std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity()},
+        {-5.f, -9.f, -2.f});
+    const bool maxOk = runCpuCase(max,
+        {-std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity()},
+        {7.f, -3.f, 8.f});
+    return sumOk && minOk && maxOk;
+}
+
+bool testCpuGridTierAndFusion() {
+    std::array<float, 3> input{1.f, 2.f, 3.f};
+    std::array<float, 1> output{0.f};
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(3, 1, 3 * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(1, sizeof(float))};
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Add<float>::build(1.f));
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = Mul<float>::build(2.f)
+        .then(PerThreadWrite<ND::_1D, float>::build(outputPtr));
+
+    using Details = ReduceDPPDetails<float, 32>;
+    const Details details{1, 3, 0.f, 0};
+    ReduceGridDPP<ParArch::CPU, Details>::exec(
+        details, read, sum, write);
+    if (std::fabs(output[0] - 18.f) > 1e-6f) {
+        std::printf("CPU fused grid reduction got=%f expected=18\n", output[0]);
+        return false;
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <int BLOCK_SIZE, typename ComputeIOp>
+bool runGpuVariant(const char* name, const int width, const float identity,
+                   const ComputeIOp& compute) {
+    constexpr int ROWS = 3;
+    const int allocationWidth = width > 0 ? width : 1;
+    Ptr2D<float> input(allocationWidth, ROWS);
+    Ptr1D<float> output(ROWS);
+    std::array<float, ROWS> expected{};
+
+    for (int row = 0; row < ROWS; ++row) {
+        expected[row] = identity;
+        for (int x = 0; x < allocationWidth; ++x) {
+            const float value = static_cast<float>(((x * 5 + row * 13) % 37) - 18);
+            input.at(Point{x, row, 0}) = value;
+            if (x < width) expected[row] = make_tuple(expected[row], value) | compute;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{ROWS, width, identity, 0};
+    executeReduce(details, read, compute, write, stream);
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU %s B=%d W=%d row=%d got=%f expected=%f\n",
+                        name, BLOCK_SIZE, width, row, got, expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testGpuVariants() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuVariant<32>("sum-empty", 0, 0.f, sum) &&
+           runGpuVariant<32>("sum", 33, 0.f, sum) &&
+           runGpuVariant<64>("max", 129,
+               -std::numeric_limits<float>::infinity(), max) &&
+           runGpuVariant<128>("sum", 257, 0.f, sum) &&
+           runGpuVariant<256>("min", 257,
+               std::numeric_limits<float>::infinity(), min);
+}
+
+bool testGpuRowReductionIOps() {
+    constexpr int ROWS = 4;
+    constexpr int WIDTH = 257;
+    constexpr int BLOCK_SIZE = 128;
+
+    Ptr2D<float> input(WIDTH, ROWS);
+    Ptr1D<float> output(ROWS);
+    std::array<float, ROWS> expected{};
+    for (int row = 0; row < ROWS; ++row) {
+        for (int x = 0; x < WIDTH; ++x) {
+            const float value = static_cast<float>(((x * 7 + row * 11) % 29) - 14);
+            input.at(Point{x, row, 0}) = value;
+            expected[row] += value;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{ROWS, WIDTH, 0.f, 0};
+    executeReduce(details, read, sum, write, stream);
+
+    output.download(stream);
+    stream.sync();
+    for (int row = 0; row < ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, expected[row]);
+            return false;
+        }
+    }
+
+    for (int row = 0; row < ROWS; ++row) {
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+    output.upload(stream);
+    const auto fusedRead = read.then(Add<float>::build(1.f));
+    const auto fusedWrite = Mul<float>::build(2.f).then(write);
+    executeReduce(details, fusedRead, sum, fusedWrite, stream);
+    output.download(stream);
+    stream.sync();
+    for (int row = 0; row < ROWS; ++row) {
+        const float fusedExpected = (expected[row] + WIDTH) * 2.f;
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - fusedExpected) > 1e-4f) {
+            std::printf("GPU fused reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, fusedExpected);
+            return false;
+        }
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuReductionIOps();
+    ok = testCpuGridTierAndFusion() && ok;
+#if defined(__NVCC__)
+    ok = testGpuVariants() && ok;
+    ok = testGpuRowReductionIOps() && ok;
+#endif
+    if (ok) std::printf("ReduceDPP CPU/GPU IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -26,6 +26,27 @@ using namespace fk;
 
 namespace {
 
+using CompileDetails = ReduceDPPDetails<float, 128>;
+static_assert(ReduceWarpDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceBlockDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceGridDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(ReduceWarpDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceBlockDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceGridDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+static_assert(std::is_trivially_copyable_v<CompileDetails>);
+
 template <typename ComputeIOp>
 bool runCpuCase(const ComputeIOp& compute,
                 const std::array<float, 3>& identity,
@@ -99,16 +120,92 @@ bool testCpuGridTierAndFusion() {
 
     using Details = ReduceDPPDetails<float, 32>;
     const Details details{1, 3, 0.f, 0};
-    ReduceGridDPP<ParArch::CPU, Details>::exec(
+    ReduceDPP<ParArch::CPU, Details>::exec(
         details, read, sum, write);
     if (std::fabs(output[0] - 18.f) > 1e-6f) {
-        std::printf("CPU fused grid reduction got=%f expected=18\n", output[0]);
+        std::printf("CPU fused row reduction got=%f expected=18\n", output[0]);
+        return false;
+    }
+
+    float gridAccumulator = 0.f;
+    for (const float value : input) {
+        ReduceGridDPP<ParArch::CPU, Details>::exec(
+            details, value, sum, nullptr, &gridAccumulator);
+    }
+    if (std::fabs(gridAccumulator - 6.f) > 1e-6f) {
+        std::printf("CPU grid partial reduction got=%f expected=6\n",
+                    gridAccumulator);
         return false;
     }
     return true;
 }
 
 #if defined(__NVCC__)
+template <int BLOCK_SIZE, typename ReadIOp, typename ComputeIOp>
+__global__ void gridReduceDPPTestKernel(
+        const __grid_constant__ ReduceDPPDetails<float, BLOCK_SIZE> details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        float* accumulator) {
+    __shared__ float warpScratch[BLOCK_SIZE / 32];
+    const int x = static_cast<int>(blockIdx.x) * BLOCK_SIZE +
+                  static_cast<int>(threadIdx.x);
+    float value = details.identity;
+    if (x < details.width) {
+        value = ReadIOp::Operation::exec(Point{x, 0, 0}, input);
+    }
+    ReduceGridDPP<ParArch::GPU_NVIDIA,
+                  ReduceDPPDetails<float, BLOCK_SIZE>>::exec(
+        details, value, compute, warpScratch, accumulator);
+}
+
+template <int BLOCK_SIZE, typename ComputeIOp, typename HostCombine>
+bool runGpuGridVariant(const char* name, const ComputeIOp& compute,
+                       const float identity, const HostCombine& hostCombine) {
+    constexpr int WIDTH = 4096 + 37;
+    Ptr1D<float> input(WIDTH);
+    Ptr1D<float> accumulator(1);
+    float expected = identity;
+    for (int x = 0; x < WIDTH; ++x) {
+        const float value = static_cast<float>(((x * 17) % 101) - 50) * 0.125f;
+        input.at(Point{x, 0, 0}) = value;
+        expected = hostCombine(expected, value);
+    }
+    accumulator.at(Point{0, 0, 0}) = identity;
+
+    Stream stream;
+    input.upload(stream);
+    accumulator.upload(stream);
+    const auto read = PerThreadRead<ND::_1D, float>::build(input);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{1, WIDTH, identity, 0};
+    constexpr int BLOCKS = (WIDTH + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    gridReduceDPPTestKernel<BLOCK_SIZE><<<BLOCKS, BLOCK_SIZE, 0,
+        stream.getCUDAStream()>>>(
+        details, read, compute, accumulator.ptr().data);
+    gpuErrchk(cudaGetLastError());
+    accumulator.download(stream);
+    stream.sync();
+
+    const float got = accumulator.at(Point{0, 0, 0});
+    const float tolerance = 1e-4f * std::fmax(1.f, std::fabs(expected));
+    if (std::fabs(got - expected) > tolerance) {
+        std::printf("GPU grid %s got=%f expected=%f blocks=%d\n",
+                    name, got, expected, BLOCKS);
+        return false;
+    }
+    return true;
+}
+
+bool testGpuGridReduction() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuGridVariant<128>("sum", sum, 0.f,
+               [](float a, float b) { return a + b; }) &&
+           runGpuGridVariant<128>("max", max,
+               -std::numeric_limits<float>::infinity(),
+               [](float a, float b) { return std::fmax(a, b); });
+}
+
 template <int BLOCK_SIZE, typename ComputeIOp>
 bool runGpuVariant(const char* name, const int width, const float identity,
                    const ComputeIOp& compute) {
@@ -154,6 +251,8 @@ bool testGpuVariants() {
     const auto min = Min<float, float, float, UnaryType>::build();
     const auto max = Max<float, float, float, UnaryType>::build();
     return runGpuVariant<32>("sum-empty", 0, 0.f, sum) &&
+           runGpuVariant<32>("sum-subwarp", 17, 0.f, sum) &&
+           runGpuVariant<32>("sum-warp", 32, 0.f, sum) &&
            runGpuVariant<32>("sum", 33, 0.f, sum) &&
            runGpuVariant<64>("max", 129,
                -std::numeric_limits<float>::infinity(), max) &&
@@ -228,6 +327,7 @@ int launch() {
     bool ok = testCpuReductionIOps();
     ok = testCpuGridTierAndFusion() && ok;
 #if defined(__NVCC__)
+    ok = testGpuGridReduction() && ok;
     ok = testGpuVariants() && ok;
     ok = testGpuRowReductionIOps() && ok;
 #endif


### PR DESCRIPTION
## Summary

Replaces `SoftmaxDPP`'s hand-rolled shared-memory reduction tree with the generic `fk::blockReduceSmem` primitive, driven by a new `MergeSoftmaxState` combine functor.

This is the **proof that the collective layer absorbs existing hand-tuned cooperative code without regression**.

> **Stacked on top of #270** (the collective reduce primitives). Until #270 merges, this PR's diff also contains #270's commit — review #270 first, or review only commit `35f0687` here. Once #270 lands I'll rebase so this shows only the softmax change.

## What changes

- Adds `blockReduceSmem<Combine, BLOCK_SIZE, T>` to `collective/reduce.h`: a pure shared-memory binary-tree all-reduce over an **arbitrary trivially-copyable T**. (`blockReduce` uses `__shfl_xor` and is scalar-only; `OnlineSoftmaxState` is a 2-float struct, so it needs the smem-tree variant.) Host stub for parity.
- `SoftmaxDPP` now does its row reduction as `blockReduceSmem<MergeSoftmaxState, BLOCK_SIZE>(st, states)` instead of an open-coded `for (stride...)` smem tree.
- `MergeSoftmaxState` is a host+device combine functor wrapping the existing `mergeSoftmaxStates`.

## No-regression evidence

The existing `utest_softmax` (5 cases incl. `|x|<=500` numerical-stability and a fused-prologue `ReadIOp.then(Mul(2)).then(Add(1))`) passes with **identical error class** (1e-8..1e-9) before and after. `MergeSoftmaxState` also verified on the g++ host pass.

## Why it matters

The softmax reduction was the canonical example of "cooperative bookkeeping FKL couldn't express". Now it's one line over a reusable primitive — and the same primitive will drive the tiled mainloop's accumulation.
