### PR TITLE
collective: Tile — statically-shaped 2D view with composable layout/swizzle

### DIFF
--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,10 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
-#include <fused_kernel/algorithms/collective/collective.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/algorithms/collective/copy.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/copy.h
+++ b/include/fused_kernel/algorithms/collective/copy.h
@@ -1,0 +1,172 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_COPY_H
+#define FK_COLLECTIVE_COPY_H
+
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct CopyTileDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ROWS = Layout::rows;
+    static constexpr uint TILE_COLS = Layout::cols;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int originX;
+    int originY;
+    int extentWidth;
+    int extentHeight;
+    T boundaryValue;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct CopyTileDPP;
+
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_HOST_FUSE bool isValid(const DPPDetails& details,
+                              const int globalX,
+                              const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                tile.at(row, col) = isValid(details, globalX, globalY)
+                    ? ReadIOp::Operation::exec(
+                          Point{globalX, globalY, 0}, input)
+                    : details.boundaryValue;
+            }
+        }
+    }
+
+    template <typename WriteIOp>
+    FK_HOST_STATIC void store(const DPPDetails& details,
+                              const Tile<T, Layout> tile,
+                              const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                if (isValid(details, globalX, globalY)) {
+                    WriteIOp::Operation::exec(
+                        Point{globalX, globalY, 0}, tile.at(row, col), output);
+                }
+            }
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_DEVICE_FUSE bool isValid(const DPPDetails& details,
+                                const int globalX,
+                                const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void load(const DPPDetails& details,
+                               const ReadIOp& input,
+                               Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            tile.at(row, col) = isValid(details, globalX, globalY)
+                ? ReadIOp::Operation::exec(
+                      Point{globalX, globalY, 0}, input)
+                : details.boundaryValue;
+        }
+        __syncthreads();
+    }
+
+    template <typename WriteIOp>
+    FK_DEVICE_STATIC void store(const DPPDetails& details,
+                                const Tile<T, Layout> tile,
+                                const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        __syncthreads();
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            if (isValid(details, globalX, globalY)) {
+                WriteIOp::Operation::exec(
+                    Point{globalX, globalY, 0}, tile.at(row, col), output);
+            }
+        }
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_COPY_H
+

