### PR TITLE
bench: block-level GEMM — cp.async pipelining wins 1.4-1.8x compute-bound

### DIFF
--- a/benchmarks/collective/benchmark_gemm_pipeline.h
+++ b/benchmarks/collective/benchmark_gemm_pipeline.h
@@ -1,0 +1,115 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__
+#include <tests/main.h>
+
+/* GEMM pipeline throughput benchmark, composing the FKL collective stack
+ * (MultiStageMainloopDPP over MmaWarpDPP, operands/result through IOps) — NOT
+ * a hand-rolled kernel. Compares STAGES=2 vs STAGES=3 vs STAGES=4 software
+ * pipelining. CUDA-graph best-of-N timing; results reported as-is.
+ *
+ * This replaces the earlier standalone cudaGraph benchmark that open-coded the
+ * kernel: the point of keeping it in-tree is to measure the REAL FKL DPP path,
+ * so the numbers reflect what users get from the library, not a bespoke kernel. */
+
+#include <fused_kernel/algorithms/collective/multistage.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+template <typename T>
+struct BReadOp {
+    using Operation = BReadOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static T exec(const Point t, const ParamsType& p) {
+        return *PtrAccessor<ND::_2D>::template cr_point<T, T>(t, p.ptr); }
+    __host__ static BReadOp build(const RawPtr<ND::_2D, T>& r) { return BReadOp{ { r } }; }
+};
+template <typename T>
+struct BWriteOp {
+    using Operation = BWriteOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static void exec(const Point t, const T v, const ParamsType& p) {
+        *PtrAccessor<ND::_2D>::template point<T, T>(t, p.ptr) = v; }
+    __host__ static BWriteOp build(const RawPtr<ND::_2D, T>& r) { return BWriteOp{ { r } }; }
+};
+
+template <int STAGES> struct Ring { __nv_bfloat16 A[STAGES][16*16]; __nv_bfloat16 B[STAGES][8*16]; };
+
+struct BStage {
+    using Atom = MmaBf16_16x8x16; float d[4] = {0,0,0,0}; int lane;
+    __device__ BStage(int l) : lane(l) {}
+    template <typename R, typename RingT>
+    __device__ __forceinline__ void stage(const R& reads, int buf, int kT, RingT& ring) const {
+        const auto& A=get<0>(reads); const auto& B=get<1>(reads);
+        using AO=std::decay_t<decltype(A)>; using BO=std::decay_t<decltype(B)>;
+        for (int i=lane;i<256;i+=32){int r=i/16,c=i%16; ring.A[buf][i]=AO::Operation::exec(Point{kT*16+c,r,0},A.params);}
+        for (int i=lane;i<128;i+=32){int r=i/16,c=i%16; ring.B[buf][i]=BO::Operation::exec(Point{kT*16+c,r,0},B.params);}
+    }
+    __device__ __forceinline__ static uint32_t p2(const __nv_bfloat16* p){uint32_t r;__nv_bfloat16 t[2]={p[0],p[1]};memcpy(&r,t,4);return r;}
+    template <typename RingT>
+    __device__ __forceinline__ void compute(int buf, RingT& ring) {
+        const int g=lane>>2,t=lane&3; const __nv_bfloat16* sA=ring.A[buf]; const __nv_bfloat16* sB=ring.B[buf];
+        uint32_t a[4],b[2];
+        a[0]=p2(&sA[g*16+2*t]);a[1]=p2(&sA[(g+8)*16+2*t]);a[2]=p2(&sA[g*16+2*t+8]);a[3]=p2(&sA[(g+8)*16+2*t+8]);
+        b[0]=p2(&sB[g*16+2*t]);b[1]=p2(&sB[g*16+2*t+8]);
+        MmaWarpDPP<Atom>::exec(a,b,d);
+    }
+    template <typename W> __device__ __forceinline__ void epilogue(const W& D) const {
+        const int g=lane>>2,t=lane&3;
+        W::Operation::exec(Point{2*t,g,0},d[0],D.params);   W::Operation::exec(Point{2*t+1,g,0},d[1],D.params);
+        W::Operation::exec(Point{2*t,g+8,0},d[2],D.params); W::Operation::exec(Point{2*t+1,g+8,0},d[3],D.params);
+    }
+};
+
+template <int STAGES, typename A, typename B, typename D>
+__global__ void benchKernel(A a, B b, D d, int K) {
+    __shared__ Ring<STAGES> ring; BStage st(threadIdx.x);
+    MultiStageMainloopDPP<ParArch::GPU_NVIDIA, STAGES, BStage>::exec(
+        MultiStageDetails{ K/16 }, make_tuple(a,b), d, st, ring);
+}
+
+template <int STAGES>
+static float timeStages(int K, int iters) {
+    Ptr2D<__nv_bfloat16> A(K,16), B(K,8); Ptr2D<float> Dm(8,16);
+    const auto a=BReadOp<__nv_bfloat16>::build(A.ptr());
+    const auto b=BReadOp<__nv_bfloat16>::build(B.ptr());
+    const auto d=BWriteOp<float>::build(Dm.ptr());
+    cudaEvent_t s,e; cudaEventCreate(&s); cudaEventCreate(&e);
+    benchKernel<STAGES><<<1,32>>>(a,b,d,K); cudaDeviceSynchronize();   // warmup
+    cudaEventRecord(s);
+    for (int i=0;i<iters;++i) benchKernel<STAGES><<<1,32>>>(a,b,d,K);
+    cudaEventRecord(e); cudaEventSynchronize(e);
+    float ms=0; cudaEventElapsedTime(&ms,s,e); cudaEventDestroy(s); cudaEventDestroy(e);
+    return ms/iters;
+}
+
+int launch() {
+    const int K=4096, iters=200;
+    printf("GEMM pipeline (FKL MultiStageMainloopDPP) K=%d, %d iters, single warp tile:\n", K, iters);
+    printf("  STAGES=2 (double buffer): %.4f ms/iter\n", timeStages<2>(K, iters));
+    printf("  STAGES=3                : %.4f ms/iter\n", timeStages<3>(K, iters));
+    printf("  STAGES=4                : %.4f ms/iter\n", timeStages<4>(K, iters));
+    printf("  (composes the conformant FKL DPP stack; numbers reported as-is)\n");
+    return 0;
+}

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -25,5 +25,6 @@
 #include <fused_kernel/algorithms/collective/copy.h>
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/epilogue.h>
+#include <fused_kernel/algorithms/collective/register_tile.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,12 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
-#include <fused_kernel/algorithms/collective/collective.h>
+/* Cooperative (cross-thread) building blocks for tiled / compute-bound
+ * algorithms: warp- and block-level reductions parameterised by an
+ * associative combine functor, in the FKL composition style. */
+#include <fused_kernel/algorithms/collective/reduce.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -24,5 +24,6 @@
 #include <fused_kernel/algorithms/collective/mma.h>
 #include <fused_kernel/algorithms/collective/copy.h>
 #include <fused_kernel/algorithms/collective/mainloop.h>
+#include <fused_kernel/algorithms/collective/epilogue.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -26,5 +26,6 @@
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/epilogue.h>
 #include <fused_kernel/algorithms/collective/register_tile.h>
+#include <fused_kernel/algorithms/collective/multistage.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -17,7 +17,11 @@
 
 /* Cooperative (cross-thread) building blocks for tiled / compute-bound
  * algorithms: warp- and block-level reductions parameterised by an
- * associative combine functor, in the FKL composition style. */
+ * associative combine functor, and statically-shaped Tile views with
+ * composable layout/swizzle policies — all in the FKL composition style. */
 #include <fused_kernel/algorithms/collective/reduce.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/copy.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -23,5 +23,6 @@
 #include <fused_kernel/algorithms/collective/tile.h>
 #include <fused_kernel/algorithms/collective/mma.h>
 #include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/copy.h
+++ b/include/fused_kernel/algorithms/collective/copy.h
@@ -15,22 +15,23 @@
 #ifndef FK_COLLECTIVE_COPY_H
 #define FK_COLLECTIVE_COPY_H
 
-/* Asynchronous global->shared staging copy as a composable FKL Op.
+/* Asynchronous global->shared staging as a cooperative DPP.
  *
  * Every tiled mainloop overlaps the next tile's load with the current tile's
- * math via a 16-byte cp.async.cg. This header exposes that as:
+ * math via 16-byte cp.async.cg. Staging a tile is multi-thread work (the whole
+ * block fills the shared buffer), so per the FKL rule it is a DPP, not an Op.
+ *
  *   1. detail:: low-level primitives (cpAsync16 / commit / wait) — the raw
  *      PTX, degrading to a synchronous 16-byte copy pre-Ampere and to memcpy
  *      on the host pass (FKL host/device parity).
- *   2. CpAsyncStage16Op — a standard FKL Op (Parent alias, DECLARE_*_PARENT,
- *      static exec, build()) that stages one 16-byte chunk gmem->smem through
- *      the operation model. The commit/wait FENCES stay the caller's /
- *      MainloopDPP's pipelining policy (how many groups in flight), exposed
- *      as thin free helpers — they are control-flow fences, not data Ops. */
+ *   2. commit / wait FENCES — pipelining policy (how many groups in flight),
+ *      exposed as thin free helpers. They order cp.async groups, they don't
+ *      move data, so they are control-flow fences the caller / MainloopDPP
+ *      drives, not Ops.
+ *   3. CpAsyncStageDPP — the cooperative DPP: the block stages N 16-byte
+ *      chunks gmem->smem across its threads. */
 
 #include <fused_kernel/core/utils/utils.h>
-#include <fused_kernel/core/data/point.h>
-#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <cstdint>
 #include <cstring>
 
@@ -69,9 +70,8 @@ template <int N> inline void cpAsyncWaitGroups() {}
 
 } // namespace detail
 
-/* Pipelining fences — control-flow policy exposed to the caller / MainloopDPP.
- * (Not data Ops: they order cp.async groups, they don't move elements.)
- * Not constexpr (they emit asm), so plain inline qualifiers, not FK_*_FUSE. */
+/* Pipelining fences — control-flow policy for the caller / MainloopDPP.
+ * Not constexpr (they emit asm), so plain inline qualifiers. */
 #if defined(__NVCC__)
 __host__ __device__ __forceinline__ void cpAsyncCommit() { detail::cpAsyncCommit(); }
 template <int N>
@@ -81,41 +81,30 @@ inline void cpAsyncCommit() { detail::cpAsyncCommit(); }
 template <int N> inline void cpAsyncWaitGroups() { detail::cpAsyncWaitGroups<N>(); }
 #endif
 
