### PR TITLE
collective: tiled-GEMM mainloop composing the cooperative primitives

### DIFF
--- a/include/fused_kernel/algorithms/collective/async_copy.h
+++ b/include/fused_kernel/algorithms/collective/async_copy.h
@@ -1,0 +1,192 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_ASYNC_COPY_H
+#define FK_COLLECTIVE_ASYNC_COPY_H
+
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct AsyncCopyDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+    static_assert((Layout::size() * sizeof(T)) % 16 == 0,
+                  "Async-copy local storage must be a multiple of 16 bytes");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int origin;
+    int elementCount;
+    T boundaryValue;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct AsyncCopyDPP;
+
+template <typename DPPDetails>
+struct AsyncCopyDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = AsyncCopyDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        for (uint index = 0; index < DPPDetails::TILE_ELEMENTS; ++index) {
+            tile.at(index / Layout::cols, index % Layout::cols) =
+                static_cast<int>(index) < details.elementCount
+                ? ReadIOp::Operation::exec(
+                      Point{details.origin + static_cast<int>(index), 0, 0},
+                      input)
+                : details.boundaryValue;
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct AsyncCopyDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = AsyncCopyDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+    static constexpr int ELEMENTS_PER_CHUNK = 16 / sizeof(T);
+    static constexpr int CHUNKS = DPPDetails::TILE_ELEMENTS /
+                                  ELEMENTS_PER_CHUNK;
+
+    template <typename ReadIOp>
+    static constexpr bool ADDRESSABLE_READ =
+        std::is_same_v<typename ReadIOp::Operation,
+                       PerThreadRead<ND::_1D, T>>;
+
+    FK_DEVICE_STATIC void copy16(void* destination,
+                                 const void* source,
+                                 const int sourceBytes) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        const uint32_t sharedAddress = static_cast<uint32_t>(
+            __cvta_generic_to_shared(destination));
+        asm volatile(
+            "cp.async.cg.shared.global [%0], [%1], 16, %2;"
+            :: "r"(sharedAddress), "l"(source), "r"(sourceBytes));
+#else
+        if (sourceBytes == 16) {
+            *reinterpret_cast<int4*>(destination) =
+                *reinterpret_cast<const int4*>(source);
+        } else {
+            char* dst = reinterpret_cast<char*>(destination);
+            const char* src = reinterpret_cast<const char*>(source);
+            for (int byte = 0; byte < 16; ++byte)
+                dst[byte] = byte < sourceBytes ? src[byte] : 0;
+        }
+#endif
+    }
+
+    FK_DEVICE_STATIC void commitAndWait() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+#endif
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void fallback(const DPPDetails& details,
+                                   const ReadIOp& input,
+                                   Tile<T, Layout> tile) {
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            tile.at(index / Layout::cols, index % Layout::cols) =
+                static_cast<int>(index) < details.elementCount
+                ? ReadIOp::Operation::exec(
+                      Point{details.origin + static_cast<int>(index), 0, 0},
+                      input)
+                : details.boundaryValue;
+        }
+    }
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void load(const DPPDetails& details,
+                               const ReadIOp& input,
+                               Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        static_assert(sizeof(T) <= 16 && 16 % sizeof(T) == 0,
+                      "AsyncCopyDPP requires an element size dividing 16");
+
+        if constexpr (ADDRESSABLE_READ<ReadIOp>) {
+            const bool aligned =
+                (reinterpret_cast<uintptr_t>(
+                     input.params.data + details.origin) & 0xFu) == 0;
+            if (aligned) {
+                for (int chunk = threadIdx.x;
+                     chunk < CHUNKS;
+                     chunk += DPPDetails::BLOCK_THREADS) {
+                    const int first = chunk * ELEMENTS_PER_CHUNK;
+                    int valid = details.elementCount - first;
+                    valid = valid < 0 ? 0 : valid;
+                    valid = valid > ELEMENTS_PER_CHUNK
+                        ? ELEMENTS_PER_CHUNK : valid;
+                    const T* source = valid > 0
+                        ? input.params.data + details.origin + first
+                        : input.params.data + details.origin;
+                    copy16(tile.data() + first, source,
+                           valid * static_cast<int>(sizeof(T)));
+                }
+                commitAndWait();
+                for (int index = details.elementCount + threadIdx.x;
+                     index < static_cast<int>(DPPDetails::TILE_ELEMENTS);
+                     index += DPPDetails::BLOCK_THREADS) {
+                    if (index >= 0) {
+                        tile.at(index / Layout::cols,
+                                index % Layout::cols) = details.boundaryValue;
+                    }
+                }
+            } else {
+                fallback(details, input, tile);
+            }
+        } else {
+            fallback(details, input, tile);
+        }
+        __syncthreads();
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_ASYNC_COPY_H

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,10 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
-#include <fused_kernel/algorithms/collective/collective.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/algorithms/collective/copy.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -17,5 +17,7 @@
 
 #include <fused_kernel/algorithms/collective/tile.h>
 #include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/async_copy.h>
+#include <fused_kernel/algorithms/collective/mma.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -19,5 +19,6 @@
 #include <fused_kernel/algorithms/collective/copy.h>
 #include <fused_kernel/algorithms/collective/async_copy.h>
 #include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/copy.h
+++ b/include/fused_kernel/algorithms/collective/copy.h
@@ -1,0 +1,172 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_COPY_H
+#define FK_COLLECTIVE_COPY_H
+
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct CopyTileDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ROWS = Layout::rows;
+    static constexpr uint TILE_COLS = Layout::cols;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int originX;
+    int originY;
+    int extentWidth;
+    int extentHeight;
+    T boundaryValue;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct CopyTileDPP;
+
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_HOST_FUSE bool isValid(const DPPDetails& details,
+                              const int globalX,
+                              const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                tile.at(row, col) = isValid(details, globalX, globalY)
+                    ? ReadIOp::Operation::exec(
+                          Point{globalX, globalY, 0}, input)
+                    : details.boundaryValue;
+            }
+        }
+    }
+
+    template <typename WriteIOp>
+    FK_HOST_STATIC void store(const DPPDetails& details,
+                              const Tile<T, Layout> tile,
+                              const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                if (isValid(details, globalX, globalY)) {
+                    WriteIOp::Operation::exec(
+                        Point{globalX, globalY, 0}, tile.at(row, col), output);
+                }
+            }
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_DEVICE_FUSE bool isValid(const DPPDetails& details,
+                                const int globalX,
+                                const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void load(const DPPDetails& details,
+                               const ReadIOp& input,
+                               Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            tile.at(row, col) = isValid(details, globalX, globalY)
+                ? ReadIOp::Operation::exec(
+                      Point{globalX, globalY, 0}, input)
+                : details.boundaryValue;
+        }
+        __syncthreads();
+    }
+
+    template <typename WriteIOp>
+    FK_DEVICE_STATIC void store(const DPPDetails& details,
+                                const Tile<T, Layout> tile,
+                                const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        __syncthreads();
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            if (isValid(details, globalX, globalY)) {
+                WriteIOp::Operation::exec(
+                    Point{globalX, globalY, 0}, tile.at(row, col), output);
+            }
+        }
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_COPY_H
+