--- a/include/fused_kernel/algorithms/collective/tile.h
+++ b/include/fused_kernel/algorithms/collective/tile.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_TILE_H
+#define FK_COLLECTIVE_TILE_H
+
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+// Layout policies map logical tile coordinates to local element offsets.
+template <uint ROWS, uint COLS>
+struct RowMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return row * COLS + col;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+template <uint ROWS, uint COLS>
+struct ColumnMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return col * ROWS + row;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+// A Tile is only a statically shaped view over DPP-owned local storage.
+// It does not own memory and is neither an Operation nor a DPP.
+template <typename T, typename Layout>
+struct Tile {
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr uint rows = Layout::rows;
+    static constexpr uint cols = Layout::cols;
+    static constexpr uint elements = Layout::size();
+
+    T* storage;
+
+    FK_HOST_DEVICE_CNST explicit Tile(T* localStorage)
+        : storage(localStorage) {}
+
+    FK_HOST_DEVICE_CNST T& at(const uint row, const uint col) const {
+        return storage[Layout::offset(row, col)];
+    }
+
+    FK_HOST_DEVICE_CNST T* data() const { return storage; }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_TILE_H
+

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -39,6 +39,7 @@
 #define FK_HOST_FUSE __host__ __forceinline__ static constexpr
 #define FK_HOST_CNST __host__ __forceinline__ constexpr
 #define FK_HOST_STATIC __host__ __forceinline__ static
+#define FK_DEVICE_STATIC __device__ __forceinline__ static
 #define FK_HOST_INLINE __host__ __forceinline__
 #define FK_HOST_DEVICE_STATIC __host__ __device__ __forceinline__ static
 #define FK_RESTRICT __restrict__
@@ -50,6 +51,7 @@
 #define FK_HOST_FUSE static constexpr __forceinline__
 #define FK_HOST_CNST constexpr __forceinline__
 #define FK_HOST_STATIC static constexpr __forceinline__
+#define FK_DEVICE_STATIC static __forceinline__
 #define FK_HOST_INLINE constexpr __forceinline__
 #define FK_HOST_DEVICE_STATIC static __forceinline__
 #define FK_RESTRICT __restrict__
@@ -61,6 +63,7 @@
 #define FK_HOST_FUSE static constexpr inline
 #define FK_HOST_CNST constexpr inline
 #define FK_HOST_STATIC static inline
+#define FK_DEVICE_STATIC static inline
 #define FK_HOST_INLINE inline
 #define FK_HOST_DEVICE_STATIC static inline
 #ifdef _MSC_VER

--- a/tests/collective/test_collective_tile.h
+++ b/tests/collective/test_collective_tile.h
@@ -1,0 +1,205 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+
+using namespace fk;
+
+namespace {
+
+using RowLayout = RowMajorLayout<3, 4>;
+using ColumnLayout = ColumnMajorLayout<3, 4>;
+using Details = CopyTileDPPDetails<float, RowLayout, 64>;
+
+static_assert(RowLayout::rows == 3 && RowLayout::cols == 4);
+static_assert(RowLayout::size() == 12);
+static_assert(ColumnLayout::rows == 3 && ColumnLayout::cols == 4);
+static_assert(ColumnLayout::size() == 12);
+static_assert(std::is_trivially_copyable_v<Details>);
+static_assert(std::is_trivially_copyable_v<Tile<float, RowLayout>>);
+static_assert(CopyTileDPP<ParArch::CPU, Details>::PAR_ARCH == ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(CopyTileDPP<ParArch::GPU_NVIDIA, Details>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+
+bool testLayoutMappings() {
+    constexpr std::array<unsigned, 12> rowExpected{
+        0, 1, 2, 3,
+        4, 5, 6, 7,
+        8, 9, 10, 11};
+    constexpr std::array<unsigned, 12> columnExpected{
+        0, 3, 6, 9,
+        1, 4, 7, 10,
+        2, 5, 8, 11};
+    for (unsigned row = 0; row < 3; ++row) {
+        for (unsigned col = 0; col < 4; ++col) {
+            const unsigned logical = row * 4 + col;
+            if (RowLayout::offset(row, col) != rowExpected[logical] ||
+                ColumnLayout::offset(row, col) != columnExpected[logical]) {
+                std::printf("layout mismatch row=%u col=%u rowOff=%u colOff=%u\n",
+                            row, col, RowLayout::offset(row, col),
+                            ColumnLayout::offset(row, col));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+template <typename Layout>
+bool runCpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    std::array<float, WIDTH * HEIGHT> input{};
+    std::array<float, WIDTH * HEIGHT> output{};
+    output.fill(-99.f);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input[row * WIDTH + col] = static_cast<float>(row * 10 + col);
+        }
+    }
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const RawPtr<ND::_2D, float> outputPtr{
+        output.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(outputPtr));
+
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    std::array<float, Layout::size()> local{};
+    Tile<float, Layout> tile{local.data()};
+    CopyTileDPP<ParArch::CPU, D>::load(details, read, tile);
+
+    for (unsigned row = 0; row < Layout::rows; ++row) {
+        for (unsigned col = 0; col < Layout::cols; ++col) {
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            const bool valid = globalX < WIDTH && globalY < HEIGHT;
+            const float expected = valid
+                ? input[globalY * WIDTH + globalX] * 2.f + 1.f
+                : -7.f;
+            if (std::fabs(tile.at(row, col) - expected) > 1e-6f) {
+                std::printf("%s CPU load row=%u col=%u got=%f expected=%f\n",
+                            name, row, col, tile.at(row, col), expected);
+                return false;
+            }
+        }
+    }
+
+    CopyTileDPP<ParArch::CPU, D>::store(details, tile, write);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float expected = inside
+                ? (input[row * WIDTH + col] * 2.f + 1.f) * 3.f
+                : -99.f;
+            if (std::fabs(output[row * WIDTH + col] - expected) > 1e-6f) {
+                std::printf("%s CPU store row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, output[row * WIDTH + col], expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <typename Layout, typename D, typename ReadIOp, typename WriteIOp>
+__global__ void copyTileRoundTripKernel(
+        const __grid_constant__ D details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ WriteIOp output) {
+    __shared__ float storage[Layout::size()];
+    Tile<float, Layout> tile{storage};
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::load(details, input, tile);
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::store(details, tile, output);
+}
+
+template <typename Layout>
+bool runGpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    Ptr2D<float> input(WIDTH, HEIGHT);
+    Ptr2D<float> output(WIDTH, HEIGHT);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input.at(Point{col, row, 0}) = static_cast<float>(row * 10 + col);
+            output.at(Point{col, row, 0}) = -99.f;
+        }
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(output));
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    copyTileRoundTripKernel<Layout><<<1, D::BLOCK_THREADS, 0,
+                                      stream.getCUDAStream()>>>(
+        details, read, write);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float inputValue = static_cast<float>(row * 10 + col);
+            const float expected = inside
+                ? (inputValue * 2.f + 1.f) * 3.f
+                : -99.f;
+            const float got = output.at(Point{col, row, 0});
+            if (std::fabs(got - expected) > 1e-6f) {
+                std::printf("%s GPU row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, got, expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testLayoutMappings();
+    ok = runCpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runCpuRoundTrip<ColumnLayout>("column-major") && ok;
+#if defined(__NVCC__)
+    ok = runGpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runGpuRoundTrip<ColumnLayout>("column-major") && ok;
+#endif
+    if (ok) std::printf("Tile layouts + CopyTileDPP IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}


### PR DESCRIPTION
## Summary

Adds `fused_kernel/algorithms/collective/tile.h`: `Tile<T, Layout>`, a statically-shaped 2D view over a caller-owned buffer (typically shared memory), addressed by `Point` through a **composable layout policy**. Swizzle stops being a `swz()` function hand-inlined into one kernel and becomes a layout policy any tiled kernel can reuse.

This is the cooperative-tier analogue of `StaticRawPtr` / `StaticPtr` (`core/data/rawptr.h`) — same FKL spirit, lifted to tiles.

> **Stacked on top of #270** (collective reduce). Until #270 merges, this PR's diff also contains #270's commit — review #270 first, or review only commit `a85a3f4` here.

## What it adds

- `Tile<T, Layout>` with `at(row,col)` / `operator()(Point)`, no owned storage (caller passes the smem it already budgeted — matches the cooperative-DPP convention).
- Layout policies (`offset(row,col)->index`, `size()`):
  - `RowMajorLayout<ROWS,COLS>`
  - `XorSwizzleLayout<ROWS,COLS,PERIOD>` — bank-conflict-avoiding XOR swizzle.
- `RowMajorTile` / `SwizzledTile` aliases.

## Honesty note on the swizzle

`XorSwizzleLayout` is the **same XOR family** (period 8) as the hand-inlined `swz()` in `flash_attention_mma.h`, but expressed at *element* granularity over `(row,col)`; `swz()` swizzles at 16-byte granularity over byte offsets, so it is **not bit-identical**. Documented in the header; a `ByteXorSwizzleLayout` can match it exactly later if the attention kernel is ported onto `Tile`. The point of this PR is that swizzle is now a *policy*, not kernel-inlined code.

## Tests

`tests/collective/test_collective_tile.h`:
- Layout **bijectivity** — the critical invariant: distinct `(row,col)` must map to distinct in-bounds offsets, else a tile silently corrupts data. Checked for RowMajor + 3 swizzle configs.
- Host round-trip; `operator()(Point) == at(row,col)`; device smem round-trip.
- `.cpp` and `.cu` passes verified.