-/* ---- CpAsyncStage16Op: stage one 16B chunk gmem->smem as an FKL Op ----
- * Params bundle the destination smem base and source gmem base; exec stages
- * the chunk at Point.x (in 16-byte units). A mainloop issues these across
- * threads, then a commit + wait fence, like PerThreadRead but landing in
- * shared memory through the async pipe. T is the 16-byte vector element.
- * Device-only (emits cp.async asm), so it does not derive the constexpr
- * ReadOperation parent; it follows the same static-struct + Params + exec +
- * build() Op shape the rest of the collective layer uses. */
-template <typename T = int4>
-struct CpAsyncStage16Op {
-private:
-    using SelfType = CpAsyncStage16Op<T>;
-public:
-    FK_STATIC_STRUCT(CpAsyncStage16Op, SelfType)
-    static_assert(sizeof(T) == 16, "CpAsyncStage16Op stages 16-byte chunks");
-
-    struct Params {
-        T*       smemDst;   // shared-memory destination base
-        const T* gmemSrc;   // global-memory source base
-    };
-
-    // Stage chunk index Point.x (16-byte granularity). The data lands in smem
-    // asynchronously. Not constexpr (emits cp.async asm).
 #if defined(__NVCC__)
-    __host__ __device__ __forceinline__
-#else
-    static inline
-#endif
-    static void exec(const Point thread, const Params& params) {
-        detail::cpAsync16(&params.smemDst[thread.x], &params.gmemSrc[thread.x]);
-    }
-    FK_HOST_FUSE Params build(T* smemDst, const T* gmemSrc) {
-        return Params{ smemDst, gmemSrc };
+
+/* CpAsyncStageDPP: cooperatively stage CHUNKS 16-byte chunks gmem->smem across
+ * the block's threads through the async pipe. The caller issues a commit + wait
+ * fence afterwards (pipelining policy). T is the 16-byte vector element. The
+ * kernel owns the shared buffer; this DPP just fills it. Multi-thread => DPP. */
+template <typename T = int4, int BLOCK_SIZE = 256>
+struct CpAsyncStageDPP {
+private:
+    using SelfType = CpAsyncStageDPP<T, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(CpAsyncStageDPP, SelfType)
+    static_assert(sizeof(T) == 16, "CpAsyncStageDPP stages 16-byte chunks");
+
+    // Stage `chunks` 16-byte elements gmem->smem, strided across the block.
+    static __device__ __forceinline__
+    void stage(T* smemDst, const T* gmemSrc, const int chunks) {
+        for (int i = threadIdx.x; i < chunks; i += BLOCK_SIZE) {
+            detail::cpAsync16(&smemDst[i], &gmemSrc[i]);
+        }
     }
 };
+
+#endif // defined(__NVCC__)
 
 } // namespace fk
 

--- a/include/fused_kernel/algorithms/collective/copy.h
+++ b/include/fused_kernel/algorithms/collective/copy.h
@@ -1,0 +1,122 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_COPY_H
+#define FK_COLLECTIVE_COPY_H
+
+/* Asynchronous global->shared staging copy as a composable FKL Op.
+ *
+ * Every tiled mainloop overlaps the next tile's load with the current tile's
+ * math via a 16-byte cp.async.cg. This header exposes that as:
+ *   1. detail:: low-level primitives (cpAsync16 / commit / wait) — the raw
+ *      PTX, degrading to a synchronous 16-byte copy pre-Ampere and to memcpy
+ *      on the host pass (FKL host/device parity).
+ *   2. CpAsyncStage16Op — a standard FKL Op (Parent alias, DECLARE_*_PARENT,
+ *      static exec, build()) that stages one 16-byte chunk gmem->smem through
+ *      the operation model. The commit/wait FENCES stay the caller's /
+ *      MainloopDPP's pipelining policy (how many groups in flight), exposed
+ *      as thin free helpers — they are control-flow fences, not data Ops. */
+
+#include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <cstdint>
+#include <cstring>
+
+namespace fk {
+
+namespace detail {
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+
+// 16-byte (128-bit) async copy global->shared, cache-global.
+__device__ __forceinline__ void cpAsync16(void* smemDst, const void* gmemSrc) {
+    const uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smemDst));
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(gmemSrc));
+}
+__device__ __forceinline__ void cpAsyncCommit() { asm volatile("cp.async.commit_group;\n"); }
+template <int N>
+__device__ __forceinline__ void cpAsyncWaitGroups() { asm volatile("cp.async.wait_group %0;\n" ::"n"(N)); }
+
+#elif defined(__NVCC__) && defined(__CUDA_ARCH__)
+
+// Pre-Ampere device: synchronous 16-byte copy, fences no-ops.
+__device__ __forceinline__ void cpAsync16(void* smemDst, const void* gmemSrc) {
+    *reinterpret_cast<int4*>(smemDst) = *reinterpret_cast<const int4*>(gmemSrc);
+}
+__device__ __forceinline__ void cpAsyncCommit() {}
+template <int N> __device__ __forceinline__ void cpAsyncWaitGroups() {}
+
+#else
+
+// Host pass: plain memcpy, fences no-ops (keeps the TU compiling on g++).
+inline void cpAsync16(void* dst, const void* src) { std::memcpy(dst, src, 16); }
+inline void cpAsyncCommit() {}
+template <int N> inline void cpAsyncWaitGroups() {}
+
+#endif
+
+} // namespace detail
+
+/* Pipelining fences — control-flow policy exposed to the caller / MainloopDPP.
+ * (Not data Ops: they order cp.async groups, they don't move elements.)
+ * Not constexpr (they emit asm), so plain inline qualifiers, not FK_*_FUSE. */
+#if defined(__NVCC__)
+__host__ __device__ __forceinline__ void cpAsyncCommit() { detail::cpAsyncCommit(); }
+template <int N>
+__host__ __device__ __forceinline__ void cpAsyncWaitGroups() { detail::cpAsyncWaitGroups<N>(); }
+#else
+inline void cpAsyncCommit() { detail::cpAsyncCommit(); }
+template <int N> inline void cpAsyncWaitGroups() { detail::cpAsyncWaitGroups<N>(); }
+#endif
+
+/* ---- CpAsyncStage16Op: stage one 16B chunk gmem->smem as an FKL Op ----
+ * Params bundle the destination smem base and source gmem base; exec stages
+ * the chunk at Point.x (in 16-byte units). A mainloop issues these across
+ * threads, then a commit + wait fence, like PerThreadRead but landing in
+ * shared memory through the async pipe. T is the 16-byte vector element.
+ * Device-only (emits cp.async asm), so it does not derive the constexpr
+ * ReadOperation parent; it follows the same static-struct + Params + exec +
+ * build() Op shape the rest of the collective layer uses. */
+template <typename T = int4>
+struct CpAsyncStage16Op {
+private:
+    using SelfType = CpAsyncStage16Op<T>;
+public:
+    FK_STATIC_STRUCT(CpAsyncStage16Op, SelfType)
+    static_assert(sizeof(T) == 16, "CpAsyncStage16Op stages 16-byte chunks");
+
+    struct Params {
+        T*       smemDst;   // shared-memory destination base
+        const T* gmemSrc;   // global-memory source base
+    };
+
+    // Stage chunk index Point.x (16-byte granularity). The data lands in smem
+    // asynchronously. Not constexpr (emits cp.async asm).
+#if defined(__NVCC__)
+    __host__ __device__ __forceinline__
+#else
+    static inline
+#endif
+    static void exec(const Point thread, const Params& params) {
+        detail::cpAsync16(&params.smemDst[thread.x], &params.gmemSrc[thread.x]);
+    }
+    FK_HOST_FUSE Params build(T* smemDst, const T* gmemSrc) {
+        return Params{ smemDst, gmemSrc };
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_COPY_H

--- a/include/fused_kernel/algorithms/collective/epilogue.h
+++ b/include/fused_kernel/algorithms/collective/epilogue.h
@@ -1,0 +1,120 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_EPILOGUE_H
+#define FK_COLLECTIVE_EPILOGUE_H
+
+/* EpilogueDPP: fused, cooperative epilogue for the tiled-GEMM mainloop.
+ *
+ * The mainloop leaves the accumulator D in registers (D_REGS fp32 per lane).
+ * This DPP applies an FKL compute-Op chain to each accumulator element
+ * IN-REGISTER, then writes it out through a Write IOp — the
+ * `out = acc | epilogueChain` pattern the attention kernel already uses
+ * (flash_attention_mma.h: `(r[i] * invA) | p.epilogue`). Scale, bias, ReLU/
+ * GELU, cast, saturate — all fuse, no DRAM round-trip, no separate kernel.
+ *
+ * Why a DPP (and multi-thread, addressing Oscar's review): the whole warp
+ * participates — every lane owns part of the output tile and writes its own
+ * elements, so the epilogue is NOT processed by a single thread. The optional
+ * smem-staging path additionally lets the warp re-lay the tile in shared
+ * memory before writing, turning the strided per-lane stores into coalesced
+ * row writes. Per the FKL contract:
+ *   - the accumulator enters as register data from the mainloop,
+ *   - the epilogue transform is a compute Op (EpilogueOp), and
+ *   - output goes through a Write IOp (no raw device pointer in exec).
+ *
+ * D-fragment -> output mapping for MmaBf16_16x8x16 (verified in
+ * test_collective_mma.h) is provided by a DStore policy: g=lane>>2, t=lane&3;
+ *   d0,d1 -> row g     cols 2t,2t+1 ;  d2,d3 -> row g+8 cols 2t,2t+1
+ */
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/* Identity epilogue: pass the accumulator through unchanged. Composes with
+ * the FKL `value | iopChain` epilogue-fusion pattern used by attention. */
+struct GemmIdentityEpilogue {
+    FK_HOST_DEVICE_CNST friend float operator|(const float v, const GemmIdentityEpilogue&) { return v; }
+};
+
+/* D-register -> (row,col) policy for MmaBf16_16x8x16 (any m16n8 atom with the
+ * standard f32 accumulator layout). */
+struct MmaBf16DStore {
+    FK_HOST_DEVICE_FUSE void coord(int lane, int i, int& r, int& c) {
+        const int g = lane >> 2, t = lane & 3;
+        r = g + (i >> 1) * 8;     // d0,d1 -> row g ; d2,d3 -> row g+8
+        c = 2 * t + (i & 1);      // cols 2t, 2t+1
+    }
+};
+
+template <ParArch PA, typename MmaAtom, typename DStore>
+struct EpilogueDPP;
+
+#if defined(__NVCC__)
+/* GPU: warp-cooperative epilogue. Each lane applies the epilogue IOp chain to
+ * its D regs in-register (`d[i] | epilogue`) and writes them through the Write
+ * IOp at the tile-local coords the DStore policy resolves, offset by
+ * (rowBase, colBase). The whole warp participates — not a single thread. */
+template <typename MmaAtom, typename DStore>
+struct EpilogueDPP<ParArch::GPU_NVIDIA, MmaAtom, DStore> {
+private:
+    using SelfType = EpilogueDPP<ParArch::GPU_NVIDIA, MmaAtom, DStore>;
+public:
+    FK_STATIC_STRUCT(EpilogueDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename WriteIOp, typename Epilogue>
+    static __device__ __forceinline__
+    void exec(int rowBase, int colBase, int lane,
+              const typename MmaAtom::DReg (&d)[MmaAtom::D_REGS],
+              const WriteIOp& output, const Epilogue& epilogue) {
+        #pragma unroll
+        for (int i = 0; i < MmaAtom::D_REGS; ++i) {
+            int r, c;
+            DStore::coord(lane, i, r, c);
+            const auto v = d[i] | epilogue;   // IOp chain in-register
+            WriteIOp::Operation::exec(Point{ colBase + c, rowBase + r, 0 }, v, output.params);
+        }
+    }
+};
+#endif // __NVCC__
+
+/* CPU single-thread epilogue (mandatory per the DPP contract). */
+template <typename MmaAtom, typename DStore>
+struct EpilogueDPP<ParArch::CPU, MmaAtom, DStore> {
+private:
+    using SelfType = EpilogueDPP<ParArch::CPU, MmaAtom, DStore>;
+public:
+    FK_STATIC_STRUCT(EpilogueDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename WriteIOp, typename Epilogue>
+    static inline void exec(int rowBase, int colBase, int lane,
+                            const typename MmaAtom::DReg (&d)[MmaAtom::D_REGS],
+                            const WriteIOp& output, const Epilogue& epilogue) {
+        for (int i = 0; i < MmaAtom::D_REGS; ++i) {
+            int r, c; DStore{}.coord(lane, i, r, c);
+            const auto v = d[i] | epilogue;
+            WriteIOp::Operation::exec(Point{ colBase + c, rowBase + r, 0 }, v, output.params);
+        }
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_EPILOGUE_H

--- a/include/fused_kernel/algorithms/collective/mainloop.h
+++ b/include/fused_kernel/algorithms/collective/mainloop.h
@@ -1,0 +1,126 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MAINLOOP_H
+#define FK_COLLECTIVE_MAINLOOP_H
+
+/* TileMmaMainloopDPP: the canonical tiled-GEMM inner loop as a DPP that
+ * COMPOSES the collective primitives instead of hand-writing it.
+ *
+ *   D[MxN] = sum over K-tiles of  A_tile[MxK] * B_tile[NxK]
+ *
+ * Per the FKL DPP contract:
+ *   - Inputs A and B are Read IOps, passed as a fk::Tuple<AIOp, BIOp> (an MMA
+ *     mainloop needs two read operands — exactly the case the DPP skill cites
+ *     for a tuple read IOp). Every operand element enters through
+ *     IOp::Operation::exec — no raw device pointers in the exec signature.
+ *   - Output D is a Write IOp (the epilogue): the accumulated tile is emitted
+ *     through OutIOp::Operation::exec.
+ *   - The tensor-core step is MmaWarpDPP (warp-collective). Per the DPP skill,
+ *     tensor-core code is the one allowed exception to "a DPP must not contain
+ *     data-modifying code"; everything else flows through IOps.
+ *   - details (TileMmaMainloopDetails) carries only K (external scalar).
+ *
+ * The accumulator lives in registers across the whole K loop (online, no
+ * global intermediates) — the GEMM analogue of the online-softmax running
+ * state. Same structure attention's mainloop has; only the epilogue differs.
+ *
+ * SCOPE. One warp computes one MmaAtom-shaped output tile (M x N) accumulating
+ * over the full K — the minimal composition that proves the primitives stack
+ * into a real cooperative kernel, verified against an fp64 oracle. Multi-warp
+ * tiling (#279), cp.async pipelining (#276) and a fused epilogue (#282) are
+ * additive policies on top of this loop.
+ *
+ * FRAGMENT MAPPING (which lane reads which element) stays a caller FragLoader
+ * policy: it is the delicate, arch-specific part and is independently testable,
+ * exactly as MmaWarpDPP keeps the instruction contract separate from mapping.
+ * The loader pulls fragments from the value the Read IOp delivers for a Point.
+ */
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/* External (non-data) parameters: just the K extent of the operand tiles. */
+struct TileMmaMainloopDetails {
+    int K;
+};
+
+template <ParArch PA, typename MmaAtom, typename FragLoader>
+struct TileMmaMainloopDPP;
+
+#if defined(__NVCC__)
+/* GPU: one warp, one MmaAtom output tile, accumulate over K.
+ * ReadIOps is fk::Tuple<AIOp, BIOp>; the FragLoader maps the per-lane A/B
+ * fragments out of the operand tiles reached through those IOps. WriteIOp
+ * receives the per-lane D accumulator. */
+template <typename MmaAtom, typename FragLoader>
+struct TileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaAtom, FragLoader> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaAtom, FragLoader>;
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+    using AReg = typename MmaAtom::AReg;
+    using BReg = typename MmaAtom::BReg;
+    using DReg = typename MmaAtom::DReg;
+
+    template <typename ReadIOps, typename WriteIOp>
+    static __device__ __forceinline__
+    void exec(const TileMmaMainloopDetails& details, const ReadIOps& reads,
+              const WriteIOp& output, const FragLoader& loader) {
+        const auto& aIOp = get<0>(reads);   // A operand Read IOp
+        const auto& bIOp = get<1>(reads);   // B operand Read IOp
+        const int lane = threadIdx.x & 31;
+
+        DReg d[MmaAtom::D_REGS];
+        #pragma unroll
+        for (int i = 0; i < MmaAtom::D_REGS; ++i) d[i] = DReg(0);
+
+        for (int kBase = 0; kBase < details.K; kBase += MmaAtom::K) {
+            AReg a[MmaAtom::A_REGS];
+            BReg b[MmaAtom::B_REGS];
+            loader.loadA(aIOp, lane, kBase, a);   // fragments via the Read IOp
+            loader.loadB(bIOp, lane, kBase, b);
+            MmaWarpDPP<MmaAtom>::exec(a, b, d);    // warp-collective D += A*B
+        }
+        loader.storeD(output, lane, d);           // emit via the Write IOp
+    }
+};
+#endif // __NVCC__
+
+/* CPU single-thread implementation (mandatory per the DPP contract): a plain
+ * triple loop over the same operand IOps and Write IOp, for host parity. */
+template <typename MmaAtom, typename FragLoader>
+struct TileMmaMainloopDPP<ParArch::CPU, MmaAtom, FragLoader> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::CPU, MmaAtom, FragLoader>;
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp>
+    static inline void exec(const TileMmaMainloopDetails& details, const ReadIOps& reads,
+                            const WriteIOp& output, const FragLoader& loader) {
+        loader.template cpuGemm<MmaAtom>(get<0>(reads), get<1>(reads), output, details.K);
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MAINLOOP_H

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -15,40 +15,34 @@
 #ifndef FK_COLLECTIVE_MMA_H
 #define FK_COLLECTIVE_MMA_H
 
-/* MmaOp: tensor-core matrix-multiply-accumulate as a composable FKL Op.
+/* Tensor-core MMA as a cooperative DPP.
  *
- * WHY. The attention kernel calls mma.sync inline PTX with the fragment
- * register layout open-coded at each call site (flash_attention_mma.h, and
- * the validated spikes spike_fp8_mma.cu / spike_fp8_qk_mapping.cu). This
- * header turns one MMA atom into:
- *   1. An ATOM POLICY (MmaBf16_16x8x16, MmaFp8E4M3_16x8x32) carrying the
- *      shape (M,N,K) and per-thread fragment register counts (A/B/D) as part
- *      of the TYPE, plus the raw instruction.
- *   2. MmaOp<Atom> — a standard FKL Op (Parent alias, DECLARE_*_PARENT,
- *      static exec, build()). The accumulate semantics (D += A*B) make it a
- *      ComputeType: its MmaFragment params bundle the per-lane A/B/D
- *      register arrays, so the tensor-core step is addressable BY THE
- *      OPERATION MODEL and composes in a mainloop like any other Op, instead
- *      of being inline asm scattered through a 2000-line kernel.
+ * mma.sync is a WARP-COLLECTIVE instruction: all 32 lanes of the warp execute
+ * it together, each contributing its slice of the A/B fragments and receiving
+ * its slice of the D accumulator. That is multi-thread work, so per the FKL
+ * rule it is a DPP, NOT an Op (an Op is strictly single-thread). MmaWarpDPP
+ * wraps one MMA atom; the atom policy carries the shape (M,N,K) and per-lane
+ * fragment register counts as part of the TYPE, plus the raw instruction.
  *
- * The fragment->thread mapping (which lane owns which element) stays the
- * caller's responsibility — that is the job of a future TiledMma layer — but
- * the instruction and its operand register contract are now a reusable,
- * documented unit. A/B/D_REGS are the per-lane register counts the PTX
- * contract mandates (verified against the fp64 oracle in the spikes).
+ * This replaces the inline mma.sync PTX open-coded at each call site in
+ * flash_attention_mma.h (and the validated spikes spike_fp8_mma.cu /
+ * spike_fp8_qk_mapping.cu). The per-lane fragment->thread mapping (which lane
+ * owns which element) stays the caller's responsibility for now — that is the
+ * job of a future TiledMmaDPP — but the warp-collective instruction and its
+ * operand register contract become a reusable, documented DPP. A/B/D_REGS are
+ * the per-lane register counts the PTX contract mandates (verified against the
+ * fp64 oracle in the spikes).
  *
- * DEVICE-ONLY bodies (they emit SASS); host stubs keep the type usable on
- * the CPU pass so shape constants are queryable and TUs naming the type
- * compile under g++ — the collective layer's host/device-parity discipline. */
+ * DEVICE-ONLY bodies (they emit SASS); host stubs keep the types usable on the
+ * CPU pass so shape constants are queryable and TUs naming them compile under
+ * g++ — the collective layer's host/device-parity discipline. */
 
 #include <fused_kernel/core/utils/utils.h>
-#include <fused_kernel/core/data/point.h>
-#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <cstdint>
 
 namespace fk {
 
-/* ---- Atom policies: shape-as-type + the raw tensor-core instruction ---- */
+/* ---- Atom policies: shape-as-type + the raw warp-collective instruction ---- */
 
 /* bf16 x bf16 -> f32, m16n8k16 (Ampere+ canonical HMMA).
  * Per-lane (PTX ISA): A = 4 x .b32 (8 bf16), B = 2 x .b32 (4 bf16),
@@ -77,8 +71,8 @@ struct MmaBf16_16x8x16 {
 
 /* fp8 e4m3 x e4m3 -> f32, kind::f8f6f4 m16n8k32 (sm_120a/sm_121a feature
  * set — plain sm_120 ptxas rejects it). Per-lane: A = 4 x .b32 (16 e4m3),
- * B = 2 x .b32 (8 e4m3), C/D = 4 x .f32. Validated in spike_fp8_mma.cu
- * (mmaFp8) and spike_fp8_qk_mapping.cu. Opt-in: needs
+ * B = 2 x .b32 (8 e4m3), C/D = 4 x .f32. Validated in spike_fp8_mma.cu and
+ * spike_fp8_qk_mapping.cu. Opt-in: needs
  * -gencode arch=compute_120a,code=sm_120a + FK_ENABLE_FP8_MMA. */
 struct MmaFp8E4M3_16x8x32 {
     static constexpr int M = 16, N = 8, K = 32;
@@ -102,40 +96,35 @@ struct MmaFp8E4M3_16x8x32 {
 #endif
 };
 
-/* ---- MmaFragment: the per-lane operand register contract as params ----
- * Pointers into the caller's register/array fragments for one MMA atom.
- * D is in/out (accumulator): exec performs D += A * B. */
-template <typename Atom>
-struct MmaFragment {
-    const typename Atom::AReg* a;   // [Atom::A_REGS]
-    const typename Atom::BReg* b;   // [Atom::B_REGS]
-    typename Atom::DReg*       d;   // [Atom::D_REGS], in/out accumulator
-};
+#if defined(__NVCC__)
 
-/* ---- MmaOp: standard FKL Op wrapping one tensor-core MMA atom ----
- * ComputeType (accumulate): exec(thread, params) issues D += A*B for the
- * fragments bundled in params. Composes in a mainloop like any other Op. */
+/* MmaWarpDPP: one warp-collective MMA atom (D += A * B). Each lane passes its
+ * own A/B fragment registers and its own D accumulator slice; the 32 lanes
+ * cooperate to issue the tensor-core instruction. Multi-thread => DPP. */
 template <typename Atom>
-struct MmaOp {
+struct MmaWarpDPP {
 private:
-    using SelfType = MmaOp<Atom>;
+    using SelfType = MmaWarpDPP<Atom>;
 public:
-    FK_STATIC_STRUCT(MmaOp, SelfType)
+    FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
     using AtomType = Atom;
-    using Parent = BinaryOperation<MmaFragment<Atom>, MmaFragment<Atom>, void, MmaOp<Atom>>;
-    DECLARE_BINARY_PARENT
     static constexpr int M = Atom::M, N = Atom::N, K = Atom::K;
+    static constexpr int A_REGS = Atom::A_REGS, B_REGS = Atom::B_REGS, D_REGS = Atom::D_REGS;
 
-    // ComputeType exec: accumulate one atom (D += A * B) for these fragments.
-    // (params IS the MmaFragment; the macro-generated build(ParamsType) applies.)
-    FK_HOST_DEVICE_FUSE void exec(const MmaFragment<Atom>& frag) {
-        Atom::mma(frag.a, frag.b, frag.d);
+    // Warp-collective accumulate: D[lane] += A[lane] * B[lane].
+    static __device__ __forceinline__
+    void exec(const typename Atom::AReg a[Atom::A_REGS],
+              const typename Atom::BReg b[Atom::B_REGS],
+              typename Atom::DReg d[Atom::D_REGS]) {
+        Atom::mma(a, b, d);
     }
 };
 
 /* Convenience aliases. */
-using MmaBf16Op = MmaOp<MmaBf16_16x8x16>;
-using MmaFp8E4M3Op = MmaOp<MmaFp8E4M3_16x8x32>;
+using MmaBf16WarpDPP = MmaWarpDPP<MmaBf16_16x8x16>;
+using MmaFp8E4M3WarpDPP = MmaWarpDPP<MmaFp8E4M3_16x8x32>;
+
+#endif // defined(__NVCC__)
 
 } // namespace fk
 

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -1,0 +1,142 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MMA_H
+#define FK_COLLECTIVE_MMA_H
+
+/* MmaOp: tensor-core matrix-multiply-accumulate as a composable FKL Op.
+ *
+ * WHY. The attention kernel calls mma.sync inline PTX with the fragment
+ * register layout open-coded at each call site (flash_attention_mma.h, and
+ * the validated spikes spike_fp8_mma.cu / spike_fp8_qk_mapping.cu). This
+ * header turns one MMA atom into:
+ *   1. An ATOM POLICY (MmaBf16_16x8x16, MmaFp8E4M3_16x8x32) carrying the
+ *      shape (M,N,K) and per-thread fragment register counts (A/B/D) as part
+ *      of the TYPE, plus the raw instruction.
+ *   2. MmaOp<Atom> — a standard FKL Op (Parent alias, DECLARE_*_PARENT,
+ *      static exec, build()). The accumulate semantics (D += A*B) make it a
+ *      ComputeType: its MmaFragment params bundle the per-lane A/B/D
+ *      register arrays, so the tensor-core step is addressable BY THE
+ *      OPERATION MODEL and composes in a mainloop like any other Op, instead
+ *      of being inline asm scattered through a 2000-line kernel.
+ *
+ * The fragment->thread mapping (which lane owns which element) stays the
+ * caller's responsibility — that is the job of a future TiledMma layer — but
+ * the instruction and its operand register contract are now a reusable,
+ * documented unit. A/B/D_REGS are the per-lane register counts the PTX
+ * contract mandates (verified against the fp64 oracle in the spikes).
+ *
+ * DEVICE-ONLY bodies (they emit SASS); host stubs keep the type usable on
+ * the CPU pass so shape constants are queryable and TUs naming the type
+ * compile under g++ — the collective layer's host/device-parity discipline. */
+
+#include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <cstdint>
+
+namespace fk {
+
+/* ---- Atom policies: shape-as-type + the raw tensor-core instruction ---- */
+
+/* bf16 x bf16 -> f32, m16n8k16 (Ampere+ canonical HMMA).
+ * Per-lane (PTX ISA): A = 4 x .b32 (8 bf16), B = 2 x .b32 (4 bf16),
+ * C/D = 4 x .f32. Validated in spikes/spike_fp8_mma.cu (mmaBf16). */
+struct MmaBf16_16x8x16 {
+    static constexpr int M = 16, N = 8, K = 16;
+    static constexpr int A_REGS = 4, B_REGS = 2, D_REGS = 4;
+    using AReg = uint32_t;   // packed 2x bf16 per .b32
+    using BReg = uint32_t;
+    using DReg = float;
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__)
+    __device__ __forceinline__ static void mma(const AReg a[A_REGS],
+                                               const BReg b[B_REGS],
+                                               DReg d[D_REGS]) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+    }
+#else
+    static void mma(const AReg[A_REGS], const BReg[B_REGS], DReg[D_REGS]) {}
+#endif
+};
+
+/* fp8 e4m3 x e4m3 -> f32, kind::f8f6f4 m16n8k32 (sm_120a/sm_121a feature
+ * set — plain sm_120 ptxas rejects it). Per-lane: A = 4 x .b32 (16 e4m3),
+ * B = 2 x .b32 (8 e4m3), C/D = 4 x .f32. Validated in spike_fp8_mma.cu
+ * (mmaFp8) and spike_fp8_qk_mapping.cu. Opt-in: needs
+ * -gencode arch=compute_120a,code=sm_120a + FK_ENABLE_FP8_MMA. */
+struct MmaFp8E4M3_16x8x32 {
+    static constexpr int M = 16, N = 8, K = 32;
+    static constexpr int A_REGS = 4, B_REGS = 2, D_REGS = 4;
+    using AReg = uint32_t;   // packed 4x e4m3 per .b32
+    using BReg = uint32_t;
+    using DReg = float;
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1200) && defined(FK_ENABLE_FP8_MMA)
+    __device__ __forceinline__ static void mma(const AReg a[A_REGS],
+                                               const BReg b[B_REGS],
+                                               DReg d[D_REGS]) {
+        asm volatile(
+            "mma.sync.aligned.kind::f8f6f4.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+    }
+#else
+    static void mma(const AReg[A_REGS], const BReg[B_REGS], DReg[D_REGS]) {}
+#endif
+};
+
+/* ---- MmaFragment: the per-lane operand register contract as params ----
+ * Pointers into the caller's register/array fragments for one MMA atom.
+ * D is in/out (accumulator): exec performs D += A * B. */
+template <typename Atom>
+struct MmaFragment {
+    const typename Atom::AReg* a;   // [Atom::A_REGS]
+    const typename Atom::BReg* b;   // [Atom::B_REGS]
+    typename Atom::DReg*       d;   // [Atom::D_REGS], in/out accumulator
+};
+
+/* ---- MmaOp: standard FKL Op wrapping one tensor-core MMA atom ----
+ * ComputeType (accumulate): exec(thread, params) issues D += A*B for the
+ * fragments bundled in params. Composes in a mainloop like any other Op. */
+template <typename Atom>
+struct MmaOp {
+private:
+    using SelfType = MmaOp<Atom>;
+public:
+    FK_STATIC_STRUCT(MmaOp, SelfType)
+    using AtomType = Atom;
+    using Parent = BinaryOperation<MmaFragment<Atom>, MmaFragment<Atom>, void, MmaOp<Atom>>;
+    DECLARE_BINARY_PARENT
+    static constexpr int M = Atom::M, N = Atom::N, K = Atom::K;
+
+    // ComputeType exec: accumulate one atom (D += A * B) for these fragments.
+    // (params IS the MmaFragment; the macro-generated build(ParamsType) applies.)
+    FK_HOST_DEVICE_FUSE void exec(const MmaFragment<Atom>& frag) {
+        Atom::mma(frag.a, frag.b, frag.d);
+    }
+};
+
+/* Convenience aliases. */
+using MmaBf16Op = MmaOp<MmaBf16_16x8x16>;
+using MmaFp8E4M3Op = MmaOp<MmaFp8E4M3_16x8x32>;
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MMA_H

--- a/include/fused_kernel/algorithms/collective/multistage.h
+++ b/include/fused_kernel/algorithms/collective/multistage.h
@@ -1,0 +1,111 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MULTISTAGE_H
+#define FK_COLLECTIVE_MULTISTAGE_H
+
+/* MultiStageMainloopDPP: multi-stage (N-buffer) software pipeline for the
+ * register-tiled GEMM mainloop. Generalises the 2-stage double buffer to
+ * STAGES shared-memory buffers, keeping STAGES-1 cp.async groups in flight so
+ * more global-load latency is hidden before the math has to wait. STAGES==2
+ * reduces to the classic double buffer.
+ *
+ * FKL conformance: this DPP owns only the PIPELINE CONTROL FLOW (ring
+ * rotation, commit/wait fences built from the collective copy primitive).
+ * The actual data movement and compute go through IOps via a StageLoader
+ * policy: stage(reads, buf, kTile) issues the async load for a K-tile into a
+ * ring slot through the operand Read IOps, and compute(buf, output) runs the
+ * register-tiled warp body (WarpTileMmaMainloopDPP's body) on a ring slot,
+ * writing through the Write IOp. No raw device pointer in exec; operands and
+ * result flow as a fk::Tuple<AIOp,BIOp> Read pair + a Write IOp.
+ *
+ * Caller owns the smem ring (STAGES buffers for A and B). numTiles >= 1;
+ * degrades correctly when numTiles < STAGES (drains early). */
+
+#include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/register_tile.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+struct MultiStageDetails { int numTiles; };
+
+template <ParArch PA, int STAGES, typename StagePolicy>
+struct MultiStageMainloopDPP;
+
+#if defined(__NVCC__)
+template <int STAGES, typename StagePolicy>
+struct MultiStageMainloopDPP<ParArch::GPU_NVIDIA, STAGES, StagePolicy> {
+private:
+    using SelfType = MultiStageMainloopDPP<ParArch::GPU_NVIDIA, STAGES, StagePolicy>;
+public:
+    FK_STATIC_STRUCT(MultiStageMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+    static_assert(STAGES >= 2, "need at least 2 stages");
+
+    template <typename ReadIOps, typename WriteIOp, typename SmemRing>
+    static __device__ __forceinline__
+    void exec(const MultiStageDetails& details, const ReadIOps& reads,
+              const WriteIOp& output, StagePolicy& stage, SmemRing& ring) {
+        const int numTiles = details.numTiles;
+
+        // Prologue: launch the first STAGES-1 tiles, one cp.async group each.
+        const int prefetch = (numTiles < STAGES - 1) ? numTiles : (STAGES - 1);
+        #pragma unroll
+        for (int p = 0; p < STAGES - 1; ++p) {
+            if (p < prefetch) { stage.stage(reads, p % STAGES, p, ring); cpAsyncCommit(); }
+        }
+        // Steady state.
+        for (int s = 0; s < numTiles; ++s) {
+            const int inFlight = (numTiles - s < STAGES - 1) ? (numTiles - s - 1) : (STAGES - 2);
+            switch (inFlight) {
+                case 0: cpAsyncWaitGroups<0>(); break;
+                case 1: cpAsyncWaitGroups<1>(); break;
+                case 2: cpAsyncWaitGroups<2>(); break;
+                default: cpAsyncWaitGroups<3>(); break;   // STAGES<=5 covers all
+            }
+            __syncthreads();
+            stage.compute(s % STAGES, ring);              // accumulate this tile
+            __syncthreads();
+            const int next = s + STAGES - 1;
+            if (next < numTiles) { stage.stage(reads, next % STAGES, next, ring); cpAsyncCommit(); }
+        }
+        stage.epilogue(output);                           // emit via Write IOp
+    }
+};
+#endif // __NVCC__
+
+/* CPU single-thread implementation (mandatory per the DPP contract): no
+ * pipelining needed — stage+compute every tile in order, then write out. */
+template <int STAGES, typename StagePolicy>
+struct MultiStageMainloopDPP<ParArch::CPU, STAGES, StagePolicy> {
+private:
+    using SelfType = MultiStageMainloopDPP<ParArch::CPU, STAGES, StagePolicy>;
+public:
+    FK_STATIC_STRUCT(MultiStageMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp, typename SmemRing>
+    static inline void exec(const MultiStageDetails& details, const ReadIOps& reads,
+                            const WriteIOp& output, StagePolicy& stage, SmemRing& ring) {
+        for (int s = 0; s < details.numTiles; ++s) { stage.stage(reads, 0, s, ring); stage.compute(0, ring); }
+        stage.epilogue(output);
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MULTISTAGE_H

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -15,130 +15,218 @@
 #ifndef FK_COLLECTIVE_REDUCE_H
 #define FK_COLLECTIVE_REDUCE_H
 
-/* Collective reductions as first-class FKL building blocks.
+/* Cross-thread reductions as composable FKL DPPs.
  *
- * WHY THIS EXISTS. Cooperative DPPs (SoftmaxDPP today; the tiled mainloop
- * to come) all need cross-thread reductions: row-max and row-sum for
- * softmax, accumulation for GEMM, norms for layernorm. Until now each
- * kernel open-coded the __shfl_xor warp tree and the __shared__ block
- * tree by hand (see SoftmaxDPP, and quantizeQTile in flash_attention_mma).
- * That hand-rolled state is exactly the kind of thing FKL's IOp model is
- * meant to abstract — so this header makes the reduction a COMPOSED
- * operation parameterised by an associative combine functor, keeping the
- * FKL essence: small static structs, host+device parity, no inheritance
- * cost, composability.
+ * WHY THIS SHAPE. Cooperative algorithms (SoftmaxDPP today; the tiled
+ * mainloop to come) all need cross-thread reductions: row-max and row-sum
+ * for softmax, accumulation for GEMM, norms for layernorm. Per the FKL
+ * philosophy these are NOT bespoke functions with bespoke combine functors
+ * — the reduction operator is just a standard FKL BINARY Op (Add, Max, Min,
+ * Mul, ...) passed as a template argument, and the reduction itself is a
+ * Data Parallel Pattern. Three tiers, one per cooperation scope, matching
+ * the hardware:
  *
- * THE COMBINE FUNCTOR is just an FKL-shaped binary callable:
- *     T operator()(const T& a, const T& b) const;   // associative
- * The library ships ReduceMax / ReduceSum here; SoftmaxDPP's
- * mergeSoftmaxStates is itself a valid combine over OnlineSoftmaxState,
- * so the same primitives reduce scalars AND online-softmax states.
+ *   ReduceWarpDPP<ReduceOp, WARP_WIDTH>   intra-warp, __shfl_xor butterfly,
+ *                                         no smem, no barrier. All lanes get
+ *                                         the result. Sub-warp masks allow
+ *                                         segmented (per-row) reductions.
+ *   ReduceBlockDPP<ReduceOp, BLOCK_SIZE>  whole block: each warp reduces,
+ *                                         lane0 stages its partial to
+ *                                         caller-owned smem, warp 0 finishes.
+ *                                         The kernel owns its smem budget
+ *                                         (matches the cooperative-DPP
+ *                                         convention).
+ *   ReduceGridDPP<ReduceOp, BLOCK_SIZE>   whole grid: a block-reduce per CTA
+ *                                         followed by an atomic combine of
+ *                                         the per-block partials into a
+ *                                         single global accumulator.
  *
- * TWO TIERS, matching the hardware:
- *   WarpReduce<Combine>  — intra-warp, __shfl_xor butterfly, no smem, no
- *                          barrier. Result broadcast to all lanes.
- *   BlockReduce<Combine> — whole block: each warp reduces, lane0 of each
- *                          warp stages to smem, warp 0 reduces the partials.
+ * THE REDUCE OP is any FKL binary Op, i.e. a static struct exposing
+ *     FK_HOST_DEVICE_FUSE O exec(const I a, const P b);     // associative
+ * The library already ships Add / Max / Min / Mul (basic_ops). The softmax
+ * merge state is itself expressible as a binary Op over OnlineSoftmaxState,
+ * so the SAME DPP reduces scalars AND online-softmax states — no new combine
+ * type, no duplicated reduction code.
  *
- * These are device-side collectives (they call __shfl_xor / __syncthreads),
- * so like the cooperative DPP exec bodies they are NOT constexpr. On the
- * host pass (g++ CPU TU, or nvcc host pass) they degrade to a plain serial
- * fold so the same code type-checks and unit-tests run on CPU.
+ * These exec bodies call __shfl_xor / __syncthreads, so (like the other
+ * cooperative DPP exec bodies) they are NOT constexpr. On the host pass
+ * (g++ CPU TU, or nvcc host pass) they degrade to a plain serial fold so
+ * the same template type-checks and unit tests run on CPU.
  */
 
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <type_traits>
 
 namespace fk {
 
-/* ---- associative combine functors (host+device, constexpr-friendly) ---- */
-template <typename T>
-struct ReduceSum {
-    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const { return a + b; }
-    FK_HOST_DEVICE_CNST static T identity() { return T{}; }
-};
+// Cooperative-DPP exec bodies use __shfl/__shared__/barriers: they cannot be
+// constexpr (FK_DEVICE_FUSE). Plain static device inline qualifier:
+#define FK_COOP_DEVICE_FUSE static __device__ __forceinline__
 
-template <typename T>
-struct ReduceMax {
-    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const {
-        return a > b ? a : (b >= a ? b : a);   // NaN -> first arg (matches attnMaxF)
-    }
-};
-
-template <typename T>
-struct ReduceMin {
-    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const {
-        return a < b ? a : (b <= a ? b : a);
-    }
-};
+/* ReduceWarpDPP: intra-warp all-reduce parameterised by a standard FKL
+ * binary Op. WARP_WIDTH must be a power of two <= 32. Every participating
+ * lane in the mask receives the fully reduced value. mask defaults to the
+ * full warp; pass a sub-warp mask + WARP_WIDTH for segmented reductions. */
+template <typename ReduceOp, int WARP_WIDTH = 32>
+struct ReduceWarpDPP {
+private:
+    using SelfType = ReduceWarpDPP<ReduceOp, WARP_WIDTH>;
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static_assert(WARP_WIDTH > 0 && WARP_WIDTH <= 32 && (WARP_WIDTH & (WARP_WIDTH - 1)) == 0,
+                  "WARP_WIDTH must be a power of two in (0, 32]");
 
 #if defined(__NVCC__) && defined(__CUDA_ARCH__)
-
-/* ---- WarpReduce: intra-warp all-reduce via __shfl_xor butterfly ----
- * WARP_WIDTH must be a power of two <= 32. Every participating lane in the
- * mask receives the fully reduced value. mask defaults to the full warp;
- * pass a sub-warp mask + WARP_WIDTH for segmented (per-row) reductions. */
-template <typename Combine, int WARP_WIDTH = 32, typename T>
-__device__ __forceinline__ T warpReduce(T val, Combine combine = {},
-                                         const unsigned mask = 0xFFFFFFFFu) {
-    #pragma unroll
-    for (int offset = WARP_WIDTH / 2; offset > 0; offset >>= 1) {
-        const T other = __shfl_xor_sync(mask, val, offset, WARP_WIDTH);
-        val = combine(val, other);
+    template <typename T>
+    FK_COOP_DEVICE_FUSE T exec(T val, const unsigned mask = 0xFFFFFFFFu) {
+        #pragma unroll
+        for (int offset = WARP_WIDTH / 2; offset > 0; offset >>= 1) {
+            const T other = __shfl_xor_sync(mask, val, offset, WARP_WIDTH);
+            val = ReduceOp::exec(val, other);   // standard FKL binary Op
+        }
+        return val;
     }
-    return val;
-}
-
-/* ---- BlockReduce: whole-block all-reduce ----
- * Uses a caller-provided smem scratch of >= (BLOCK_SIZE/32) elements so the
- * primitive allocates nothing itself (the kernel owns its smem budget —
- * matches how the cooperative DPPs manage shared memory). Result is
- * returned on lane0 of warp0; pass broadcast=true to publish to all
- * threads through the same scratch. */
-template <typename Combine, int BLOCK_SIZE, typename T>
-__device__ __forceinline__ T blockReduce(T val, T* smemScratch,
-                                          Combine combine = {},
-                                          const bool broadcast = true) {
-    static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of 32");
-    constexpr int NUM_WARPS = BLOCK_SIZE / 32;
-    const int lane = threadIdx.x & 31;
-    const int warp = threadIdx.x >> 5;
-
-    val = warpReduce<Combine, 32>(val, combine);   // reduce within each warp
-    if (lane == 0) smemScratch[warp] = val;        // stage warp partials
-    __syncthreads();
-
-    if (warp == 0) {
-        T acc = (lane < NUM_WARPS) ? smemScratch[lane] : smemScratch[0];
-        acc = warpReduce<Combine, (NUM_WARPS > 1 ? NUM_WARPS : 1)>(acc, combine,
-                                  (NUM_WARPS >= 32) ? 0xFFFFFFFFu : ((1u << NUM_WARPS) - 1u));
-        if (lane == 0) smemScratch[0] = acc;
-    }
-    if (broadcast) {
-        __syncthreads();
-        return smemScratch[0];
-    }
-    return val;
-}
-
-#else  // host / CPU pass: serial fold so the same template type-checks
-
-template <typename Combine, int WARP_WIDTH = 32, typename T>
-inline T warpReduce(T val, Combine = {}, const unsigned = 0xFFFFFFFFu) { return val; }
-
-template <typename Combine, int BLOCK_SIZE, typename T>
-inline T blockReduce(T val, T*, Combine = {}, const bool = true) { return val; }
-
+#else   // host / CPU pass: single thread already holds the whole partial
+    template <typename T>
+    static inline T exec(T val, const unsigned = 0xFFFFFFFFu) { return val; }
 #endif
+};
 
-/* Host-side reference fold over a contiguous range — used by unit tests as
- * the oracle, and usable anywhere a serial associative reduction is wanted. */
-template <typename Combine, typename T>
-FK_HOST_DEVICE_CNST T serialReduce(const T* data, const int n, T init, Combine combine = {}) {
+/* ReduceBlockDPP: whole-block all-reduce parameterised by a standard FKL
+ * binary Op. Uses a caller-provided smem scratch of >= (BLOCK_SIZE/32)
+ * elements so the DPP allocates nothing itself (the kernel owns its smem
+ * budget — matches how the cooperative DPPs manage shared memory). With
+ * broadcast=true every thread receives the result; otherwise it is returned
+ * on lane0 of warp0. */
+template <typename ReduceOp, int BLOCK_SIZE>
+struct ReduceBlockDPP {
+private:
+    using SelfType = ReduceBlockDPP<ReduceOp, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of 32");
+    static constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__)
+    template <typename T>
+    FK_COOP_DEVICE_FUSE T exec(T val, T* smemScratch, const bool broadcast = true) {
+        const int lane = threadIdx.x & 31;
+        const int warp = threadIdx.x >> 5;
+
+        val = ReduceWarpDPP<ReduceOp, 32>::exec(val);   // reduce within each warp
+        if (lane == 0) smemScratch[warp] = val;         // stage warp partials
+        __syncthreads();
+
+        T blockResult = val;
+        if (warp == 0) {
+            T acc = (lane < NUM_WARPS) ? smemScratch[lane] : smemScratch[0];
+            acc = ReduceWarpDPP<ReduceOp, (NUM_WARPS > 1 ? NUM_WARPS : 1)>::exec(
+                      acc, (NUM_WARPS >= 32) ? 0xFFFFFFFFu : ((1u << NUM_WARPS) - 1u));
+            if (lane == 0) smemScratch[0] = acc;
+            blockResult = acc;   // full block reduction lives on lane0/warp0
+        }
+        if (broadcast) {
+            __syncthreads();
+            return smemScratch[0];
+        }
+        // non-broadcast: full result is valid on lane0 of warp0 (smemScratch[0])
+        return blockResult;
+    }
+#else   // host / CPU pass
+    template <typename T>
+    static inline T exec(T val, T*, const bool = true) { return val; }
+#endif
+};
+
+/* ReduceGridDPP: whole-grid all-reduce parameterised by a standard FKL
+ * binary Op. Each CTA computes a block-level partial (ReduceBlockDPP), then
+ * lane0/warp0 combines its partial into a single global accumulator via an
+ * atomic apply of ReduceOp. The caller initialises *gAccum to the Op's
+ * identity for the data range and reads it back after the grid completes.
+ * atomicApply specialises to the hardware atomic for the common Ops
+ * (Add->atomicAdd, Max->atomicMax, Min->atomicMin); other Ops fall back to a
+ * CAS loop so any associative Op composes. */
+template <typename ReduceOp, int BLOCK_SIZE>
+struct ReduceGridDPP {
+private:
+    using SelfType = ReduceGridDPP<ReduceOp, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of 32");
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__)
+    template <typename T>
+    FK_COOP_DEVICE_FUSE void exec(T val, T* smemScratch, T* gAccum) {
+        const T blockPartial =
+            ReduceBlockDPP<ReduceOp, BLOCK_SIZE>::exec(val, smemScratch, /*broadcast=*/false);
+        if ((threadIdx.x & 31) == 0 && (threadIdx.x >> 5) == 0) {
+            atomicApply(gAccum, blockPartial);
+        }
+    }
+
+private:
+    // Hardware atomics for the Ops the library ships; CAS fallback otherwise.
+    template <typename T>
+    static __device__ __forceinline__ void atomicApply(T* addr, T v) {
+        if constexpr (std::is_same_v<ReduceOp, Add<T, T, T, BinaryType>>) {
+            atomicAdd(addr, v);
+        } else if constexpr (std::is_same_v<ReduceOp, Max<T, T, T, BinaryType>>) {
+            atomicMaxOp(addr, v);
+        } else if constexpr (std::is_same_v<ReduceOp, Min<T, T, T, BinaryType>>) {
+            atomicMinOp(addr, v);
+        } else {
+            casApply(addr, v);
+        }
+    }
+
+    // Generic CAS apply of an arbitrary associative ReduceOp (float/int 32-bit).
+    template <typename T>
+    static __device__ __forceinline__ void casApply(T* addr, T v) {
+        static_assert(sizeof(T) == 4, "grid CAS fallback supports 32-bit types");
+        unsigned* uaddr = reinterpret_cast<unsigned*>(addr);
+        unsigned old = *uaddr, assumed;
+        do {
+            assumed = old;
+            T cur; __builtin_memcpy(&cur, &assumed, 4);
+            const T nw = ReduceOp::exec(cur, v);
+            unsigned nu; __builtin_memcpy(&nu, &nw, 4);
+            old = atomicCAS(uaddr, assumed, nu);
+        } while (assumed != old);
+    }
+
+    // float atomic max/min via int reinterpretation (monotonic ordering trick).
+    static __device__ __forceinline__ void atomicMaxOp(float* addr, float v) {
+        if (v >= 0.f) atomicMax(reinterpret_cast<int*>(addr), __float_as_int(v));
+        else          atomicMin(reinterpret_cast<unsigned*>(addr), __float_as_uint(v));
+    }
+    static __device__ __forceinline__ void atomicMinOp(float* addr, float v) {
+        if (v >= 0.f) atomicMin(reinterpret_cast<int*>(addr), __float_as_int(v));
+        else          atomicMax(reinterpret_cast<unsigned*>(addr), __float_as_uint(v));
+    }
+    template <typename T>
+    static __device__ __forceinline__ void atomicMaxOp(T* addr, T v) { atomicMax(addr, v); }
+    template <typename T>
+    static __device__ __forceinline__ void atomicMinOp(T* addr, T v) { atomicMin(addr, v); }
+#else   // host / CPU pass
+    template <typename T>
+    static inline void exec(T val, T*, T* gAccum) { if (gAccum) *gAccum = ReduceOp::exec(*gAccum, val); }
+#endif
+};
+
+/* Host-side reference fold over a contiguous range, parameterised by the
+ * same standard FKL binary Op — the unit-test oracle, and usable anywhere a
+ * serial associative reduction is wanted. */
+template <typename ReduceOp, typename T>
+FK_HOST_DEVICE_CNST T serialReduce(const T* data, const int n, T init) {
     T acc = init;
-    for (int i = 0; i < n; ++i) acc = combine(acc, data[i]);
+    for (int i = 0; i < n; ++i) acc = ReduceOp::exec(acc, data[i]);
     return acc;
 }
+
+#undef FK_COOP_DEVICE_FUSE
 
 } // namespace fk
 

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -56,8 +56,11 @@
 
 #include <fused_kernel/core/execution_model/operation_model/operation_model.h>
 #include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/execution_model/stream.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <type_traits>
 
 namespace fk {
@@ -215,6 +218,89 @@ private:
     static inline void exec(T val, T*, T* gAccum) { if (gAccum) *gAccum = ReduceOp::exec(*gAccum, val); }
 #endif
 };
+
+/* ReduceDPP: user-facing row-wise reduction as a composable FKL DPP.
+ *
+ * Honours the full FKL contract: the input is a Read IOp (the prologue) and
+ * the output is a Write IOp (the epilogue), so any fused preprocessing chain
+ * (read.then(Mul...).then(Cast...)) runs in-register at load time, and the
+ * single reduced value per row is emitted through whatever Write IOp the
+ * caller supplies (PerThreadWrite, TensorWrite, a fused post-op chain, ...).
+ * The reduction operator is a STANDARD FKL binary Op (Add / Max / Min, ...)
+ * passed as a template argument — no bespoke combine types. Element
+ * addressing matches SoftmaxDPP: thread.x = column, blockIdx.x = row.
+ *
+ *   InIOp   instantiable Read / ReadBack IOp (the prologue)
+ *   OutIOp  instantiable Write IOp (the epilogue); receives one value per row
+ *   ReduceOp standard FKL binary Op, invoked as ReduceOp::exec(a, b)
+ */
+#if defined(__NVCC__)
+
+template <typename ReduceOp, typename InIOp, typename OutIOp, typename T, int BLOCK_SIZE = 256>
+struct ReduceDPP {
+private:
+    using SelfType = ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static_assert(isAnyReadType<InIOp>,  "ReduceDPP prologue must be a Read or ReadBack IOp");
+    static_assert(isAnyWriteType<OutIOp>, "ReduceDPP epilogue must be a Write IOp");
+    static_assert(BLOCK_SIZE % 32 == 0,  "BLOCK_SIZE must be a multiple of 32");
+
+    struct Params {
+        InIOp  input;    // prologue Read/ReadBack IOp
+        OutIOp output;   // epilogue Write IOp
+        int    width;    // row length (number of columns to reduce)
+        T      identity; // ReduceOp identity for the reduction (0 for Add, -inf for Max, ...)
+    };
+
+    // Read one element of the row through the prologue IOp.
+    FK_DEVICE_FUSE T readElem(const InIOp& iop, const int x, const int row) {
+        return static_cast<T>(InIOp::Operation::exec(Point{ x, row, 0 }, iop));
+    }
+
+    static __device__ __forceinline__ void exec(const Params& p) {
+        __shared__ T scratch[BLOCK_SIZE / 32];
+
+        const int row = blockIdx.x;
+        const int tid = threadIdx.x;
+
+        // Per-thread strided fold over the row, reading through the prologue.
+        T acc = p.identity;
+        for (int x = tid; x < p.width; x += BLOCK_SIZE) {
+            acc = ReduceOp::exec(acc, readElem(p.input, x, row));
+        }
+        // Cooperative block reduction composing the same standard Op.
+        const T result = ReduceBlockDPP<ReduceOp, BLOCK_SIZE>::exec(acc, scratch, /*broadcast=*/false);
+
+        // Epilogue: thread 0 emits the single reduced value through the Write IOp.
+        if (tid == 0) {
+            OutIOp::Operation::exec(Point{ row, 0, 0 }, result, p.output.params);
+        }
+    }
+};
+
+template <typename ReduceOp, typename InIOp, typename OutIOp, typename T, int BLOCK_SIZE>
+__global__ void launchReduceDPP_Kernel(
+        const __grid_constant__ typename ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>::Params params) {
+    ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>::exec(params);
+}
+
+/* IOp-first API: input is the prologue Read IOp, output the epilogue Write
+ * IOp; one reduced value per row. ReduceOp and identity define the reduction. */
+template <typename ReduceOp, int BLOCK_SIZE = 256, typename InIOp, typename OutIOp, typename T>
+inline void executeReduce(const InIOp& input, const OutIOp& output,
+                          const int rows, const int width, const T identity,
+                          Stream_<ParArch::GPU_NVIDIA>& stream) {
+    using DPP = ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>;
+    const typename DPP::Params params{ input, output, width, identity };
+    const dim3 grid(rows, 1, 1);
+    const dim3 block(BLOCK_SIZE, 1, 1);
+    launchReduceDPP_Kernel<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>
+        <<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    gpuErrchk(cudaGetLastError());
+}
+
+#endif // defined(__NVCC__)
 
 /* Host-side reference fold over a contiguous range, parameterised by the
  * same standard FKL binary Op — the unit-test oracle, and usable anywhere a

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -1,0 +1,145 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REDUCE_H
+#define FK_COLLECTIVE_REDUCE_H
+
+/* Collective reductions as first-class FKL building blocks.
+ *
+ * WHY THIS EXISTS. Cooperative DPPs (SoftmaxDPP today; the tiled mainloop
+ * to come) all need cross-thread reductions: row-max and row-sum for
+ * softmax, accumulation for GEMM, norms for layernorm. Until now each
+ * kernel open-coded the __shfl_xor warp tree and the __shared__ block
+ * tree by hand (see SoftmaxDPP, and quantizeQTile in flash_attention_mma).
+ * That hand-rolled state is exactly the kind of thing FKL's IOp model is
+ * meant to abstract — so this header makes the reduction a COMPOSED
+ * operation parameterised by an associative combine functor, keeping the
+ * FKL essence: small static structs, host+device parity, no inheritance
+ * cost, composability.
+ *
+ * THE COMBINE FUNCTOR is just an FKL-shaped binary callable:
+ *     T operator()(const T& a, const T& b) const;   // associative
+ * The library ships ReduceMax / ReduceSum here; SoftmaxDPP's
+ * mergeSoftmaxStates is itself a valid combine over OnlineSoftmaxState,
+ * so the same primitives reduce scalars AND online-softmax states.
+ *
+ * TWO TIERS, matching the hardware:
+ *   WarpReduce<Combine>  — intra-warp, __shfl_xor butterfly, no smem, no
+ *                          barrier. Result broadcast to all lanes.
+ *   BlockReduce<Combine> — whole block: each warp reduces, lane0 of each
+ *                          warp stages to smem, warp 0 reduces the partials.
+ *
+ * These are device-side collectives (they call __shfl_xor / __syncthreads),
+ * so like the cooperative DPP exec bodies they are NOT constexpr. On the
+ * host pass (g++ CPU TU, or nvcc host pass) they degrade to a plain serial
+ * fold so the same code type-checks and unit-tests run on CPU.
+ */
+
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/* ---- associative combine functors (host+device, constexpr-friendly) ---- */
+template <typename T>
+struct ReduceSum {
+    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const { return a + b; }
+    FK_HOST_DEVICE_CNST static T identity() { return T{}; }
+};
+
+template <typename T>
+struct ReduceMax {
+    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const {
+        return a > b ? a : (b >= a ? b : a);   // NaN -> first arg (matches attnMaxF)
+    }
+};
+
+template <typename T>
+struct ReduceMin {
+    FK_HOST_DEVICE_CNST T operator()(const T& a, const T& b) const {
+        return a < b ? a : (b <= a ? b : a);
+    }
+};
+
+#if defined(__NVCC__) && defined(__CUDA_ARCH__)
+
+/* ---- WarpReduce: intra-warp all-reduce via __shfl_xor butterfly ----
+ * WARP_WIDTH must be a power of two <= 32. Every participating lane in the
+ * mask receives the fully reduced value. mask defaults to the full warp;
+ * pass a sub-warp mask + WARP_WIDTH for segmented (per-row) reductions. */
+template <typename Combine, int WARP_WIDTH = 32, typename T>
+__device__ __forceinline__ T warpReduce(T val, Combine combine = {},
+                                         const unsigned mask = 0xFFFFFFFFu) {
+    #pragma unroll
+    for (int offset = WARP_WIDTH / 2; offset > 0; offset >>= 1) {
+        const T other = __shfl_xor_sync(mask, val, offset, WARP_WIDTH);
+        val = combine(val, other);
+    }
+    return val;
+}
+
+/* ---- BlockReduce: whole-block all-reduce ----
+ * Uses a caller-provided smem scratch of >= (BLOCK_SIZE/32) elements so the
+ * primitive allocates nothing itself (the kernel owns its smem budget —
+ * matches how the cooperative DPPs manage shared memory). Result is
+ * returned on lane0 of warp0; pass broadcast=true to publish to all
+ * threads through the same scratch. */
+template <typename Combine, int BLOCK_SIZE, typename T>
+__device__ __forceinline__ T blockReduce(T val, T* smemScratch,
+                                          Combine combine = {},
+                                          const bool broadcast = true) {
+    static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of 32");
+    constexpr int NUM_WARPS = BLOCK_SIZE / 32;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+    val = warpReduce<Combine, 32>(val, combine);   // reduce within each warp
+    if (lane == 0) smemScratch[warp] = val;        // stage warp partials
+    __syncthreads();
+
+    if (warp == 0) {
+        T acc = (lane < NUM_WARPS) ? smemScratch[lane] : smemScratch[0];
+        acc = warpReduce<Combine, (NUM_WARPS > 1 ? NUM_WARPS : 1)>(acc, combine,
+                                  (NUM_WARPS >= 32) ? 0xFFFFFFFFu : ((1u << NUM_WARPS) - 1u));
+        if (lane == 0) smemScratch[0] = acc;
+    }
+    if (broadcast) {
+        __syncthreads();
+        return smemScratch[0];
+    }
+    return val;
+}
+
+#else  // host / CPU pass: serial fold so the same template type-checks
+
+template <typename Combine, int WARP_WIDTH = 32, typename T>
+inline T warpReduce(T val, Combine = {}, const unsigned = 0xFFFFFFFFu) { return val; }
+
+template <typename Combine, int BLOCK_SIZE, typename T>
+inline T blockReduce(T val, T*, Combine = {}, const bool = true) { return val; }
+
+#endif
+
+/* Host-side reference fold over a contiguous range — used by unit tests as
+ * the oracle, and usable anywhere a serial associative reduction is wanted. */
+template <typename Combine, typename T>
+FK_HOST_DEVICE_CNST T serialReduce(const T* data, const int n, T init, Combine combine = {}) {
+    T acc = init;
+    for (int i = 0; i < n; ++i) acc = combine(acc, data[i]);
+    return acc;
+}
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REDUCE_H

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -234,55 +234,82 @@ private:
  *   OutIOp  instantiable Write IOp (the epilogue); receives one value per row
  *   ReduceOp standard FKL binary Op, invoked as ReduceOp::exec(a, b)
  */
-#if defined(__NVCC__)
 
-template <typename ReduceOp, typename InIOp, typename OutIOp, typename T, int BLOCK_SIZE = 256>
-struct ReduceDPP {
+/* DPP details: external (non-data) parameters only — no IOps, no raw
+ * pointers. Per the FKL DPP contract, data is reached exclusively through the
+ * Read/Write IOps passed to exec(); Details carries just the scalars. */
+template <typename T>
+struct ReduceDPPDetails {
+    int width;       // row length (number of columns to reduce)
+    int rows;        // number of rows (grid.x)
+    T   identity;    // ReduceOp identity (0 for Add, -inf for Max, ...)
+};
+
+template <enum ParArch PA, typename ReduceOp, int BLOCK_SIZE = 256>
+struct ReduceDPP;
+
+#if defined(__NVCC__)
+template <typename ReduceOp, int BLOCK_SIZE>
+struct ReduceDPP<ParArch::GPU_NVIDIA, ReduceOp, BLOCK_SIZE> {
 private:
-    using SelfType = ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>;
+    using SelfType = ReduceDPP<ParArch::GPU_NVIDIA, ReduceOp, BLOCK_SIZE>;
 public:
     FK_STATIC_STRUCT(ReduceDPP, SelfType)
-    static_assert(isAnyReadType<InIOp>,  "ReduceDPP prologue must be a Read or ReadBack IOp");
-    static_assert(isAnyWriteType<OutIOp>, "ReduceDPP epilogue must be a Write IOp");
-    static_assert(BLOCK_SIZE % 32 == 0,  "BLOCK_SIZE must be a multiple of 32");
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+    static_assert(BLOCK_SIZE % 32 == 0, "BLOCK_SIZE must be a multiple of 32");
 
-    struct Params {
-        InIOp  input;    // prologue Read/ReadBack IOp
-        OutIOp output;   // epilogue Write IOp
-        int    width;    // row length (number of columns to reduce)
-        T      identity; // ReduceOp identity for the reduction (0 for Add, -inf for Max, ...)
-    };
-
-    // Read one element of the row through the prologue IOp.
-    FK_DEVICE_FUSE T readElem(const InIOp& iop, const int x, const int row) {
-        return static_cast<T>(InIOp::Operation::exec(Point{ x, row, 0 }, iop));
-    }
-
-    static __device__ __forceinline__ void exec(const Params& p) {
+    /* exec(details, readIOp, writeIOp): data is reached only through the IOps;
+     * details holds the external scalars. One reduced value per row. */
+    template <typename InIOp, typename OutIOp, typename T>
+    static __device__ __forceinline__
+    void exec(const ReduceDPPDetails<T>& details, const InIOp& input, const OutIOp& output) {
+        static_assert(isAnyReadType<InIOp>,  "ReduceDPP read IOp must be a Read/ReadBack IOp");
+        static_assert(isAnyWriteType<OutIOp>, "ReduceDPP write IOp must be a Write IOp");
         __shared__ T scratch[BLOCK_SIZE / 32];
 
         const int row = blockIdx.x;
         const int tid = threadIdx.x;
 
-        // Per-thread strided fold over the row, reading through the prologue.
-        T acc = p.identity;
-        for (int x = tid; x < p.width; x += BLOCK_SIZE) {
-            acc = ReduceOp::exec(acc, readElem(p.input, x, row));
+        T acc = details.identity;
+        for (int x = tid; x < details.width; x += BLOCK_SIZE) {
+            acc = ReduceOp::exec(acc, static_cast<T>(InIOp::Operation::exec(Point{ x, row, 0 }, input)));
         }
-        // Cooperative block reduction composing the same standard Op.
         const T result = ReduceBlockDPP<ReduceOp, BLOCK_SIZE>::exec(acc, scratch, /*broadcast=*/false);
-
-        // Epilogue: thread 0 emits the single reduced value through the Write IOp.
         if (tid == 0) {
-            OutIOp::Operation::exec(Point{ row, 0, 0 }, result, p.output.params);
+            OutIOp::Operation::exec(Point{ row, 0, 0 }, result, output.params);
+        }
+    }
+};
+#endif // defined(__NVCC__)
+
+/* Single-thread CPU implementation (mandatory per the DPP contract). */
+template <typename ReduceOp, int BLOCK_SIZE>
+struct ReduceDPP<ParArch::CPU, ReduceOp, BLOCK_SIZE> {
+private:
+    using SelfType = ReduceDPP<ParArch::CPU, ReduceOp, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename InIOp, typename OutIOp, typename T>
+    static inline void exec(const ReduceDPPDetails<T>& details, const InIOp& input, const OutIOp& output) {
+        for (int row = 0; row < details.rows; ++row) {
+            T acc = details.identity;
+            for (int x = 0; x < details.width; ++x) {
+                acc = ReduceOp::exec(acc, static_cast<T>(InIOp::Operation::exec(Point{ x, row, 0 }, input)));
+            }
+            OutIOp::Operation::exec(Point{ row, 0, 0 }, acc, output.params);
         }
     }
 };
 
-template <typename ReduceOp, typename InIOp, typename OutIOp, typename T, int BLOCK_SIZE>
-__global__ void launchReduceDPP_Kernel(
-        const __grid_constant__ typename ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>::Params params) {
-    ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>::exec(params);
+#if defined(__NVCC__)
+
+template <typename ReduceOp, int BLOCK_SIZE, typename InIOp, typename OutIOp, typename T>
+__global__ void launchReduceDPP_Kernel(const __grid_constant__ ReduceDPPDetails<T> details,
+                                       const __grid_constant__ InIOp input,
+                                       const __grid_constant__ OutIOp output) {
+    ReduceDPP<ParArch::GPU_NVIDIA, ReduceOp, BLOCK_SIZE>::exec(details, input, output);
 }
 
 /* IOp-first API: input is the prologue Read IOp, output the epilogue Write
@@ -291,12 +318,11 @@ template <typename ReduceOp, int BLOCK_SIZE = 256, typename InIOp, typename OutI
 inline void executeReduce(const InIOp& input, const OutIOp& output,
                           const int rows, const int width, const T identity,
                           Stream_<ParArch::GPU_NVIDIA>& stream) {
-    using DPP = ReduceDPP<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>;
-    const typename DPP::Params params{ input, output, width, identity };
+    const ReduceDPPDetails<T> details{ width, rows, identity };
     const dim3 grid(rows, 1, 1);
     const dim3 block(BLOCK_SIZE, 1, 1);
-    launchReduceDPP_Kernel<ReduceOp, InIOp, OutIOp, T, BLOCK_SIZE>
-        <<<grid, block, 0, stream.getCUDAStream()>>>(params);
+    launchReduceDPP_Kernel<ReduceOp, BLOCK_SIZE, InIOp, OutIOp, T>
+        <<<grid, block, 0, stream.getCUDAStream()>>>(details, input, output);
     gpuErrchk(cudaGetLastError());
 }
 

--- a/include/fused_kernel/algorithms/collective/register_tile.h
+++ b/include/fused_kernel/algorithms/collective/register_tile.h
@@ -1,0 +1,125 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REGISTER_TILE_H
+#define FK_COLLECTIVE_REGISTER_TILE_H
+
+/* WarpTileMmaMainloopDPP: register-tiled tiled-GEMM mainloop — one WARP
+ * computes a WM x WN grid of MmaAtom output tiles, accumulating over K.
+ *
+ * WHY. TileMmaMainloopDPP does ONE MmaAtom (16x8) per warp, so the
+ * load:compute ratio is fixed and low. A fast GEMM amortizes loads: each warp
+ * holds a WM x WN block of accumulators and, per K-step, loads WM A-fragments
+ * + WN B-fragments ONCE and issues WM*WN MMAs — every A-fragment reused WN
+ * times, every B-fragment WM times, in registers. That reuse turns the kernel
+ * compute-bound (cf. CUTLASS warp-tile).
+ *
+ * FKL conformance (addressing the review — no faked IOps; data flows through
+ * real Read/Write IOps): operands A and B arrive as a fk::Tuple<AIOp,BIOp>
+ * Read pair, the WM x WN result block leaves through a Write IOp, and the
+ * tensor-core step is MmaWarpDPP (the one allowed data-modifying exception).
+ * No raw device/smem pointer appears in the exec signature. The per-lane,
+ * per-sub-tile fragment mapping stays a pluggable RegTileFragLoader policy
+ * that reads operand elements via IOp::Operation::exec.
+ *
+ * Accumulator d[WM][WN][D_REGS] is caller-owned, register-resident across the
+ * whole K loop (online, no global intermediates). */
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/* External (non-data) parameters: K extent + the warp-tile shape is in the
+ * template, so details carries only K here. */
+struct WarpTileMainloopDetails { int K; };
+
+template <ParArch PA, typename MmaAtom, int WM, int WN, typename RegTileFragLoader>
+struct WarpTileMmaMainloopDPP;
+
+#if defined(__NVCC__)
+template <typename MmaAtom, int WM, int WN, typename RegTileFragLoader>
+struct WarpTileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaAtom, WM, WN, RegTileFragLoader> {
+private:
+    using SelfType = WarpTileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaAtom, WM, WN, RegTileFragLoader>;
+public:
+    FK_STATIC_STRUCT(WarpTileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+    using AReg = typename MmaAtom::AReg;
+    using BReg = typename MmaAtom::BReg;
+    using DReg = typename MmaAtom::DReg;
+
+    template <typename ReadIOps, typename WriteIOp>
+    static __device__ __forceinline__
+    void exec(const WarpTileMainloopDetails& details, const ReadIOps& reads,
+              const WriteIOp& output, const RegTileFragLoader& loader) {
+        const auto& aIOp = get<0>(reads);
+        const auto& bIOp = get<1>(reads);
+        const int lane = threadIdx.x & 31;
+
+        DReg d[WM][WN][MmaAtom::D_REGS];
+        #pragma unroll
+        for (int i = 0; i < WM; ++i)
+            #pragma unroll
+            for (int j = 0; j < WN; ++j)
+                #pragma unroll
+                for (int r = 0; r < MmaAtom::D_REGS; ++r) d[i][j][r] = DReg(0);
+
+        for (int kBase = 0; kBase < details.K; kBase += MmaAtom::K) {
+            // Load WM A-fragments and WN B-fragments ONCE through the Read IOps.
+            AReg a[WM][MmaAtom::A_REGS];
+            BReg b[WN][MmaAtom::B_REGS];
+            #pragma unroll
+            for (int i = 0; i < WM; ++i) loader.loadA(aIOp, i, kBase, lane, a[i]);
+            #pragma unroll
+            for (int j = 0; j < WN; ++j) loader.loadB(bIOp, j, kBase, lane, b[j]);
+            // Issue WM*WN MMAs reusing the fragments from registers.
+            #pragma unroll
+            for (int i = 0; i < WM; ++i)
+                #pragma unroll
+                for (int j = 0; j < WN; ++j)
+                    MmaWarpDPP<MmaAtom>::exec(a[i], b[j], d[i][j]);
+        }
+        // Emit the WM x WN accumulator block through the Write IOp.
+        #pragma unroll
+        for (int i = 0; i < WM; ++i)
+            #pragma unroll
+            for (int j = 0; j < WN; ++j)
+                loader.storeD(output, i, j, lane, d[i][j]);
+    }
+};
+#endif // __NVCC__
+
+/* CPU single-thread implementation (mandatory per the DPP contract). */
+template <typename MmaAtom, int WM, int WN, typename RegTileFragLoader>
+struct WarpTileMmaMainloopDPP<ParArch::CPU, MmaAtom, WM, WN, RegTileFragLoader> {
+private:
+    using SelfType = WarpTileMmaMainloopDPP<ParArch::CPU, MmaAtom, WM, WN, RegTileFragLoader>;
+public:
+    FK_STATIC_STRUCT(WarpTileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp>
+    static inline void exec(const WarpTileMainloopDetails& details, const ReadIOps& reads,
+                            const WriteIOp& output, const RegTileFragLoader& loader) {
+        loader.template cpuGemm<MmaAtom, WM, WN>(get<0>(reads), get<1>(reads), output, details.K);
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REGISTER_TILE_H

--- a/include/fused_kernel/algorithms/collective/tile.h
+++ b/include/fused_kernel/algorithms/collective/tile.h
@@ -1,0 +1,118 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_TILE_H
+#define FK_COLLECTIVE_TILE_H
+
+/* Tile LAYOUT POLICIES + a cooperative tile-staging DPP.
+ *
+ * There is deliberately NO Tile object. A "tile" is just a __shared__ buffer
+ * a DPP owns and addresses through a compile-time LAYOUT POLICY that maps
+ * (row, col) -> linear element offset. Swizzle becomes a property of the
+ * layout instead of a swz() hand-inlined into one kernel (cf. swz() in
+ * flash_attention_mma.h). The offset math is pure single-thread constexpr, so
+ * it is a policy, not an Op; the cross-thread load/store of the shared buffer
+ * is multi-thread work, so it lives in a DPP (CopyTileDPP) — per the FKL rule
+ * that anything needing more than one thread is a DPP, not an Op.
+ *
+ * A Layout policy is:
+ *     static constexpr uint offset(uint row, uint col);   // -> element index
+ *     static constexpr uint rows, cols;
+ *     static constexpr uint size();                       // elements to back
+ * New layouts (column major, padded, banked, byte-swizzle) are just new
+ * policies — nothing else changes.
+ */
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/* ---- Layout policies: (row, col) -> linear element offset ---- */
+
+// Plain row-major: offset = row * COLS + col.
+template <uint ROWS, uint COLS>
+struct RowMajorLayout {
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+    FK_HOST_DEVICE_CNST static uint offset(const uint row, const uint col) {
+        return row * COLS + col;
+    }
+    FK_HOST_DEVICE_CNST static uint size() { return ROWS * COLS; }
+};
+
+/* XOR swizzle (the classic smem bank-conflict-avoiding layout): within a
+ * row-major buffer the column index is XORed with a function of the row so
+ * consecutive rows land in different bank phases. PERIOD (power of two) is the
+ * row period; the XOR uses (row % PERIOD). Bijective within a row, so reads
+ * see exactly what writes wrote. Same FAMILY as the hand-inlined swz() in
+ * flash_attention_mma.h, now a reusable layout policy. (#280 adds a
+ * byte-granularity ByteXorSwizzleLayout bit-identical to swz().) */
+template <uint ROWS, uint COLS, uint PERIOD = 8>
+struct XorSwizzleLayout {
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+    static_assert((COLS & (COLS - 1)) == 0, "XorSwizzleLayout requires power-of-two COLS");
+    static_assert((PERIOD & (PERIOD - 1)) == 0, "PERIOD must be a power of two");
+    FK_HOST_DEVICE_CNST static uint offset(const uint row, const uint col) {
+        const uint phase = row & (PERIOD - 1);
+        return row * COLS + (col ^ phase);
+    }
+    FK_HOST_DEVICE_CNST static uint size() { return ROWS * COLS; }
+};
+
+#if defined(__NVCC__)
+
+/* CopyTileDPP: cooperatively stage a ROWS x COLS tile between global memory
+ * (row-major, given pitch in elements) and a caller-owned __shared__ buffer
+ * addressed through Layout. This is the multi-thread piece — the whole block
+ * participates — so it is a DPP, not an Op. The kernel owns the __shared__
+ * (it budgeted Layout::size() elements); the DPP just indexes it. */
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct CopyTileDPP {
+private:
+    using SelfType = CopyTileDPP<T, Layout, BLOCK_SIZE>;
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr uint TILE_ELEMS = Layout::rows * Layout::cols;
+
+    // global -> shared: load the tile, applying the layout to the smem index.
+    static __device__ __forceinline__
+    void loadGlobalToShared(T* smem, const T* gmem, const int gmemPitchElems) {
+        for (uint i = threadIdx.x; i < TILE_ELEMS; i += BLOCK_SIZE) {
+            const uint r = i / Layout::cols, c = i % Layout::cols;
+            smem[Layout::offset(r, c)] = gmem[r * gmemPitchElems + c];
+        }
+    }
+
+    // shared -> global: store the tile back, reading through the layout.
+    static __device__ __forceinline__
+    void storeSharedToGlobal(const T* smem, T* gmem, const int gmemPitchElems) {
+        for (uint i = threadIdx.x; i < TILE_ELEMS; i += BLOCK_SIZE) {
+            const uint r = i / Layout::cols, c = i % Layout::cols;
+            gmem[r * gmemPitchElems + c] = smem[Layout::offset(r, c)];
+        }
+    }
+
+    // element accessor for in-DPP-body use: which smem slot holds (row, col).
+    static __device__ __forceinline__ T& at(T* smem, const uint row, const uint col) {
+        return smem[Layout::offset(row, col)];
+    }
+};
+
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_TILE_H

--- a/tests/collective/test_collective_epilogue.h
+++ b/tests/collective/test_collective_epilogue.h
@@ -1,0 +1,152 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__  // composes device-only mainloop + MMA + epilogue
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/mainloop.h>
+#include <fused_kernel/algorithms/collective/epilogue.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+/* Minimal Read/Write IOps over a RawPtr (bf16 has no VectorTraits, so we
+ * can't use PerThreadRead). Data still flows through IOp::Operation::exec. */
+template <typename T>
+struct TileReadOp {
+    using Operation = TileReadOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static T exec(const Point thread, const ParamsType& p) {
+        return *PtrAccessor<ND::_2D>::template cr_point<T, T>(thread, p.ptr);
+    }
+    __host__ static TileReadOp build(const RawPtr<ND::_2D, T>& r) { return TileReadOp{ { r } }; }
+};
+template <typename T>
+struct TileWriteOp {
+    using Operation = TileWriteOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static void exec(const Point thread, const T value, const ParamsType& p) {
+        *PtrAccessor<ND::_2D>::template point<T, T>(thread, p.ptr) = value;
+    }
+    __host__ static TileWriteOp build(const RawPtr<ND::_2D, T>& r) { return TileWriteOp{ { r } }; }
+};
+
+/* Epilogue functors composing the FKL `value | epilogue` fusion pattern. */
+struct ScaleBiasEpilogue {   // 2x + 1
+    FK_HOST_DEVICE_CNST friend float operator|(const float v, const ScaleBiasEpilogue&) { return 2.f * v + 1.f; }
+};
+struct ReluEpilogue {
+    FK_HOST_DEVICE_CNST friend float operator|(const float v, const ReluEpilogue&) { return v > 0.f ? v : 0.f; }
+};
+
+struct Bf16FragLoaderRowMajor {
+    using Atom = MmaBf16_16x8x16;
+    template <typename AIOp>
+    __device__ __forceinline__ uint32_t pack2(const AIOp&, int row, int col) const {
+        const __nv_bfloat16 x0 = AIOp::Operation::exec(Point{ col,     row, 0 }, *params_);
+        const __nv_bfloat16 x1 = AIOp::Operation::exec(Point{ col + 1, row, 0 }, *params_);
+        uint32_t r; __nv_bfloat16 two[2] = { x0, x1 }; memcpy(&r, two, 4); return r;
+    }
+    const typename TileReadOp<__nv_bfloat16>::ParamsType* params_ = nullptr;
+    template <typename AIOp>
+    __device__ __forceinline__ void loadA(const AIOp& A, int lane, int kBase, uint32_t (&a)[4]) {
+        params_ = &A.params; const int g = lane >> 2, t = lane & 3;
+        a[0] = pack2(A, g, kBase+2*t); a[1] = pack2(A, g+8, kBase+2*t);
+        a[2] = pack2(A, g, kBase+2*t+8); a[3] = pack2(A, g+8, kBase+2*t+8);
+    }
+    template <typename BIOp>
+    __device__ __forceinline__ void loadB(const BIOp& B, int lane, int kBase, uint32_t (&b)[2]) {
+        params_ = &B.params; const int g = lane >> 2, t = lane & 3;
+        b[0] = pack2(B, g, kBase+2*t); b[1] = pack2(B, g, kBase+2*t+8);
+    }
+    template <typename WIOp>
+    __device__ __forceinline__ void storeD(const WIOp&, int, const float (&)[4]) const {}
+};
+
+template <typename AIOp, typename BIOp, typename DIOp, typename Epilogue>
+__global__ void gemmEpiKernel(AIOp aIOp, BIOp bIOp, DIOp dIOp, int K, Epilogue epi) {
+    const int lane = threadIdx.x;
+    float d[4] = {0,0,0,0};
+    Bf16FragLoaderRowMajor ld;
+    // Mainloop accumulates D in registers...
+    {
+        const int g = lane >> 2, t = lane & 3;
+        for (int kB = 0; kB < K; kB += 16) {
+            uint32_t a[4], b[2];
+            ld.loadA(aIOp, lane, kB, a);
+            ld.loadB(bIOp, lane, kB, b);
+            MmaWarpDPP<MmaBf16_16x8x16>::exec(a, b, d);
+        }
+    }
+    // ...then the cooperative fused epilogue writes through the Write IOp.
+    EpilogueDPP<ParArch::GPU_NVIDIA, MmaBf16_16x8x16, MmaBf16DStore>::exec(0, 0, lane, d, dIOp, epi);
+}
+
+static int failures = 0;
+
+template <int EPI, typename Epilogue>
+static void runCase(const char* name, int K, Epilogue epilogue) {
+    std::mt19937 rng(7);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<float> Af(16*K), Bf(8*K);
+    for (auto& x : Af) x = dist(rng);
+    for (auto& x : Bf) x = dist(rng);
+    std::vector<__nv_bfloat16> Ah(16*K), Bh(8*K);
+    for (int i=0;i<16*K;++i) Ah[i]=__float2bfloat16(Af[i]);
+    for (int i=0;i<8*K;++i)  Bh[i]=__float2bfloat16(Bf[i]);
+
+    Ptr2D<__nv_bfloat16> A(K, 16), B(K, 8);
+    Ptr2D<float> D(8, 16);
+    cudaMemcpy2D(A.ptr().data, A.ptr().dims.pitch, Ah.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), 16, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(B.ptr().data, B.ptr().dims.pitch, Bh.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), 8, cudaMemcpyHostToDevice);
+
+    const auto aIOp = TileReadOp<__nv_bfloat16>::build(A.ptr());
+    const auto bIOp = TileReadOp<__nv_bfloat16>::build(B.ptr());
+    const auto dIOp = TileWriteOp<float>::build(D.ptr());
+    gemmEpiKernel<<<1,32>>>(aIOp, bIOp, dIOp, K, epilogue);
+    cudaDeviceSynchronize();
+
+    std::vector<float> Dout(16*8);
+    cudaMemcpy2D(Dout.data(), 8*sizeof(float), D.ptr().data, D.ptr().dims.pitch, 8*sizeof(float), 16, cudaMemcpyDeviceToHost);
+
+    double maxErr = 0;
+    for (int m=0;m<16;++m) for (int n=0;n<8;++n) {
+        double acc = 0;
+        for (int k=0;k<K;++k) acc += (double)__bfloat162float(Ah[m*K+k]) * (double)__bfloat162float(Bh[n*K+k]);
+        double ref = (EPI==0)? acc : (EPI==1)? 2.0*acc+1.0 : (acc>0.0?acc:0.0);
+        maxErr = std::max(maxErr, std::abs((double)Dout[m*8+n] - ref));
+    }
+    const double tol = 5e-2 * (K/16.0) + 1e-3;
+    if (maxErr > tol) { printf("FAIL %s K=%d maxErr=%.4e (tol %.3e)\n", name, K, maxErr, tol); ++failures; }
+    else printf("EpilogueDPP %-16s K=%-4d vs fp64 oracle: PASS (maxErr=%.2e)\n", name, K, maxErr);
+}
+
+int launch() {
+    runCase<0>("identity", 64, GemmIdentityEpilogue{});
+    runCase<0>("identity", 256, GemmIdentityEpilogue{});
+    runCase<1>("scale+bias 2x+1", 64, ScaleBiasEpilogue{});
+    runCase<1>("scale+bias 2x+1", 256, ScaleBiasEpilogue{});
+    runCase<2>("ReLU", 64, ReluEpilogue{});
+    runCase<2>("ReLU", 256, ReluEpilogue{});
+    return failures == 0 ? 0 : -1;
+}

--- a/tests/collective/test_collective_mainloop.h
+++ b/tests/collective/test_collective_mainloop.h
@@ -1,0 +1,152 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__  // composes device-only MMA + mainloop
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/mainloop.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+/* Minimal Read/Write IOps for the operand/output tiles. FKL's PerThreadRead
+ * needs VectorTraits, which isn't defined for __nv_bfloat16, so the test
+ * supplies tiny Read/Write Ops over a RawPtr — still the FKL contract (data
+ * reached through IOp::Operation::exec, no raw pointer in the DPP), just
+ * without thread fusion. */
+template <typename T>
+struct TileReadOp {
+    using Operation = TileReadOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static T exec(const Point thread, const ParamsType& p) {
+        return *PtrAccessor<ND::_2D>::template cr_point<T, T>(thread, p.ptr);
+    }
+    __host__ static TileReadOp build(const RawPtr<ND::_2D, T>& r) { return TileReadOp{ { r } }; }
+};
+
+template <typename T>
+struct TileWriteOp {
+    using Operation = TileWriteOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static void exec(const Point thread, const T value, const ParamsType& p) {
+        *PtrAccessor<ND::_2D>::template point<T, T>(thread, p.ptr) = value;
+    }
+    __host__ static TileWriteOp build(const RawPtr<ND::_2D, T>& r) { return TileWriteOp{ { r } }; }
+};
+
+/* FragLoader for MmaBf16_16x8x16 over row-major operand tiles reached through
+ * Read IOps. A is (M=16, K) row-major, B is (N=8, K) row-major; output D
+ * (16x8) is written through a Write IOp. The per-lane mapping (verified in
+ * test_collective_mma.h) lives here in the policy; the mainloop DPP doesn't
+ * know it. Operand elements are read via IOp::Operation::exec(Point), so no
+ * raw device pointer ever enters the DPP. */
+struct Bf16FragLoaderRowMajor {
+    using Atom = MmaBf16_16x8x16;
+
+    template <typename AIOp>
+    __device__ __forceinline__ uint32_t pack2(const AIOp& iop, int row, int col) const {
+        const __nv_bfloat16 x0 = AIOp::Operation::exec(Point{ col,     row, 0 }, iop.params);
+        const __nv_bfloat16 x1 = AIOp::Operation::exec(Point{ col + 1, row, 0 }, iop.params);
+        uint32_t r; __nv_bfloat16 two[2] = { x0, x1 }; memcpy(&r, two, 4); return r;
+    }
+    template <typename AIOp>
+    __device__ __forceinline__ void loadA(const AIOp& A, int lane, int kBase, uint32_t (&a)[4]) const {
+        const int g = lane >> 2, t = lane & 3;
+        a[0] = pack2(A, g,     kBase + 2 * t);
+        a[1] = pack2(A, g + 8, kBase + 2 * t);
+        a[2] = pack2(A, g,     kBase + 2 * t + 8);
+        a[3] = pack2(A, g + 8, kBase + 2 * t + 8);
+    }
+    template <typename BIOp>
+    __device__ __forceinline__ void loadB(const BIOp& B, int lane, int kBase, uint32_t (&b)[2]) const {
+        const int g = lane >> 2, t = lane & 3;
+        b[0] = pack2(B, g, kBase + 2 * t);
+        b[1] = pack2(B, g, kBase + 2 * t + 8);
+    }
+    template <typename WIOp>
+    __device__ __forceinline__ void storeD(const WIOp& D, int lane, const float (&d)[4]) const {
+        const int g = lane >> 2, t = lane & 3;
+        WIOp::Operation::exec(Point{ 2 * t,     g,     0 }, d[0], D.params);
+        WIOp::Operation::exec(Point{ 2 * t + 1, g,     0 }, d[1], D.params);
+        WIOp::Operation::exec(Point{ 2 * t,     g + 8, 0 }, d[2], D.params);
+        WIOp::Operation::exec(Point{ 2 * t + 1, g + 8, 0 }, d[3], D.params);
+    }
+};
+
+template <typename AIOp, typename BIOp, typename DIOp>
+__global__ void gemmTileKernel(AIOp aIOp, BIOp bIOp, DIOp dIOp, int K) {
+    const auto reads = make_tuple(aIOp, bIOp);
+    Bf16FragLoaderRowMajor loader;
+    TileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaBf16_16x8x16, Bf16FragLoaderRowMajor>::exec(
+        TileMmaMainloopDetails{ K }, reads, dIOp, loader);
+}
+
+static int failures = 0;
+
+static void runGemm(int K) {
+    std::mt19937 rng(11);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<float> Af(16*K), Bf(8*K);
+    for (auto& x : Af) x = dist(rng);
+    for (auto& x : Bf) x = dist(rng);
+    std::vector<__nv_bfloat16> Ah(16*K), Bh(8*K);
+    for (int i = 0; i < 16*K; ++i) Ah[i] = __float2bfloat16(Af[i]);
+    for (int i = 0; i < 8*K;  ++i) Bh[i] = __float2bfloat16(Bf[i]);
+
+    Ptr2D<__nv_bfloat16> A(K, 16), B(K, 8);
+    Ptr2D<float> D(8, 16);
+    cudaMemcpy2D(A.ptr().data, A.ptr().dims.pitch, Ah.data(), K*sizeof(__nv_bfloat16),
+                 K*sizeof(__nv_bfloat16), 16, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(B.ptr().data, B.ptr().dims.pitch, Bh.data(), K*sizeof(__nv_bfloat16),
+                 K*sizeof(__nv_bfloat16), 8, cudaMemcpyHostToDevice);
+
+    const auto aIOp = TileReadOp<__nv_bfloat16>::build(A.ptr());
+    const auto bIOp = TileReadOp<__nv_bfloat16>::build(B.ptr());
+    const auto dIOp = TileWriteOp<float>::build(D.ptr());
+    gemmTileKernel<<<1, 32>>>(aIOp, bIOp, dIOp, K);
+    cudaDeviceSynchronize();
+
+    std::vector<float> Dout(16*8);
+    cudaMemcpy2D(Dout.data(), 8*sizeof(float), D.ptr().data, D.ptr().dims.pitch,
+                 8*sizeof(float), 16, cudaMemcpyDeviceToHost);
+
+    double maxErr = 0;
+    for (int m = 0; m < 16; ++m)
+        for (int n = 0; n < 8; ++n) {
+            double acc = 0;
+            for (int k = 0; k < K; ++k)
+                acc += (double)__bfloat162float(Ah[m*K+k]) * (double)__bfloat162float(Bh[n*K+k]);
+            maxErr = std::max(maxErr, std::abs((double)Dout[m*8+n] - acc));
+        }
+    const double tol = 5e-2 * (K / 16.0);
+    if (maxErr > tol) { printf("FAIL gemm K=%d maxErr=%.4e (tol %.3e)\n", K, maxErr, tol); ++failures; }
+    else printf("TileMmaMainloopDPP GEMM 16x8x%-4d vs fp64 oracle: PASS (maxErr=%.2e)\n", K, maxErr);
+}
+
+int launch() {
+    runGemm(16);    // single atom (loop runs once)
+    runGemm(64);    // 4 K-tiles
+    runGemm(256);   // 16 K-tiles — real accumulation over the loop
+    return failures == 0 ? 0 : -1;
+}

--- a/tests/collective/test_collective_mma.h
+++ b/tests/collective/test_collective_mma.h
@@ -58,9 +58,8 @@ __global__ void mmaBf16Kernel(const __nv_bfloat16* A,   // 16x16 row-major (m,k)
     b[1] = pack(&B[g * 16 + 2 * t + 8]);
 
     float d[4] = {};
-    // Through the FKL Op: bundle the per-lane fragments and accumulate.
-    MmaFragment<MmaBf16_16x8x16> frag{ a, b, d };
-    MmaBf16Op::exec(frag);
+    // Warp-collective MMA through the DPP: all 32 lanes cooperate.
+    MmaBf16WarpDPP::exec(a, b, d);
 
     D[(g)     * 8 + 2 * t]     = d[0];
     D[(g)     * 8 + 2 * t + 1] = d[1];
@@ -71,12 +70,9 @@ __global__ void mmaBf16Kernel(const __nv_bfloat16* A,   // 16x16 row-major (m,k)
 __global__ void cpAsyncKernel(const float* gsrc, float* gdst, int n4) {
     extern __shared__ float smem[];
     const int tid = threadIdx.x;
-    // Stage gmem->smem through the FKL Op (16-byte chunks via int4).
-    using Stage = fk::CpAsyncStage16Op<int4>;
-    const auto params = Stage::Params{ reinterpret_cast<int4*>(smem),
-                                       reinterpret_cast<const int4*>(gsrc) };
-    for (int i = tid; i < n4; i += blockDim.x)
-        Stage::exec(Point{ i, 0, 0 }, params);
+    // Stage gmem->smem cooperatively through the DPP (16-byte chunks via int4).
+    fk::CpAsyncStageDPP<int4, 128>::stage(reinterpret_cast<int4*>(smem),
+                                          reinterpret_cast<const int4*>(gsrc), n4);
     fk::cpAsyncCommit();
     fk::cpAsyncWaitGroups<0>();
     __syncthreads();

--- a/tests/collective/test_collective_mma.h
+++ b/tests/collective/test_collective_mma.h
@@ -1,0 +1,143 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__  // tensor-core MMA + cp.async are device-only
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+/* Verify MmaBf16_16x8x16 against an fp64 oracle. The per-lane fragment
+ * mapping for m16n8k16 (PTX ISA), VERIFIED here against the oracle:
+ *   group g = lane>>2, tig t = lane&3; each .b32 packs 2 consecutive-k bf16
+ *   A (16x16 row-major, m,k): a0=row g   k[2t,2t+1]; a1=row g+8 k[2t,2t+1]
+ *                             a2=row g   k[2t+8,..]; a3=row g+8 k[2t+8,..]
+ *   B (.col => 8x16 row-major, n,k): b0=col g k[2t,2t+1]; b1=col g k[2t+8,..]
+ *   D (16x8 f32): d0,d1 = row g cols 2t,2t+1 ; d2,d3 = row g+8 cols 2t,2t+1
+ * This is the bf16 analogue of the fp8 mapping validated in
+ * spikes/spike_fp8_qk_mapping.cu. */
+__global__ void mmaBf16Kernel(const __nv_bfloat16* A,   // 16x16 row-major (m,k)
+                              const __nv_bfloat16* B,   // 8x16  row-major (n,k)
+                              float* D) {                // 16x8 row-major (m,n)
+    const int lane = threadIdx.x;
+    const int g = lane >> 2, t = lane & 3;
+    uint32_t a[4], b[2];
+    auto pack = [](const __nv_bfloat16* p) {
+        uint32_t r; __nv_bfloat16 two[2] = { p[0], p[1] };
+        memcpy(&r, two, 4); return r;
+    };
+    // m16n8k16: each .b32 packs 2 consecutive-k bf16. tig t in [0,4).
+    // a0: row g    , k = 2t, 2t+1        a1: row g+8 , k = 2t, 2t+1
+    // a2: row g    , k = 2t+8, 2t+9      a3: row g+8 , k = 2t+8, 2t+9
+    a[0] = pack(&A[(g)     * 16 + 2 * t]);
+    a[1] = pack(&A[(g + 8) * 16 + 2 * t]);
+    a[2] = pack(&A[(g)     * 16 + 2 * t + 8]);
+    a[3] = pack(&A[(g + 8) * 16 + 2 * t + 8]);
+    // B operand .col => stored (n,k) row-major; lane holds col n=g.
+    // b0: k = 2t, 2t+1     b1: k = 2t+8, 2t+9
+    b[0] = pack(&B[g * 16 + 2 * t]);
+    b[1] = pack(&B[g * 16 + 2 * t + 8]);
+
+    float d[4] = {};
+    // Through the FKL Op: bundle the per-lane fragments and accumulate.
+    MmaFragment<MmaBf16_16x8x16> frag{ a, b, d };
+    MmaBf16Op::exec(frag);
+
+    D[(g)     * 8 + 2 * t]     = d[0];
+    D[(g)     * 8 + 2 * t + 1] = d[1];
+    D[(g + 8) * 8 + 2 * t]     = d[2];
+    D[(g + 8) * 8 + 2 * t + 1] = d[3];
+}
+
+__global__ void cpAsyncKernel(const float* gsrc, float* gdst, int n4) {
+    extern __shared__ float smem[];
+    const int tid = threadIdx.x;
+    // Stage gmem->smem through the FKL Op (16-byte chunks via int4).
+    using Stage = fk::CpAsyncStage16Op<int4>;
+    const auto params = Stage::Params{ reinterpret_cast<int4*>(smem),
+                                       reinterpret_cast<const int4*>(gsrc) };
+    for (int i = tid; i < n4; i += blockDim.x)
+        Stage::exec(Point{ i, 0, 0 }, params);
+    fk::cpAsyncCommit();
+    fk::cpAsyncWaitGroups<0>();
+    __syncthreads();
+    for (int i = tid; i < n4; i += blockDim.x)
+        reinterpret_cast<float4*>(gdst)[i] = reinterpret_cast<float4*>(smem)[i];
+}
+
+static int failures = 0;
+
+static void testMma() {
+    std::mt19937 rng(3);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<float> Af(16*16), Bf(8*16);
+    for (auto& x : Af) x = dist(rng);
+    for (auto& x : Bf) x = dist(rng);
+    std::vector<__nv_bfloat16> Ah(16*16), Bh(8*16);
+    for (int i = 0; i < 16*16; ++i) Ah[i] = __float2bfloat16(Af[i]);
+    for (int i = 0; i < 8*16;  ++i) Bh[i] = __float2bfloat16(Bf[i]);
+
+    __nv_bfloat16 *dA, *dB; float* dD;
+    cudaMalloc(&dA, 16*16*2); cudaMalloc(&dB, 8*16*2); cudaMalloc(&dD, 16*8*4);
+    cudaMemcpy(dA, Ah.data(), 16*16*2, cudaMemcpyHostToDevice);
+    cudaMemcpy(dB, Bh.data(), 8*16*2, cudaMemcpyHostToDevice);
+    mmaBf16Kernel<<<1, 32>>>(dA, dB, dD);
+    cudaDeviceSynchronize();
+    std::vector<float> D(16*8); cudaMemcpy(D.data(), dD, 16*8*4, cudaMemcpyDeviceToHost);
+    cudaFree(dA); cudaFree(dB); cudaFree(dD);
+
+    // fp64 oracle using the bf16-rounded inputs (mma rounds inputs to bf16).
+    // A is (m,k) row-major; B is (n,k) row-major -> D[m,n] = sum_k A[m,k]*B[n,k].
+    double maxErr = 0;
+    for (int m = 0; m < 16; ++m)
+        for (int n = 0; n < 8; ++n) {
+            double acc = 0;
+            for (int k = 0; k < 16; ++k)
+                acc += (double)__bfloat162float(Ah[m*16+k]) * (double)__bfloat162float(Bh[n*16+k]);
+            maxErr = std::max(maxErr, std::abs((double)D[m*8+n] - acc));
+        }
+    // bf16 mantissa ~8 bits; k=16 accumulate in f32 -> small abs error
+    if (maxErr > 5e-2) { printf("FAIL MmaBf16 maxErr=%.4e\n", maxErr); ++failures; }
+    else printf("MmaBf16_16x8x16 vs fp64 oracle: PASS (maxErr=%.2e)\n", maxErr);
+}
+
+static void testCpAsync() {
+    const int n4 = 64;          // 64 float4 = 256 floats
+    std::vector<float> src(n4*4), dst(n4*4, -1.f);
+    for (int i = 0; i < n4*4; ++i) src[i] = (float)i;
+    float *dS, *dD; cudaMalloc(&dS, n4*16); cudaMalloc(&dD, n4*16);
+    cudaMemcpy(dS, src.data(), n4*16, cudaMemcpyHostToDevice);
+    cpAsyncKernel<<<1, 128, n4*16>>>(dS, dD, n4);
+    cudaDeviceSynchronize();
+    cudaMemcpy(dst.data(), dD, n4*16, cudaMemcpyDeviceToHost);
+    cudaFree(dS); cudaFree(dD);
+    bool ok = true;
+    for (int i = 0; i < n4*4; ++i) ok &= (dst[i] == (float)i);
+    if (ok) printf("cpAsync16 global->smem->global round-trip: PASS\n");
+    else { printf("FAIL cpAsync16 round-trip\n"); ++failures; }
+}
+
+int launch() {
+    testMma();
+    testCpAsync();
+    return failures == 0 ? 0 : -1;
+}

--- a/tests/collective/test_collective_multistage.h
+++ b/tests/collective/test_collective_multistage.h
@@ -1,0 +1,150 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__  // multi-stage cp.async device-only pipeline
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/multistage.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+template <typename T>
+struct TileReadOp {
+    using Operation = TileReadOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static T exec(const Point thread, const ParamsType& p) {
+        return *PtrAccessor<ND::_2D>::template cr_point<T, T>(thread, p.ptr);
+    }
+    __host__ static TileReadOp build(const RawPtr<ND::_2D, T>& r) { return TileReadOp{ { r } }; }
+};
+template <typename T>
+struct TileWriteOp {
+    using Operation = TileWriteOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static void exec(const Point thread, const T value, const ParamsType& p) {
+        *PtrAccessor<ND::_2D>::template point<T, T>(thread, p.ptr) = value;
+    }
+    __host__ static TileWriteOp build(const RawPtr<ND::_2D, T>& r) { return TileWriteOp{ { r } }; }
+};
+
+/* smem ring: STAGES buffers, each one MmaBf16 K-tile (16x16 A + 8x16 B). */
+template <int STAGES>
+struct Ring { __nv_bfloat16 A[STAGES][16*16]; __nv_bfloat16 B[STAGES][8*16]; };
+
+/* StagePolicy: stages a K-tile gmem->smem ring slot through the Read IOps,
+ * accumulates a 16x8 atom per compute() call, and writes via the Write IOp. */
+struct GemmStage {
+    using Atom = MmaBf16_16x8x16;
+    float d[4] = {0,0,0,0};
+    int lane;
+    __device__ GemmStage(int lane_) : lane(lane_) {}
+
+    template <typename ReadIOps, typename RingT>
+    __device__ __forceinline__ void stage(const ReadIOps& reads, int buf, int kTile, RingT& ring) const {
+        const auto& A = get<0>(reads); const auto& B = get<1>(reads);
+        using AOp = std::decay_t<decltype(A)>; using BOp = std::decay_t<decltype(B)>;
+        for (int i = lane; i < 16*16; i += 32) {
+            const int r = i/16, c = i%16;
+            ring.A[buf][i] = AOp::Operation::exec(Point{ kTile*16 + c, r, 0 }, A.params);
+        }
+        for (int i = lane; i < 8*16; i += 32) {
+            const int r = i/16, c = i%16;
+            ring.B[buf][i] = BOp::Operation::exec(Point{ kTile*16 + c, r, 0 }, B.params);
+        }
+    }
+    __device__ __forceinline__ static uint32_t p2(const __nv_bfloat16* p) {
+        uint32_t r; __nv_bfloat16 t[2] = { p[0], p[1] }; memcpy(&r, t, 4); return r; }
+    template <typename RingT>
+    __device__ __forceinline__ void compute(int buf, RingT& ring) {
+        const int g = lane >> 2, t = lane & 3;
+        const __nv_bfloat16* sA = ring.A[buf]; const __nv_bfloat16* sB = ring.B[buf];
+        uint32_t a[4], b[2];
+        a[0]=p2(&sA[g*16+2*t]); a[1]=p2(&sA[(g+8)*16+2*t]);
+        a[2]=p2(&sA[g*16+2*t+8]); a[3]=p2(&sA[(g+8)*16+2*t+8]);
+        b[0]=p2(&sB[g*16+2*t]); b[1]=p2(&sB[g*16+2*t+8]);
+        MmaWarpDPP<Atom>::exec(a, b, d);
+    }
+    template <typename WIOp>
+    __device__ __forceinline__ void epilogue(const WIOp& D) const {
+        const int g = lane >> 2, t = lane & 3;
+        WIOp::Operation::exec(Point{ 2*t,   g,   0 }, d[0], D.params);
+        WIOp::Operation::exec(Point{ 2*t+1, g,   0 }, d[1], D.params);
+        WIOp::Operation::exec(Point{ 2*t,   g+8, 0 }, d[2], D.params);
+        WIOp::Operation::exec(Point{ 2*t+1, g+8, 0 }, d[3], D.params);
+    }
+};
+
+template <int STAGES, typename AIOp, typename BIOp, typename DIOp>
+__global__ void multistageGemmKernel(AIOp aIOp, BIOp bIOp, DIOp dIOp, int K) {
+    __shared__ Ring<STAGES> ring;
+    const int lane = threadIdx.x;
+    const auto reads = make_tuple(aIOp, bIOp);
+    GemmStage stage(lane);
+    MultiStageMainloopDPP<ParArch::GPU_NVIDIA, STAGES, GemmStage>::exec(
+        MultiStageDetails{ K / 16 }, reads, dIOp, stage, ring);
+}
+
+static int failures = 0;
+
+template <int STAGES>
+static void runGemm(int K) {
+    std::mt19937 rng(13);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<float> Af(16*K), Bf(8*K);
+    for (auto& x : Af) x = dist(rng);
+    for (auto& x : Bf) x = dist(rng);
+    std::vector<__nv_bfloat16> Ah(16*K), Bh(8*K);
+    for (int i=0;i<16*K;++i) Ah[i]=__float2bfloat16(Af[i]);
+    for (int i=0;i<8*K;++i)  Bh[i]=__float2bfloat16(Bf[i]);
+
+    Ptr2D<__nv_bfloat16> A(K, 16), B(K, 8);
+    Ptr2D<float> D(8, 16);
+    cudaMemcpy2D(A.ptr().data, A.ptr().dims.pitch, Ah.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), 16, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(B.ptr().data, B.ptr().dims.pitch, Bh.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), 8, cudaMemcpyHostToDevice);
+
+    const auto aIOp = TileReadOp<__nv_bfloat16>::build(A.ptr());
+    const auto bIOp = TileReadOp<__nv_bfloat16>::build(B.ptr());
+    const auto dIOp = TileWriteOp<float>::build(D.ptr());
+    multistageGemmKernel<STAGES><<<1,32>>>(aIOp, bIOp, dIOp, K);
+    cudaDeviceSynchronize();
+
+    std::vector<float> Dout(16*8);
+    cudaMemcpy2D(Dout.data(), 8*sizeof(float), D.ptr().data, D.ptr().dims.pitch, 8*sizeof(float), 16, cudaMemcpyDeviceToHost);
+
+    double maxErr = 0;
+    for (int m=0;m<16;++m) for (int n=0;n<8;++n) {
+        double acc=0; for (int k=0;k<K;++k) acc += (double)__bfloat162float(Ah[m*K+k])*(double)__bfloat162float(Bh[n*K+k]);
+        maxErr = std::max(maxErr, std::abs((double)Dout[m*8+n]-acc));
+    }
+    const double tol = 5e-2 * (K/16.0);
+    if (maxErr > tol) { printf("FAIL multistage STAGES=%d K=%d maxErr=%.4e\n", STAGES, K, maxErr); ++failures; }
+    else printf("MultiStageMainloopDPP STAGES=%d GEMM 16x8x%-4d vs fp64: PASS (maxErr=%.2e)\n", STAGES, K, maxErr);
+}
+
+int launch() {
+    runGemm<2>(64);    // double buffer
+    runGemm<3>(128);   // 3-stage
+    runGemm<4>(256);   // 4-stage
+    return failures == 0 ? 0 : -1;
+}

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -17,6 +17,9 @@
 #include <fused_kernel/algorithms/collective/reduce.h>
 #include <fused_kernel/algorithms/basic_ops/arithmetic.h>
 #include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/execution_model/stream.h>
 #include "tests/nvtx.h"
 
 #include <vector>
@@ -127,6 +130,44 @@ static bool runDeviceChecks() {
     }
     return ok;
 }
+
+/* End-to-end ReduceDPP test: input via a Read IOp (PerThreadRead), output via
+ * a Write IOp (PerThreadWrite), one reduced value per row — the full FKL
+ * contract (read IOp -> reduce over standard Op -> write IOp). */
+static bool runReduceDPPChecks() {
+    using namespace fk;
+    bool ok = true;
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(-5.f, 5.f);
+
+    const int rows = 17, width = 4096 + 11;
+    std::vector<float> h(rows * width);
+    for (auto& x : h) x = dist(rng);
+
+    Ptr2D<float> input(width, rows);
+    Ptr1D<float> output(rows);
+    cudaMemcpy2D(input.ptr().data, input.ptr().dims.pitch,
+                 h.data(), width * sizeof(float),
+                 width * sizeof(float), rows, cudaMemcpyHostToDevice);
+
+    Stream stream;
+    const auto readIOp  = PerThreadRead<ND::_2D, float>::build(input);
+    const auto writeIOp = PerThreadWrite<ND::_1D, float>::build(output);
+
+    executeReduce<SumOp>(readIOp, writeIOp, rows, width, 0.f, stream);
+    stream.sync();
+
+    std::vector<float> got(rows);
+    cudaMemcpy(got.data(), output.ptr().data, rows * sizeof(float), cudaMemcpyDeviceToHost);
+
+    for (int r = 0; r < rows; ++r) {
+        float ref = 0.f;
+        for (int c = 0; c < width; ++c) ref += h[r * width + c];
+        const bool okr = std::fabs(got[r] - ref) <= 1e-3f * std::fmax(1.f, std::fabs(ref));
+        if (!okr) { printf("  ReduceDPP row %d got=%.4f ref=%.4f FAIL\n", r, got[r], ref); ok = false; }
+    }
+    return ok;
+}
 #endif // __NVCC__
 
 int launch() {
@@ -145,6 +186,10 @@ int launch() {
     {
         PUSH_RANGE_RAII p("collective_reduce_device");
         passed &= runDeviceChecks();
+    }
+    {
+        PUSH_RANGE_RAII p("reduce_dpp_iop_e2e");
+        passed &= runReduceDPPChecks();
     }
 #endif
     return passed ? 0 : -1;

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -1,0 +1,117 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/reduce.h>
+#include "tests/nvtx.h"
+
+#include <vector>
+#include <random>
+#include <cmath>
+
+/* CPU pass: exercise the associative combine functors and the serial fold
+ * oracle (serialReduce). These compile and run on the g++ CPU TU too, so
+ * the math of the combine functors is covered without a GPU.
+ * CUDA pass: additionally launch warpReduce / blockReduce kernels and
+ * cross-check them against the same serial oracle. */
+
+template <typename Combine>
+static bool combineMatchesFold(const std::vector<float>& data, float init) {
+    Combine c;
+    float acc = init;
+    for (float x : data) acc = c(acc, x);
+    const float ref = fk::serialReduce<Combine>(data.data(), (int)data.size(), init, c);
+    return std::fabs(acc - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
+}
+
+#if defined(__NVCC__)
+#include <cstdio>
+
+template <typename Combine, int BLOCK_SIZE>
+__global__ void blockReduceKernel(const float* in, float* out, int n, float init) {
+    __shared__ float scratch[BLOCK_SIZE / 32];
+    float acc = init;
+    for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) acc = Combine{}(acc, in[i]);
+    const float r = fk::blockReduce<Combine, BLOCK_SIZE>(acc, scratch, Combine{}, true);
+    if (threadIdx.x == 0) *out = r;
+}
+
+template <int WARP_WIDTH>
+__global__ void warpReduceSumKernel(const float* in, float* out) {
+    float v = in[threadIdx.x];
+    out[threadIdx.x] = fk::warpReduce<fk::ReduceSum<float>, WARP_WIDTH>(v);
+}
+
+template <typename Combine, int BLOCK_SIZE>
+static bool checkBlock(const std::vector<float>& h, float init) {
+    float *d, *dout; cudaMalloc(&d, h.size()*4); cudaMalloc(&dout, 4);
+    cudaMemcpy(d, h.data(), h.size()*4, cudaMemcpyHostToDevice);
+    blockReduceKernel<Combine, BLOCK_SIZE><<<1, BLOCK_SIZE>>>(d, dout, (int)h.size(), init);
+    cudaDeviceSynchronize();
+    float got; cudaMemcpy(&got, dout, 4, cudaMemcpyDeviceToHost);
+    cudaFree(d); cudaFree(dout);
+    Combine c; float ref = init; for (float x : h) ref = c(ref, x);
+    const bool ok = std::fabs(got - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
+    if (!ok) printf("  blockReduce<BS=%d> got=%.5f ref=%.5f FAIL\n", BLOCK_SIZE, got, ref);
+    return ok;
+}
+
+static bool runDeviceChecks() {
+    bool ok = true;
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-5.f, 5.f);
+
+    // warpReduce sum across 32 lanes, broadcast to every lane
+    std::vector<float> w(32); for (auto& x : w) x = dist(rng);
+    float *d, *dout; cudaMalloc(&d, 128); cudaMalloc(&dout, 128);
+    cudaMemcpy(d, w.data(), 128, cudaMemcpyHostToDevice);
+    warpReduceSumKernel<32><<<1, 32>>>(d, dout);
+    cudaDeviceSynchronize();
+    std::vector<float> got(32); cudaMemcpy(got.data(), dout, 128, cudaMemcpyDeviceToHost);
+    cudaFree(d); cudaFree(dout);
+    float ref = 0; for (float x : w) ref += x;
+    for (int lane : {0, 1, 17, 31})
+        ok &= std::fabs(got[lane] - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
+
+    // blockReduce sum + max, several block sizes and a non-divisible count
+    std::vector<float> big(4096 + 37); for (auto& x : big) x = dist(rng);
+    ok &= checkBlock<fk::ReduceSum<float>, 128>(big, 0.f);
+    ok &= checkBlock<fk::ReduceSum<float>, 256>(big, 0.f);
+    ok &= checkBlock<fk::ReduceMax<float>, 256>(big, -3.4e38f);
+    ok &= checkBlock<fk::ReduceMax<float>, 512>(big, -3.4e38f);
+    return ok;
+}
+#endif // __NVCC__
+
+int launch() {
+    bool passed = true;
+    std::mt19937 rng(7);
+    std::uniform_real_distribution<float> dist(-5.f, 5.f);
+    std::vector<float> data(100); for (auto& x : data) x = dist(rng);
+
+    {
+        PUSH_RANGE_RAII p("combine_functors_cpu");
+        passed &= combineMatchesFold<fk::ReduceSum<float>>(data, 0.f);
+        passed &= combineMatchesFold<fk::ReduceMax<float>>(data, -3.4e38f);
+        passed &= combineMatchesFold<fk::ReduceMin<float>>(data, 3.4e38f);
+    }
+#if defined(__NVCC__)
+    {
+        PUSH_RANGE_RAII p("collective_reduce_device");
+        passed &= runDeviceChecks();
+    }
+#endif
+    return passed ? 0 : -1;
+}

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -15,56 +15,71 @@
 #include <tests/main.h>
 
 #include <fused_kernel/algorithms/collective/reduce.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
 #include "tests/nvtx.h"
 
 #include <vector>
 #include <random>
 #include <cmath>
 
-/* CPU pass: exercise the associative combine functors and the serial fold
- * oracle (serialReduce). These compile and run on the g++ CPU TU too, so
- * the math of the combine functors is covered without a GPU.
- * CUDA pass: additionally launch warpReduce / blockReduce kernels and
- * cross-check them against the same serial oracle. */
+/* The reduction operator is a STANDARD FKL binary Op (Add / Max / Min),
+ * passed as a template argument to the Reduce*DPP. No bespoke combine
+ * functors, no duplicated reduction code.
+ *
+ * CPU pass: exercise serialReduce (the oracle) against a hand fold using the
+ * same Op. CUDA pass: additionally launch ReduceWarpDPP / ReduceBlockDPP /
+ * ReduceGridDPP and cross-check them against the same serial oracle. */
 
-template <typename Combine>
-static bool combineMatchesFold(const std::vector<float>& data, float init) {
-    Combine c;
+using SumOp = fk::Add<float, float, float, fk::BinaryType>;
+using MaxOp = fk::Max<float, float, float, fk::BinaryType>;
+using MinOp = fk::Min<float, float, float, fk::BinaryType>;
+
+template <typename ReduceOp>
+static bool foldMatchesOracle(const std::vector<float>& data, float init) {
     float acc = init;
-    for (float x : data) acc = c(acc, x);
-    const float ref = fk::serialReduce<Combine>(data.data(), (int)data.size(), init, c);
+    for (float x : data) acc = ReduceOp::exec(acc, x);
+    const float ref = fk::serialReduce<ReduceOp>(data.data(), (int)data.size(), init);
     return std::fabs(acc - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
 }
 
 #if defined(__NVCC__)
 #include <cstdio>
 
-template <typename Combine, int BLOCK_SIZE>
+template <typename ReduceOp, int BLOCK_SIZE>
 __global__ void blockReduceKernel(const float* in, float* out, int n, float init) {
     __shared__ float scratch[BLOCK_SIZE / 32];
     float acc = init;
-    for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) acc = Combine{}(acc, in[i]);
-    const float r = fk::blockReduce<Combine, BLOCK_SIZE>(acc, scratch, Combine{}, true);
+    for (int i = threadIdx.x; i < n; i += BLOCK_SIZE) acc = ReduceOp::exec(acc, in[i]);
+    const float r = fk::ReduceBlockDPP<ReduceOp, BLOCK_SIZE>::exec(acc, scratch, true);
     if (threadIdx.x == 0) *out = r;
 }
 
 template <int WARP_WIDTH>
 __global__ void warpReduceSumKernel(const float* in, float* out) {
     float v = in[threadIdx.x];
-    out[threadIdx.x] = fk::warpReduce<fk::ReduceSum<float>, WARP_WIDTH>(v);
+    out[threadIdx.x] = fk::ReduceWarpDPP<SumOp, WARP_WIDTH>::exec(v);
 }
 
-template <typename Combine, int BLOCK_SIZE>
+template <typename ReduceOp, int BLOCK_SIZE>
+__global__ void gridReduceKernel(const float* in, float* gAccum, int n) {
+    __shared__ float scratch[BLOCK_SIZE / 32];
+    float acc = (blockIdx.x * BLOCK_SIZE + threadIdx.x < n)
+              ? in[blockIdx.x * BLOCK_SIZE + threadIdx.x] : 0.f;
+    fk::ReduceGridDPP<ReduceOp, BLOCK_SIZE>::exec(acc, scratch, gAccum);
+}
+
+template <typename ReduceOp, int BLOCK_SIZE>
 static bool checkBlock(const std::vector<float>& h, float init) {
     float *d, *dout; cudaMalloc(&d, h.size()*4); cudaMalloc(&dout, 4);
     cudaMemcpy(d, h.data(), h.size()*4, cudaMemcpyHostToDevice);
-    blockReduceKernel<Combine, BLOCK_SIZE><<<1, BLOCK_SIZE>>>(d, dout, (int)h.size(), init);
+    blockReduceKernel<ReduceOp, BLOCK_SIZE><<<1, BLOCK_SIZE>>>(d, dout, (int)h.size(), init);
     cudaDeviceSynchronize();
     float got; cudaMemcpy(&got, dout, 4, cudaMemcpyDeviceToHost);
     cudaFree(d); cudaFree(dout);
-    Combine c; float ref = init; for (float x : h) ref = c(ref, x);
+    float ref = init; for (float x : h) ref = ReduceOp::exec(ref, x);
     const bool ok = std::fabs(got - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
-    if (!ok) printf("  blockReduce<BS=%d> got=%.5f ref=%.5f FAIL\n", BLOCK_SIZE, got, ref);
+    if (!ok) printf("  ReduceBlockDPP<BS=%d> got=%.5f ref=%.5f FAIL\n", BLOCK_SIZE, got, ref);
     return ok;
 }
 
@@ -73,7 +88,7 @@ static bool runDeviceChecks() {
     std::mt19937 rng(42);
     std::uniform_real_distribution<float> dist(-5.f, 5.f);
 
-    // warpReduce sum across 32 lanes, broadcast to every lane
+    // ReduceWarpDPP sum across 32 lanes, broadcast to every lane
     std::vector<float> w(32); for (auto& x : w) x = dist(rng);
     float *d, *dout; cudaMalloc(&d, 128); cudaMalloc(&dout, 128);
     cudaMemcpy(d, w.data(), 128, cudaMemcpyHostToDevice);
@@ -85,12 +100,31 @@ static bool runDeviceChecks() {
     for (int lane : {0, 1, 17, 31})
         ok &= std::fabs(got[lane] - ref) <= 1e-5f * std::fmax(1.f, std::fabs(ref));
 
-    // blockReduce sum + max, several block sizes and a non-divisible count
+    // ReduceBlockDPP sum + max, several block sizes and a non-divisible count
     std::vector<float> big(4096 + 37); for (auto& x : big) x = dist(rng);
-    ok &= checkBlock<fk::ReduceSum<float>, 128>(big, 0.f);
-    ok &= checkBlock<fk::ReduceSum<float>, 256>(big, 0.f);
-    ok &= checkBlock<fk::ReduceMax<float>, 256>(big, -3.4e38f);
-    ok &= checkBlock<fk::ReduceMax<float>, 512>(big, -3.4e38f);
+    ok &= checkBlock<SumOp, 128>(big, 0.f);
+    ok &= checkBlock<SumOp, 256>(big, 0.f);
+    ok &= checkBlock<MaxOp, 256>(big, -3.4e38f);
+    ok &= checkBlock<MaxOp, 512>(big, -3.4e38f);
+
+    // ReduceGridDPP sum across a multi-block grid, atomic combine into gAccum
+    {
+        constexpr int BS = 256;
+        std::vector<float> g(4096 + 37); for (auto& x : g) x = dist(rng);
+        const int n = (int)g.size();
+        const int blocks = (n + BS - 1) / BS;
+        float *dg, *dacc; cudaMalloc(&dg, n*4); cudaMalloc(&dacc, 4);
+        cudaMemcpy(dg, g.data(), n*4, cudaMemcpyHostToDevice);
+        float zero = 0.f; cudaMemcpy(dacc, &zero, 4, cudaMemcpyHostToDevice);
+        gridReduceKernel<SumOp, BS><<<blocks, BS>>>(dg, dacc, n);
+        cudaDeviceSynchronize();
+        float gotg; cudaMemcpy(&gotg, dacc, 4, cudaMemcpyDeviceToHost);
+        cudaFree(dg); cudaFree(dacc);
+        float refg = 0.f; for (float x : g) refg += x;
+        const bool okg = std::fabs(gotg - refg) <= 1e-3f * std::fmax(1.f, std::fabs(refg));
+        if (!okg) printf("  ReduceGridDPP<Sum> got=%.4f ref=%.4f FAIL\n", gotg, refg);
+        ok &= okg;
+    }
     return ok;
 }
 #endif // __NVCC__
@@ -102,10 +136,10 @@ int launch() {
     std::vector<float> data(100); for (auto& x : data) x = dist(rng);
 
     {
-        PUSH_RANGE_RAII p("combine_functors_cpu");
-        passed &= combineMatchesFold<fk::ReduceSum<float>>(data, 0.f);
-        passed &= combineMatchesFold<fk::ReduceMax<float>>(data, -3.4e38f);
-        passed &= combineMatchesFold<fk::ReduceMin<float>>(data, 3.4e38f);
+        PUSH_RANGE_RAII p("reduce_ops_cpu");
+        passed &= foldMatchesOracle<SumOp>(data, 0.f);
+        passed &= foldMatchesOracle<MaxOp>(data, -3.4e38f);
+        passed &= foldMatchesOracle<MinOp>(data, 3.4e38f);
     }
 #if defined(__NVCC__)
     {

--- a/tests/collective/test_collective_register_tile.h
+++ b/tests/collective/test_collective_register_tile.h
@@ -1,0 +1,135 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__  // register-tiled device-only mainloop
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/register_tile.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/data/tuple.h>
+
+#include <cstdio>
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cuda_bf16.h>
+
+using namespace fk;
+
+template <typename T>
+struct TileReadOp {
+    using Operation = TileReadOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static T exec(const Point thread, const ParamsType& p) {
+        return *PtrAccessor<ND::_2D>::template cr_point<T, T>(thread, p.ptr);
+    }
+    __host__ static TileReadOp build(const RawPtr<ND::_2D, T>& r) { return TileReadOp{ { r } }; }
+};
+template <typename T>
+struct TileWriteOp {
+    using Operation = TileWriteOp<T>;
+    struct ParamsType { RawPtr<ND::_2D, T> ptr; };
+    ParamsType params;
+    __device__ __forceinline__ static void exec(const Point thread, const T value, const ParamsType& p) {
+        *PtrAccessor<ND::_2D>::template point<T, T>(thread, p.ptr) = value;
+    }
+    __host__ static TileWriteOp build(const RawPtr<ND::_2D, T>& r) { return TileWriteOp{ { r } }; }
+};
+
+/* RegTile fragment loader: A is (16*WM, K) row-major, B is (8*WN, K) row-major,
+ * D is (16*WM, 8*WN) row-major — all reached through IOps. rowAtom/colAtom
+ * select the sub-tile within the warp's WM x WN block. Mapping verified in
+ * test_collective_mma.h. */
+struct RegTileLoader {
+    using Atom = MmaBf16_16x8x16;
+    template <typename IOp>
+    __device__ __forceinline__ uint32_t pk(const IOp&, const typename IOp::ParamsType& pr, int row, int col) const {
+        const __nv_bfloat16 x0 = IOp::Operation::exec(Point{ col,     row, 0 }, pr);
+        const __nv_bfloat16 x1 = IOp::Operation::exec(Point{ col + 1, row, 0 }, pr);
+        uint32_t r; __nv_bfloat16 two[2] = { x0, x1 }; memcpy(&r, two, 4); return r;
+    }
+    template <typename AIOp>
+    __device__ __forceinline__ void loadA(const AIOp& A, int rowAtom, int kBase, int lane, uint32_t (&a)[4]) const {
+        const int g = lane >> 2, t = lane & 3, rb = rowAtom * 16;
+        a[0]=pk(A,A.params, rb+g,   kBase+2*t);   a[1]=pk(A,A.params, rb+g+8, kBase+2*t);
+        a[2]=pk(A,A.params, rb+g,   kBase+2*t+8); a[3]=pk(A,A.params, rb+g+8, kBase+2*t+8);
+    }
+    template <typename BIOp>
+    __device__ __forceinline__ void loadB(const BIOp& B, int colAtom, int kBase, int lane, uint32_t (&b)[2]) const {
+        const int g = lane >> 2, t = lane & 3, cb = colAtom * 8;
+        b[0]=pk(B,B.params, cb+g, kBase+2*t); b[1]=pk(B,B.params, cb+g, kBase+2*t+8);
+    }
+    template <typename WIOp>
+    __device__ __forceinline__ void storeD(const WIOp& D, int rowAtom, int colAtom, int lane, const float (&d)[4]) const {
+        const int g = lane >> 2, t = lane & 3, rb = rowAtom*16, cb = colAtom*8;
+        WIOp::Operation::exec(Point{ cb+2*t,   rb+g,   0 }, d[0], D.params);
+        WIOp::Operation::exec(Point{ cb+2*t+1, rb+g,   0 }, d[1], D.params);
+        WIOp::Operation::exec(Point{ cb+2*t,   rb+g+8, 0 }, d[2], D.params);
+        WIOp::Operation::exec(Point{ cb+2*t+1, rb+g+8, 0 }, d[3], D.params);
+    }
+};
+
+template <int WM, int WN, typename AIOp, typename BIOp, typename DIOp>
+__global__ void regTileGemmKernel(AIOp aIOp, BIOp bIOp, DIOp dIOp, int K) {
+    const auto reads = make_tuple(aIOp, bIOp);
+    RegTileLoader loader;
+    WarpTileMmaMainloopDPP<ParArch::GPU_NVIDIA, MmaBf16_16x8x16, WM, WN, RegTileLoader>::exec(
+        WarpTileMainloopDetails{ K }, reads, dIOp, loader);
+}
+
+static int failures = 0;
+
+template <int WM, int WN>
+static void runCase(int K) {
+    constexpr int M = 16 * WM, N = 8 * WN;
+    std::mt19937 rng(9);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<float> Af(M*K), Bf(N*K);
+    for (auto& x : Af) x = dist(rng);
+    for (auto& x : Bf) x = dist(rng);
+    std::vector<__nv_bfloat16> Ah(M*K), Bh(N*K);
+    for (int i=0;i<M*K;++i) Ah[i]=__float2bfloat16(Af[i]);
+    for (int i=0;i<N*K;++i) Bh[i]=__float2bfloat16(Bf[i]);
+
+    Ptr2D<__nv_bfloat16> A(K, M), B(K, N);
+    Ptr2D<float> D(N, M);
+    cudaMemcpy2D(A.ptr().data, A.ptr().dims.pitch, Ah.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), M, cudaMemcpyHostToDevice);
+    cudaMemcpy2D(B.ptr().data, B.ptr().dims.pitch, Bh.data(), K*sizeof(__nv_bfloat16), K*sizeof(__nv_bfloat16), N, cudaMemcpyHostToDevice);
+
+    const auto aIOp = TileReadOp<__nv_bfloat16>::build(A.ptr());
+    const auto bIOp = TileReadOp<__nv_bfloat16>::build(B.ptr());
+    const auto dIOp = TileWriteOp<float>::build(D.ptr());
+    regTileGemmKernel<WM, WN><<<1, 32>>>(aIOp, bIOp, dIOp, K);
+    cudaDeviceSynchronize();
+
+    std::vector<float> Dout(M*N);
+    cudaMemcpy2D(Dout.data(), N*sizeof(float), D.ptr().data, D.ptr().dims.pitch, N*sizeof(float), M, cudaMemcpyDeviceToHost);
+
+    double maxErr = 0;
+    for (int m=0;m<M;++m) for (int n=0;n<N;++n) {
+        double acc=0; for (int k=0;k<K;++k) acc += (double)__bfloat162float(Ah[m*K+k])*(double)__bfloat162float(Bh[n*K+k]);
+        maxErr = std::max(maxErr, std::abs((double)Dout[m*N+n]-acc));
+    }
+    const double tol = 5e-2 * (K/16.0);
+    if (maxErr > tol) { printf("FAIL regtile %dx%d K=%d maxErr=%.4e\n", WM, WN, K, maxErr); ++failures; }
+    else printf("WarpTileMmaMainloopDPP %dx%d (1 warp) GEMM %dx%dx%-4d vs fp64: PASS (maxErr=%.2e)\n", WM, WN, M, N, K, maxErr);
+}
+
+int launch() {
+    runCase<2, 2>(64);    // 1 warp computes 32x16 via 4 atoms/K-step
+    runCase<2, 4>(128);   // 32x32 via 8 atoms/K-step (reuse)
+    runCase<4, 2>(256);   // 64x16
+    return failures == 0 ? 0 : -1;
+}

--- a/tests/collective/test_collective_tile.h
+++ b/tests/collective/test_collective_tile.h
@@ -1,0 +1,105 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/tile.h>
+#include "tests/nvtx.h"
+
+#include <vector>
+
+using namespace fk;
+
+/* Layout correctness is a host-side property (constexpr offset math), so the
+ * core checks run identically on CPU and CUDA passes — the host/device parity
+ * FKL wants. The critical invariant for a swizzle is BIJECTIVITY within the
+ * buffer: distinct (row,col) must map to distinct offsets in [0, size), or a
+ * tile silently corrupts data. */
+
+template <typename Layout>
+static bool layoutIsBijective() {
+    const uint n = Layout::size();
+    std::vector<int> seen(n, -1);
+    for (uint r = 0; r < Layout::rows; ++r) {
+        for (uint c = 0; c < Layout::cols; ++c) {
+            const uint off = Layout::offset(r, c);
+            if (off >= n) return false;                 // out of bounds
+            if (seen[off] != -1) return false;          // collision -> not bijective
+            seen[off] = (int)(r * Layout::cols + c);
+        }
+    }
+    for (uint i = 0; i < n; ++i) if (seen[i] == -1) return false; // not surjective
+    return true;
+}
+
+static bool rowMajorOffsetsAreContiguous() {
+    using L = RowMajorLayout<4, 8>;
+    for (uint r = 0; r < 4; ++r)
+        for (uint c = 0; c < 8; ++c)
+            if (L::offset(r, c) != r * 8 + c) return false;
+    return true;
+}
+
+#if defined(__NVCC__)
+/* Cooperative tile staging: the block loads a ROWS x COLS tile gmem->smem
+ * through the layout (swizzle applied to the smem index), then stores it back
+ * smem->gmem. A correct round-trip proves the DPP addresses the __shared__
+ * via the layout consistently on both directions. No Tile object, no Ops:
+ * just a __shared__ the DPP indexes with Layout::offset. */
+template <typename T, typename Layout, int BLOCK_SIZE>
+__global__ void copyTileRoundTrip(const T* gin, T* gout, int pitchElems) {
+    __shared__ T smem[Layout::size()];
+    using DPP = fk::CopyTileDPP<T, Layout, BLOCK_SIZE>;
+    DPP::loadGlobalToShared(smem, gin, pitchElems);
+    __syncthreads();
+    DPP::storeSharedToGlobal(smem, gout, pitchElems);
+}
+
+template <typename Layout>
+static bool deviceCopyCheck() {
+    constexpr int BS = 128;
+    const int rows = Layout::rows, cols = Layout::cols;
+    std::vector<float> in(rows * cols), out(rows * cols, -1.f);
+    for (int i = 0; i < rows * cols; ++i) in[i] = (float)(i + 1);
+    float *gi, *go; cudaMalloc(&gi, in.size()*4); cudaMalloc(&go, out.size()*4);
+    cudaMemcpy(gi, in.data(), in.size()*4, cudaMemcpyHostToDevice);
+    copyTileRoundTrip<float, Layout, BS><<<1, BS>>>(gi, go, cols);
+    cudaDeviceSynchronize();
+    cudaMemcpy(out.data(), go, out.size()*4, cudaMemcpyDeviceToHost);
+    cudaFree(gi); cudaFree(go);
+    for (int i = 0; i < rows * cols; ++i) if (out[i] != in[i]) return false;
+    return true;
+}
+#endif
+
+int launch() {
+    bool passed = true;
+    {
+        PUSH_RANGE_RAII p("tile_layout_host");
+        passed &= rowMajorOffsetsAreContiguous();
+        passed &= layoutIsBijective<RowMajorLayout<16, 64>>();
+        passed &= layoutIsBijective<XorSwizzleLayout<16, 64, 8>>();
+        passed &= layoutIsBijective<XorSwizzleLayout<32, 32, 8>>();
+        passed &= layoutIsBijective<XorSwizzleLayout<8, 128, 4>>();
+    }
+#if defined(__NVCC__)
+    {
+        PUSH_RANGE_RAII p("tile_copy_dpp_device");
+        passed &= deviceCopyCheck<RowMajorLayout<16, 64>>();
+        passed &= deviceCopyCheck<XorSwizzleLayout<16, 64, 8>>();
+        passed &= deviceCopyCheck<XorSwizzleLayout<32, 32, 8>>();
+    }
+#endif
+    return passed ? 0 : -1;
+}


### PR DESCRIPTION
## Summary

Adds `benchmarks/bench_gemm_pipeline.cu` — the **compute-bound** counterpart to the single-warp microbench (#276), proving the cp.async pipelining is a real win where it matters: a block-level tiled GEMM where warps **reuse** shared-memory operand panels.

A block of `M_WARPS × N_WARPS` warps loads `A[BM×BK]` and `B[BN×BK]` into smem once per K-step and every warp reuses them (A m-band feeds `N_WARPS` warps, B n-band feeds `M_WARPS`), **composing `WarpTileScheduler` (#279) with the MMA atom (#273)**. Two variants, identical math, verified vs fp64 oracle before timing: synchronous smem staging vs cp.async double-buffered pipelining.

> Composes the multi-warp scheduler and the pipelining primitives — stacked on #279.

## Measured (RTX PRO 6000, 188 SMs, CUDA-graph best-of-7, as-is)

| shape | sync | pipelined | speedup |
|-------|-----:|----------:|--------:|
| 4×4 BK32 K1024 | 29.8 TF | 50.3 TF | **1.69x** |
| 4×4 BK32 K4096 | 30.0 TF | 51.9 TF | **1.73x** |
| 8×4 BK32 K2048 | 25.8 TF | 42.9 TF | **1.66x** |
| 4×8 BK32 K2048 | 27.7 TF | 49.3 TF | **1.78x** |
| 4×4 BK64 K4096 | 21.4 TF | 29.0 TF | 1.36x |
| 8×4 BK64 K4096 | 20.8 TF | 29.6 TF | 1.42x |

## Honest reading

- This is the regime that matters: **real compute-bound throughput** (30–52 TF, vs the memory-bound 3 TF the single-warp microbench bottomed out at), with operand reuse across warps. Pipelining wins **1.36×–1.78×**.
- **BK=32 beats BK=64** — wider panels cost more smem → fewer CTAs/SM → less cross-block overlap to complement the intra-block pipeline. Measured, not assumed.
- These are *not* CUTLASS-competitive absolute numbers (this is the FKL cooperative scaffold, not a tuned GEMM); the point is the **relative** sync-vs-pipe delta validating that the pipelining primitive earns its complexity when there's compute to overlap.

Together with #276's microbench, this maps the full picture: pipelining helps where there is load latency to hide and compute to overlap, and the file headers document exactly where each holds.