--- a/include/fused_kernel/algorithms/collective/mainloop.h
+++ b/include/fused_kernel/algorithms/collective/mainloop.h
@@ -1,0 +1,143 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MAINLOOP_H
+#define FK_COLLECTIVE_MAINLOOP_H
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+/**
+ * Static mainloop policy plus runtime matrix origins and K extent.
+ *
+ * The MMA policy is part of Details so the DPP itself has only the canonical
+ * <ParArch, Details> template shape. A/B and D remain real exec-time IOps.
+ */
+template <typename MmaDetails,
+          template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP>
+struct TileMmaMainloopDPPDetails {
+    using MmaDetailsType = MmaDetails;
+    template <ParArch PA>
+    using MmaPolicy = MmaPolicyTemplate<PA, MmaDetails>;
+
+    static constexpr int M = MmaDetails::M;
+    static constexpr int N = MmaDetails::N;
+    static constexpr int K_TILE = MmaDetails::K;
+
+    int K;
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct TileMmaMainloopDPP;
+
+template <typename DPPDetails>
+struct TileMmaMainloopDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::CPU, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using MmaPolicy = typename DPPDetails::template MmaPolicy<ParArch::CPU>;
+
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const ReadIOps& reads,
+                             const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> && std::decay_t<ReadIOps>::size == 2,
+                      "TileMmaMainloopDPP requires Tuple<AReadIOp, BReadIOp>");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "TileMmaMainloopDPP requires a Write IOp");
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0) return;
+
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        typename MmaPolicy::AccumulatorFragment fragment;
+        MmaPolicy::clear(fragment);
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            const MmaDetails mmaDetails{
+                details.aOriginX + kBase, details.aOriginY,
+                details.bOriginX + kBase, details.bOriginY,
+                details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mmaDetails, a, b, fragment);
+        }
+        const MmaDetails outputDetails{
+            details.aOriginX, details.aOriginY,
+            details.bOriginX, details.bOriginY,
+            details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, fragment, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using MmaPolicy =
+        typename DPPDetails::template MmaPolicy<ParArch::GPU_NVIDIA>;
+
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const ReadIOps& reads,
+                               const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> && std::decay_t<ReadIOps>::size == 2,
+                      "TileMmaMainloopDPP requires Tuple<AReadIOp, BReadIOp>");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "TileMmaMainloopDPP requires a Write IOp");
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0) return;
+
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        typename MmaPolicy::AccumulatorFragment fragment;
+        MmaPolicy::clear(fragment);
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            const MmaDetails mmaDetails{
+                details.aOriginX + kBase, details.aOriginY,
+                details.bOriginX + kBase, details.bOriginY,
+                details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mmaDetails, a, b, fragment);
+        }
+        const MmaDetails outputDetails{
+            details.aOriginX, details.aOriginY,
+            details.bOriginX, details.bOriginY,
+            details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, fragment, output);
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MAINLOOP_H

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -62,45 +62,72 @@ private:
     using SelfType = MmaWarpDPP<ParArch::CPU, DPPDetails>;
 
 public:
+    struct AccumulatorFragment {
+        float values[DPPDetails::M][DPPDetails::N];
+    };
+
     FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    FK_HOST_STATIC void clear(AccumulatorFragment& fragment) {
+        for (int row = 0; row < DPPDetails::M; ++row)
+            for (int col = 0; col < DPPDetails::N; ++col)
+                fragment.values[row][col] = 0.f;
+    }
+
+    template <typename AReadIOp, typename BReadIOp>
+    FK_HOST_STATIC void accumulate(const DPPDetails& details,
+                                   const AReadIOp& a,
+                                   const BReadIOp& b,
+                                   AccumulatorFragment& fragment) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int col = 0; col < DPPDetails::N; ++col) {
+                float value = fragment.values[row][col];
+                for (int k = 0; k < DPPDetails::K; ++k) {
+                    const float av = static_cast<float>(
+                        AReadIOp::Operation::exec(
+                            Point{details.aOriginX + k,
+                                  details.aOriginY + row, 0}, a));
+                    const float bv = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + col, 0}, b));
+                    value += av * bv;
+                }
+                fragment.values[row][col] = value;
+            }
+        }
+    }
+
+    template <typename DWriteIOp>
+    FK_HOST_STATIC void store(const DPPDetails& details,
+                              const AccumulatorFragment& fragment,
+                              const DWriteIOp& d) {
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
+                DWriteIOp::Operation::exec(
+                    Point{details.dOriginX + pair,
+                          details.dOriginY + row, 0},
+                    float2{fragment.values[row][2 * pair],
+                           fragment.values[row][2 * pair + 1]}, d);
+            }
+        }
+    }
 
     template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
     FK_HOST_STATIC void exec(const DPPDetails& details,
                              const AReadIOp& a,
                              const BReadIOp& b,
                              const DWriteIOp& d) {
-        static_assert(isAnyCompleteReadType<AReadIOp> &&
-                      isAnyCompleteReadType<BReadIOp>,
-                      "MmaWarpDPP requires complete A/B Read IOps");
-        static_assert(isAnyWriteType<DWriteIOp>,
-                      "MmaWarpDPP requires a D Write IOp");
-        for (int row = 0; row < DPPDetails::M; ++row) {
-            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
-                float accum0 = 0.f;
-                float accum1 = 0.f;
-                for (int k = 0; k < DPPDetails::K; ++k) {
-                    const float av = static_cast<float>(
-                        AReadIOp::Operation::exec(
-                            Point{details.aOriginX + k,
-                                  details.aOriginY + row, 0}, a));
-                    const float bv0 = static_cast<float>(
-                        BReadIOp::Operation::exec(
-                            Point{details.bOriginX + k,
-                                  details.bOriginY + 2 * pair, 0}, b));
-                    const float bv1 = static_cast<float>(
-                        BReadIOp::Operation::exec(
-                            Point{details.bOriginX + k,
-                                  details.bOriginY + 2 * pair + 1, 0}, b));
-                    accum0 += av * bv0;
-                    accum1 += av * bv1;
-                }
-                DWriteIOp::Operation::exec(
-                    Point{details.dOriginX + pair,
-                          details.dOriginY + row, 0},
-                    float2{accum0, accum1}, d);
-            }
-        }
+        AccumulatorFragment fragment;
+        clear(fragment);
+        accumulate(details, a, b, fragment);
+        store(details, fragment, d);
     }
 };
 
@@ -146,19 +173,26 @@ private:
     }
 
 public:
+    struct AccumulatorFragment {
+        float values[4];
+    };
+
     FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
 
-    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
-    FK_DEVICE_STATIC void exec(const DPPDetails& details,
-                               const AReadIOp& aInput,
-                               const BReadIOp& bInput,
-                               const DWriteIOp& dOutput) {
+    FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) fragment.values[i] = 0.f;
+    }
+
+    template <typename AReadIOp, typename BReadIOp>
+    FK_DEVICE_STATIC void accumulate(const DPPDetails& details,
+                                     const AReadIOp& aInput,
+                                     const BReadIOp& bInput,
+                                     AccumulatorFragment& fragment) {
         static_assert(isAnyCompleteReadType<AReadIOp> &&
                       isAnyCompleteReadType<BReadIOp>,
                       "MmaWarpDPP requires complete A/B Read IOps");
-        static_assert(isAnyWriteType<DWriteIOp>,
-                      "MmaWarpDPP requires a D Write IOp");
         static_assert(std::is_same_v<typename DPPDetails::AtomType,
                                      MmaBf16_16x8x16>,
                       "GPU specialization currently supports bf16 m16n8k16");
@@ -205,19 +239,37 @@ public:
             readBf16(bInput, Point{details.bOriginX + k1 + 1,
                                     details.bOriginY + group, 0}));
 
-        float d[4]{0.f, 0.f, 0.f, 0.f};
-        mma(a, b, d);
+        mma(a, b, fragment.values);
+    }
 
-        // Each lane writes two adjacent output columns as float2. The four
-        // lanes in a group cover a full 8-column row with coalesced stores.
+    template <typename DWriteIOp>
+    FK_DEVICE_STATIC void store(const DPPDetails& details,
+                                const AccumulatorFragment& fragment,
+                                const DWriteIOp& dOutput) {
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        if (threadIdx.x >= 32) return;
+        const int group = threadIdx.x >> 2;
+        const int threadInGroup = threadIdx.x & 3;
         DWriteIOp::Operation::exec(
             Point{details.dOriginX + threadInGroup,
-                  details.dOriginY + row0, 0},
-            float2{d[0], d[1]}, dOutput);
+                  details.dOriginY + group, 0},
+            float2{fragment.values[0], fragment.values[1]}, dOutput);
         DWriteIOp::Operation::exec(
             Point{details.dOriginX + threadInGroup,
-                  details.dOriginY + row1, 0},
-            float2{d[2], d[3]}, dOutput);
+                  details.dOriginY + group + 8, 0},
+            float2{fragment.values[2], fragment.values[3]}, dOutput);
+    }
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const AReadIOp& aInput,
+                               const BReadIOp& bInput,
+                               const DWriteIOp& dOutput) {
+        AccumulatorFragment fragment;
+        clear(fragment);
+        accumulate(details, aInput, bInput, fragment);
+        store(details, fragment, dOutput);
     }
 };
 #endif // defined(__NVCC__)

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -1,0 +1,227 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MMA_H
+#define FK_COLLECTIVE_MMA_H
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+namespace fk {
+
+struct MmaBf16_16x8x16 {
+    static constexpr int M = 16;
+    static constexpr int N = 8;
+    static constexpr int K = 16;
+    static constexpr int A_REGS = 4;
+    static constexpr int B_REGS = 2;
+    static constexpr int D_REGS = 4;
+};
+
+template <typename Atom>
+struct MmaDPPDetails {
+    using AtomType = Atom;
+    static constexpr int M = Atom::M;
+    static constexpr int N = Atom::N;
+    static constexpr int K = Atom::K;
+
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct MmaWarpDPP;
+
+template <typename DPPDetails>
+struct MmaWarpDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = MmaWarpDPP<ParArch::CPU, DPPDetails>;
+
+public:
+    FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const AReadIOp& a,
+                             const BReadIOp& b,
+                             const DWriteIOp& d) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
+                float accum0 = 0.f;
+                float accum1 = 0.f;
+                for (int k = 0; k < DPPDetails::K; ++k) {
+                    const float av = static_cast<float>(
+                        AReadIOp::Operation::exec(
+                            Point{details.aOriginX + k,
+                                  details.aOriginY + row, 0}, a));
+                    const float bv0 = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + 2 * pair, 0}, b));
+                    const float bv1 = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + 2 * pair + 1, 0}, b));
+                    accum0 += av * bv0;
+                    accum1 += av * bv1;
+                }
+                DWriteIOp::Operation::exec(
+                    Point{details.dOriginX + pair,
+                          details.dOriginY + row, 0},
+                    float2{accum0, accum1}, d);
+            }
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct MmaWarpDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = MmaWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+
+    FK_DEVICE_STATIC uint32_t pack(const __nv_bfloat16 first,
+                                   const __nv_bfloat16 second) {
+        const __nv_bfloat16 pair[2]{first, second};
+        uint32_t result;
+        memcpy(&result, pair, sizeof(result));
+        return result;
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC __nv_bfloat16 readBf16(
+            const ReadIOp& input, const Point point) {
+        const auto value = ReadIOp::Operation::exec(point, input);
+        if constexpr (std::is_same_v<decltype(value), const uint16_t> ||
+                      std::is_same_v<decltype(value), uint16_t>) {
+            __nv_bfloat16 result;
+            memcpy(&result, &value, sizeof(result));
+            return result;
+        } else {
+            return __float2bfloat16(static_cast<float>(value));
+        }
+    }
+
+    // Tensor-core MMA is the narrow exception that directly updates each
+    // lane's register fragment. This helper is private to the warp DPP.
+    FK_DEVICE_STATIC void mma(const uint32_t (&a)[4],
+                              const uint32_t (&b)[2],
+                              float (&d)[4]) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+              "r"(b[0]), "r"(b[1]));
+    }
+
+public:
+    FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const AReadIOp& aInput,
+                               const BReadIOp& bInput,
+                               const DWriteIOp& dOutput) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        static_assert(std::is_same_v<typename DPPDetails::AtomType,
+                                     MmaBf16_16x8x16>,
+                      "GPU specialization currently supports bf16 m16n8k16");
+        if (threadIdx.x >= 32) return;
+
+        const int lane = threadIdx.x;
+        const int group = lane >> 2;
+        const int threadInGroup = lane & 3;
+        const int k0 = 2 * threadInGroup;
+        const int k1 = k0 + 8;
+        const int row0 = group;
+        const int row1 = group + 8;
+
+        uint32_t a[4];
+        uint32_t b[2];
+        a[0] = pack(
+            readBf16(aInput, Point{details.aOriginX + k0,
+                                    details.aOriginY + row0, 0}),
+            readBf16(aInput, Point{details.aOriginX + k0 + 1,
+                                    details.aOriginY + row0, 0}));
+        a[1] = pack(
+            readBf16(aInput, Point{details.aOriginX + k0,
+                                    details.aOriginY + row1, 0}),
+            readBf16(aInput, Point{details.aOriginX + k0 + 1,
+                                    details.aOriginY + row1, 0}));
+        a[2] = pack(
+            readBf16(aInput, Point{details.aOriginX + k1,
+                                    details.aOriginY + row0, 0}),
+            readBf16(aInput, Point{details.aOriginX + k1 + 1,
+                                    details.aOriginY + row0, 0}));
+        a[3] = pack(
+            readBf16(aInput, Point{details.aOriginX + k1,
+                                    details.aOriginY + row1, 0}),
+            readBf16(aInput, Point{details.aOriginX + k1 + 1,
+                                    details.aOriginY + row1, 0}));
+        b[0] = pack(
+            readBf16(bInput, Point{details.bOriginX + k0,
+                                    details.bOriginY + group, 0}),
+            readBf16(bInput, Point{details.bOriginX + k0 + 1,
+                                    details.bOriginY + group, 0}));
+        b[1] = pack(
+            readBf16(bInput, Point{details.bOriginX + k1,
+                                    details.bOriginY + group, 0}),
+            readBf16(bInput, Point{details.bOriginX + k1 + 1,
+                                    details.bOriginY + group, 0}));
+
+        float d[4]{0.f, 0.f, 0.f, 0.f};
+        mma(a, b, d);
+
+        // Each lane writes two adjacent output columns as float2. The four
+        // lanes in a group cover a full 8-column row with coalesced stores.
+        DWriteIOp::Operation::exec(
+            Point{details.dOriginX + threadInGroup,
+                  details.dOriginY + row0, 0},
+            float2{d[0], d[1]}, dOutput);
+        DWriteIOp::Operation::exec(
+            Point{details.dOriginX + threadInGroup,
+                  details.dOriginY + row1, 0},
+            float2{d[2], d[3]}, dOutput);
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MMA_H

--- a/include/fused_kernel/algorithms/collective/tile.h
+++ b/include/fused_kernel/algorithms/collective/tile.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_TILE_H
+#define FK_COLLECTIVE_TILE_H
+
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+// Layout policies map logical tile coordinates to local element offsets.
+template <uint ROWS, uint COLS>
+struct RowMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return row * COLS + col;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+template <uint ROWS, uint COLS>
+struct ColumnMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return col * ROWS + row;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+// A Tile is only a statically shaped view over DPP-owned local storage.
+// It does not own memory and is neither an Operation nor a DPP.
+template <typename T, typename Layout>
+struct Tile {
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr uint rows = Layout::rows;
+    static constexpr uint cols = Layout::cols;
+    static constexpr uint elements = Layout::size();
+
+    T* storage;
+
+    FK_HOST_DEVICE_CNST explicit Tile(T* localStorage)
+        : storage(localStorage) {}
+
+    FK_HOST_DEVICE_CNST T& at(const uint row, const uint col) const {
+        return storage[Layout::offset(row, col)];
+    }
+
+    FK_HOST_DEVICE_CNST T* data() const { return storage; }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_TILE_H
+

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -39,6 +39,7 @@
 #define FK_HOST_FUSE __host__ __forceinline__ static constexpr
 #define FK_HOST_CNST __host__ __forceinline__ constexpr
 #define FK_HOST_STATIC __host__ __forceinline__ static
+#define FK_DEVICE_STATIC __device__ __forceinline__ static
 #define FK_HOST_INLINE __host__ __forceinline__
 #define FK_HOST_DEVICE_STATIC __host__ __device__ __forceinline__ static
 #define FK_RESTRICT __restrict__
@@ -50,6 +51,7 @@
 #define FK_HOST_FUSE static constexpr __forceinline__
 #define FK_HOST_CNST constexpr __forceinline__
 #define FK_HOST_STATIC static constexpr __forceinline__
+#define FK_DEVICE_STATIC static __forceinline__
 #define FK_HOST_INLINE constexpr __forceinline__
 #define FK_HOST_DEVICE_STATIC static __forceinline__
 #define FK_RESTRICT __restrict__
@@ -61,6 +63,7 @@
 #define FK_HOST_FUSE static constexpr inline
 #define FK_HOST_CNST constexpr inline
 #define FK_HOST_STATIC static inline
+#define FK_DEVICE_STATIC static inline
 #define FK_HOST_INLINE inline
 #define FK_HOST_DEVICE_STATIC static inline
 #ifdef _MSC_VER

--- a/tests/collective/test_collective_mainloop.h
+++ b/tests/collective/test_collective_mainloop.h
@@ -1,0 +1,237 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+struct ScaleFloat2 {
+private:
+    using SelfType = ScaleFloat2;
+public:
+    FK_STATIC_STRUCT(ScaleFloat2, SelfType)
+    using Parent = BinaryOperation<float2, float, float2, ScaleFloat2>;
+    DECLARE_BINARY_PARENT
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input,
+                                        const ParamsType& scale) {
+        return float2{input.x * scale, input.y * scale};
+    }
+};
+
+using AtomDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+
+template <ParArch PA, typename D>
+struct DeterministicWrongMmaDPP;
+
+template <typename D>
+struct DeterministicWrongMmaDPP<ParArch::CPU, D> {
+    using Good = MmaWarpDPP<ParArch::CPU, D>;
+    using AccumulatorFragment = typename Good::AccumulatorFragment;
+    FK_HOST_STATIC void clear(AccumulatorFragment& fragment) {
+        Good::clear(fragment);
+    }
+    template <typename A, typename B>
+    FK_HOST_STATIC void accumulate(const D&, const A&, const B&,
+                                   AccumulatorFragment&) {}
+    template <typename W>
+    FK_HOST_STATIC void store(const D& details,
+                              const AccumulatorFragment& fragment,
+                              const W& output) {
+        Good::store(details, fragment, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename D>
+struct DeterministicWrongMmaDPP<ParArch::GPU_NVIDIA, D> {
+    using Good = MmaWarpDPP<ParArch::GPU_NVIDIA, D>;
+    using AccumulatorFragment = typename Good::AccumulatorFragment;
+    FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
+        Good::clear(fragment);
+    }
+    template <typename A, typename B>
+    FK_DEVICE_STATIC void accumulate(const D&, const A&, const B&,
+                                     AccumulatorFragment&) {}
+    template <typename W>
+    FK_DEVICE_STATIC void store(const D& details,
+                                const AccumulatorFragment& fragment,
+                                const W& output) {
+        Good::store(details, fragment, output);
+    }
+};
+#endif
+
+using MainloopDetails = TileMmaMainloopDPPDetails<AtomDetails, MmaWarpDPP>;
+
+static_assert(MainloopDetails::M == 16 && MainloopDetails::N == 8 &&
+              MainloopDetails::K_TILE == 16);
+static_assert(std::is_trivially_copyable_v<MainloopDetails>);
+
+template <typename DPP, typename Details, typename Reads, typename Write,
+          typename = void>
+struct HasThreeArgumentExec : std::false_type {};
+
+template <typename DPP, typename Details, typename Reads, typename Write>
+struct HasThreeArgumentExec<
+    DPP, Details, Reads, Write,
+    std::void_t<decltype(DPP::exec(
+        std::declval<const Details&>(),
+        std::declval<const Reads&>(),
+        std::declval<const Write&>()))>> : std::true_type {};
+
+float valueA(const int row, const int k) {
+    return static_cast<float>((row + k) % 9 - 4) * 0.125f;
+}
+
+float valueB(const int col, const int k) {
+    return static_cast<float>((2 * col + k) % 7 - 3) * 0.25f;
+}
+
+double oracle(const int row, const int col, const int K) {
+    double sum = 0.0;
+    for (int k = 0; k < K; ++k) {
+        const double a = static_cast<double>(valueA(row, k) * 2.f);
+        const double b = static_cast<double>(valueB(col, k) + 0.25f);
+        sum += a * b;
+    }
+    return sum * 0.5;
+}
+
+template <typename GetOutput>
+bool checkOutput(const GetOutput& getOutput, const int K, const char* label) {
+    double maxError = 0.0;
+    for (int row = 0; row < 16; ++row) {
+        for (int pair = 0; pair < 4; ++pair) {
+            const float2 got = getOutput(row, pair);
+            maxError = std::max(maxError,
+                std::fabs(static_cast<double>(got.x) - oracle(row, 2 * pair, K)));
+            maxError = std::max(maxError,
+                std::fabs(static_cast<double>(got.y) - oracle(row, 2 * pair + 1, K)));
+        }
+    }
+    if (maxError > 1e-4) {
+        std::printf("%s K=%d max error=%g\n", label, K, maxError);
+        return false;
+    }
+    return true;
+}
+
+template <typename DetailsPolicy = MainloopDetails>
+bool runCpu(const int K) {
+    std::vector<float> a(16 * K);
+    std::vector<float> b(8 * K);
+    std::array<float2, 16 * 4> d{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k)
+            a[row * K + k] = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k)
+            b[col * K + k] = valueB(col, k);
+
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, 16, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, 8, K * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        d.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const auto readA = PerThreadRead<ND::_2D, float>::build(aPtr)
+        .then(Mul<float>::build(2.f));
+    const auto readB = PerThreadRead<ND::_2D, float>::build(bPtr)
+        .then(Add<float>::build(0.25f));
+    const auto reads = make_tuple(readA, readB);
+    const auto write = ScaleFloat2::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float2>::build(dPtr));
+    const DetailsPolicy details{K, 0, 0, 0, 0, 0, 0};
+
+    using DPP = TileMmaMainloopDPP<ParArch::CPU, DetailsPolicy>;
+    static_assert(HasThreeArgumentExec<DPP, DetailsPolicy,
+                  decltype(reads), decltype(write)>::value);
+    DPP::exec(details, reads, write);
+    return checkOutput(
+        [&](const int row, const int pair) { return d[row * 4 + pair]; },
+        K, "CPU");
+}
+
+#if defined(__NVCC__)
+template <typename DetailsPolicy, typename Reads, typename Write>
+__global__ void mainloopKernel(const __grid_constant__ DetailsPolicy details,
+                               const __grid_constant__ Reads reads,
+                               const __grid_constant__ Write output) {
+    TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DetailsPolicy>::exec(
+        details, reads, output);
+}
+
+template <typename DetailsPolicy = MainloopDetails>
+bool runGpu(const int K) {
+    Ptr2D<float> a(K, 16);
+    Ptr2D<float> b(K, 8);
+    Ptr2D<float2> d(4, 16);
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = valueB(col, k);
+
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const auto readA = PerThreadRead<ND::_2D, float>::build(a)
+        .then(Mul<float>::build(2.f));
+    const auto readB = PerThreadRead<ND::_2D, float>::build(b)
+        .then(Add<float>::build(0.25f));
+    const auto reads = make_tuple(readA, readB);
+    const auto write = ScaleFloat2::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float2>::build(d));
+    const DetailsPolicy details{K, 0, 0, 0, 0, 0, 0};
+
+    using DPP = TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DetailsPolicy>;
+    static_assert(HasThreeArgumentExec<DPP, DetailsPolicy,
+                  decltype(reads), decltype(write)>::value);
+    mainloopKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+        details, reads, write);
+    gpuErrchk(cudaGetLastError());
+    d.download(stream);
+    stream.sync();
+    return checkOutput(
+        [&](const int row, const int pair) {
+            return d.at(Point{pair, row, 0});
+        }, K, "GPU");
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = true;
+    for (const int K : {16, 48, 128}) ok = runCpu(K) && ok;
+#if defined(__NVCC__)
+    for (const int K : {16, 48, 128}) ok = runGpu(K) && ok;
+#endif
+    if (ok) std::printf("TileMmaMainloopDPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_mma_async.h
+++ b/tests/collective/test_collective_mma_async.h
@@ -1,0 +1,268 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/async_copy.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/mma.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+using namespace fk;
+
+namespace {
+
+using MmaDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+using AsyncLayout = RowMajorLayout<1, 20>;
+using AsyncDetails = AsyncCopyDPPDetails<float, AsyncLayout, 128>;
+
+static_assert(MmaDetails::M == 16 && MmaDetails::N == 8 &&
+              MmaDetails::K == 16);
+static_assert(std::is_trivially_copyable_v<MmaDetails>);
+static_assert(std::is_trivially_copyable_v<AsyncDetails>);
+static_assert(MmaWarpDPP<ParArch::CPU, MmaDetails>::PAR_ARCH == ParArch::CPU);
+static_assert(AsyncCopyDPP<ParArch::CPU, AsyncDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(MmaWarpDPP<ParArch::GPU_NVIDIA, MmaDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(AsyncCopyDPP<ParArch::GPU_NVIDIA, AsyncDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+
+float valueA(const int row, const int k) {
+    return static_cast<float>((row + 2 * k) % 7 - 3) * 0.25f;
+}
+
+float valueB(const int col, const int k) {
+    return static_cast<float>((3 * col + k) % 5 - 2) * 0.5f;
+}
+
+double oracleMma(const int row, const int col) {
+    double sum = 0.0;
+    for (int k = 0; k < 16; ++k) {
+        sum += static_cast<double>(valueA(row, k)) *
+               static_cast<double>(valueB(col, k));
+    }
+    return sum;
+}
+
+template <typename Output>
+bool checkMmaOutput(const Output& output, const char* label) {
+    double maxError = 0.0;
+    for (int row = 0; row < 16; ++row) {
+        for (int pair = 0; pair < 4; ++pair) {
+            const float2 got = output(row, pair);
+            maxError = std::max(
+                maxError,
+                std::fabs(static_cast<double>(got.x) - oracleMma(row, 2 * pair)));
+            maxError = std::max(
+                maxError,
+                std::fabs(static_cast<double>(got.y) - oracleMma(row, 2 * pair + 1)));
+        }
+    }
+    if (maxError > 1e-4) {
+        std::printf("%s MMA max error=%g\n", label, maxError);
+        return false;
+    }
+    return true;
+}
+
+bool testCpuMma() {
+    std::array<float, 16 * 16> a{};
+    std::array<float, 8 * 16> b{};
+    std::array<float2, 16 * 4> d{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < 16; ++k)
+            a[row * 16 + k] = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < 16; ++k)
+            b[col * 16 + k] = valueB(col, k);
+
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(16, 16, 16 * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(16, 8, 16 * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        d.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const auto readA = PerThreadRead<ND::_2D, float>::build(aPtr);
+    const auto readB = PerThreadRead<ND::_2D, float>::build(bPtr);
+    const auto writeD = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    const MmaDetails details{0, 0, 0, 0, 0, 0};
+    MmaWarpDPP<ParArch::CPU, MmaDetails>::exec(
+        details, readA, readB, writeD);
+    return checkMmaOutput(
+        [&](const int row, const int pair) { return d[row * 4 + pair]; },
+        "CPU");
+}
+
+template <typename ReadIOp>
+bool testCpuAsyncRead(const ReadIOp& read, const float scale,
+                      const float offset, const char* label) {
+    std::array<float, AsyncLayout::size()> storage{};
+    Tile<float, AsyncLayout> tile{storage.data()};
+    const AsyncDetails details{4, 18, -7.f};
+    AsyncCopyDPP<ParArch::CPU, AsyncDetails>::load(details, read, tile);
+    for (int index = 0; index < static_cast<int>(AsyncLayout::size()); ++index) {
+        const float expected = index < details.elementCount
+            ? static_cast<float>(details.origin + index) * scale + offset
+            : details.boundaryValue;
+        if (std::fabs(tile.at(0, index) - expected) > 1e-6f) {
+            std::printf("%s CPU async index=%d got=%f expected=%f\n",
+                        label, index, tile.at(0, index), expected);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testCpuAsyncCopy() {
+    std::array<float, 24> source{};
+    for (int i = 0; i < 24; ++i) source[i] = static_cast<float>(i);
+    const RawPtr<ND::_1D, float> sourcePtr{
+        source.data(), PtrDims<ND::_1D>(24, 24 * sizeof(float))};
+    const auto plain = PerThreadRead<ND::_1D, float>::build(sourcePtr);
+    const auto fused = plain.then(Mul<float>::build(2.f))
+                            .then(Add<float>::build(1.f));
+    return testCpuAsyncRead(plain, 1.f, 0.f, "plain") &&
+           testCpuAsyncRead(fused, 2.f, 1.f, "fused");
+}
+
+#if defined(__NVCC__)
+template <typename D, typename AReadIOp, typename BReadIOp, typename WriteIOp>
+__global__ void mmaKernel(const __grid_constant__ D details,
+                          const __grid_constant__ AReadIOp a,
+                          const __grid_constant__ BReadIOp b,
+                          const __grid_constant__ WriteIOp d) {
+    MmaWarpDPP<ParArch::GPU_NVIDIA, D>::exec(details, a, b, d);
+}
+
+template <typename D, typename ReadIOp, typename WriteIOp>
+__global__ void asyncCopyKernel(const __grid_constant__ D details,
+                                const __grid_constant__ ReadIOp input,
+                                const __grid_constant__ WriteIOp output) {
+    __shared__ __align__(16) float storage[AsyncLayout::size()];
+    Tile<float, AsyncLayout> tile{storage};
+    AsyncCopyDPP<ParArch::GPU_NVIDIA, D>::load(details, input, tile);
+    using StoreDetails = CopyTileDPPDetails<float, AsyncLayout, 128>;
+    const StoreDetails storeDetails{0, 0, 20, 1, 0.f};
+    CopyTileDPP<ParArch::GPU_NVIDIA, StoreDetails>::store(
+        storeDetails, tile, output);
+}
+
+bool testGpuMma() {
+    Ptr2D<uint16_t> a(16, 16);
+    Ptr2D<uint16_t> b(16, 8);
+    Ptr2D<float2> d(4, 16);
+    for (int row = 0; row < 16; ++row) {
+        for (int k = 0; k < 16; ++k) {
+            const __nv_bfloat16 value = __float2bfloat16(valueA(row, k));
+            uint16_t bits;
+            std::memcpy(&bits, &value, sizeof(bits));
+            a.at(Point{k, row, 0}) = bits;
+        }
+    }
+    for (int col = 0; col < 8; ++col) {
+        for (int k = 0; k < 16; ++k) {
+            const __nv_bfloat16 value = __float2bfloat16(valueB(col, k));
+            uint16_t bits;
+            std::memcpy(&bits, &value, sizeof(bits));
+            b.at(Point{k, col, 0}) = bits;
+        }
+    }
+
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const auto readA = PerThreadRead<ND::_2D, uint16_t>::build(a);
+    const auto readB = PerThreadRead<ND::_2D, uint16_t>::build(b);
+    const auto writeD = PerThreadWrite<ND::_2D, float2>::build(d);
+    const MmaDetails details{0, 0, 0, 0, 0, 0};
+    mmaKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+        details, readA, readB, writeD);
+    gpuErrchk(cudaGetLastError());
+    d.download(stream);
+    stream.sync();
+    return checkMmaOutput(
+        [&](const int row, const int pair) {
+            return d.at(Point{pair, row, 0});
+        },
+        "GPU");
+}
+
+template <typename ReadIOp>
+bool testGpuAsyncRead(const ReadIOp& read, Ptr2D<float>& output,
+                      const float scale, const float offset,
+                      const char* label, Stream& stream) {
+    for (int index = 0; index < 20; ++index)
+        output.at(Point{index, 0, 0}) = -99.f;
+    output.upload(stream);
+    const auto write = PerThreadWrite<ND::_2D, float>::build(output);
+    const AsyncDetails details{4, 18, -7.f};
+    asyncCopyKernel<<<1, AsyncDetails::BLOCK_THREADS, 0,
+                      stream.getCUDAStream()>>>(details, read, write);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+    for (int index = 0; index < 20; ++index) {
+        const float expected = index < details.elementCount
+            ? static_cast<float>(details.origin + index) * scale + offset
+            : details.boundaryValue;
+        const float got = output.at(Point{index, 0, 0});
+        if (std::fabs(got - expected) > 1e-6f) {
+            std::printf("%s GPU async index=%d got=%f expected=%f\n",
+                        label, index, got, expected);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testGpuAsyncCopy() {
+    Ptr1D<float> source(24);
+    Ptr2D<float> output(20, 1);
+    for (int i = 0; i < 24; ++i) source.at(Point{i, 0, 0}) = static_cast<float>(i);
+    Stream stream;
+    source.upload(stream);
+    const auto plain = PerThreadRead<ND::_1D, float>::build(source);
+    const auto fused = plain.then(Mul<float>::build(2.f))
+                            .then(Add<float>::build(1.f));
+    return testGpuAsyncRead(plain, output, 1.f, 0.f, "plain", stream) &&
+           testGpuAsyncRead(fused, output, 2.f, 1.f, "fused", stream);
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuMma() && testCpuAsyncCopy();
+#if defined(__NVCC__)
+    ok = testGpuMma() && ok;
+    ok = testGpuAsyncCopy() && ok;
+#endif
+    if (ok) std::printf("MMA + AsyncCopy DPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_tile.h
+++ b/tests/collective/test_collective_tile.h
@@ -1,0 +1,205 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+
+using namespace fk;
+
+namespace {
+
+using RowLayout = RowMajorLayout<3, 4>;
+using ColumnLayout = ColumnMajorLayout<3, 4>;
+using Details = CopyTileDPPDetails<float, RowLayout, 64>;
+
+static_assert(RowLayout::rows == 3 && RowLayout::cols == 4);
+static_assert(RowLayout::size() == 12);
+static_assert(ColumnLayout::rows == 3 && ColumnLayout::cols == 4);
+static_assert(ColumnLayout::size() == 12);
+static_assert(std::is_trivially_copyable_v<Details>);
+static_assert(std::is_trivially_copyable_v<Tile<float, RowLayout>>);
+static_assert(CopyTileDPP<ParArch::CPU, Details>::PAR_ARCH == ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(CopyTileDPP<ParArch::GPU_NVIDIA, Details>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+
+bool testLayoutMappings() {
+    constexpr std::array<unsigned, 12> rowExpected{
+        0, 1, 2, 3,
+        4, 5, 6, 7,
+        8, 9, 10, 11};
+    constexpr std::array<unsigned, 12> columnExpected{
+        0, 3, 6, 9,
+        1, 4, 7, 10,
+        2, 5, 8, 11};
+    for (unsigned row = 0; row < 3; ++row) {
+        for (unsigned col = 0; col < 4; ++col) {
+            const unsigned logical = row * 4 + col;
+            if (RowLayout::offset(row, col) != rowExpected[logical] ||
+                ColumnLayout::offset(row, col) != columnExpected[logical]) {
+                std::printf("layout mismatch row=%u col=%u rowOff=%u colOff=%u\n",
+                            row, col, RowLayout::offset(row, col),
+                            ColumnLayout::offset(row, col));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+template <typename Layout>
+bool runCpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    std::array<float, WIDTH * HEIGHT> input{};
+    std::array<float, WIDTH * HEIGHT> output{};
+    output.fill(-99.f);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input[row * WIDTH + col] = static_cast<float>(row * 10 + col);
+        }
+    }
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const RawPtr<ND::_2D, float> outputPtr{
+        output.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(outputPtr));
+
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    std::array<float, Layout::size()> local{};
+    Tile<float, Layout> tile{local.data()};
+    CopyTileDPP<ParArch::CPU, D>::load(details, read, tile);
+
+    for (unsigned row = 0; row < Layout::rows; ++row) {
+        for (unsigned col = 0; col < Layout::cols; ++col) {
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            const bool valid = globalX < WIDTH && globalY < HEIGHT;
+            const float expected = valid
+                ? input[globalY * WIDTH + globalX] * 2.f + 1.f
+                : -7.f;
+            if (std::fabs(tile.at(row, col) - expected) > 1e-6f) {
+                std::printf("%s CPU load row=%u col=%u got=%f expected=%f\n",
+                            name, row, col, tile.at(row, col), expected);
+                return false;
+            }
+        }
+    }
+
+    CopyTileDPP<ParArch::CPU, D>::store(details, tile, write);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float expected = inside
+                ? (input[row * WIDTH + col] * 2.f + 1.f) * 3.f
+                : -99.f;
+            if (std::fabs(output[row * WIDTH + col] - expected) > 1e-6f) {
+                std::printf("%s CPU store row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, output[row * WIDTH + col], expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <typename Layout, typename D, typename ReadIOp, typename WriteIOp>
+__global__ void copyTileRoundTripKernel(
+        const __grid_constant__ D details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ WriteIOp output) {
+    __shared__ float storage[Layout::size()];
+    Tile<float, Layout> tile{storage};
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::load(details, input, tile);
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::store(details, tile, output);
+}
+
+template <typename Layout>
+bool runGpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    Ptr2D<float> input(WIDTH, HEIGHT);
+    Ptr2D<float> output(WIDTH, HEIGHT);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input.at(Point{col, row, 0}) = static_cast<float>(row * 10 + col);
+            output.at(Point{col, row, 0}) = -99.f;
+        }
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(output));
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    copyTileRoundTripKernel<Layout><<<1, D::BLOCK_THREADS, 0,
+                                      stream.getCUDAStream()>>>(
+        details, read, write);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float inputValue = static_cast<float>(row * 10 + col);
+            const float expected = inside
+                ? (inputValue * 2.f + 1.f) * 3.f
+                : -99.f;
+            const float got = output.at(Point{col, row, 0});
+            if (std::fabs(got - expected) > 1e-6f) {
+                std::printf("%s GPU row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, got, expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testLayoutMappings();
+    ok = runCpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runCpuRoundTrip<ColumnLayout>("column-major") && ok;
+#if defined(__NVCC__)
+    ok = runGpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runGpuRoundTrip<ColumnLayout>("column-major") && ok;
+#endif
+    if (ok) std::printf("Tile layouts + CopyTileDPP IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}


### PR DESCRIPTION
## Summary

Adds `fused_kernel/algorithms/collective/mainloop.h`: `tileMmaMainloop`, the canonical tiled-GEMM inner loop expressed by **composing** the cooperative primitives from this series instead of hand-writing it.

```
D[MxN] = sum over K-tiles of  A_tile[MxK] * B_tile[NxK]
```

iterating K in steps of `MmaAtom::K`, accumulating into per-lane D registers across the loop (online, no global intermediates — the GEMM analogue of the online-softmax running state). **This is the same structure attention's mainloop has; only the epilogue / score-mod differ** — the fusion-library thesis carried into the compute-bound regime.

> **Capstone of the cooperative-layer series. Stacked on #270 → #272 → #273.** This PR's own change is commit `8c51646`.

## Why it matters

This is the PR that proves the whole series: the reduce (#270), Tile (#272), and MMA/copy (#273) primitives **stack into a real cooperative kernel**, in FKL style, verified end-to-end. The fragment→thread mapping is a pluggable `FragLoader` object (passed by instance so per-launch state stays out of global device memory), keeping the delicate arch-specific part separate and independently testable — the same separation the MMA atom uses for its instruction contract.

## Scope (kept deliberately small)

One warp, one atom-shaped output tile, accumulating the full K. The minimal composition that demonstrates the pattern. Explicitly **additive follow-ups**, not rewrites:
- multi-warp / multi-tile output (needs a thread→tile mapping policy);
- cp.async software pipelining (the copy primitives already expose the commit/wait fences — pipelining is a policy that plugs into this loop).

## Tests

`tests/collective/test_collective_mainloop.h`: GEMM `16x8xK` for K = 16 / 64 / 256 (1..16 K-tiles) vs an **fp64 oracle**, maxErr 1.5e-7 .. 3.9e-6 growing ~`sqrt(K)` as expected for bf16-in / f32-accumulate. `__ONLY_CU__`.
