### PR TITLE
collective: port one-query-tile flash attention onto the cooperative stack

### DIFF
--- a/include/fused_kernel/algorithms/basic_ops/memory_operations.h
+++ b/include/fused_kernel/algorithms/basic_ops/memory_operations.h
@@ -22,7 +22,25 @@
 #include <fused_kernel/core/data/array.h>
 #include <vector>
 
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
 namespace fk {
+#if defined(__NVCC__)
+    template <uint ELEMS_PER_THREAD>
+    struct ThreadFusionTypeImpl<__nv_bfloat16, ELEMS_PER_THREAD,
+                                __nv_bfloat16, void> {
+        using type = __nv_bfloat16;
+    };
+
+    template <uint ELEMS_PER_THREAD>
+    struct ThreadFusionTypeImpl<__nv_bfloat162, ELEMS_PER_THREAD,
+                                __nv_bfloat162, void> {
+        using type = __nv_bfloat162;
+    };
+#endif
+
     template <ND D, typename T>
     struct PerThreadRead {
     private:
@@ -120,6 +138,71 @@ namespace fk {
             return PerThreadWrite<D, PtrDataType>::build(ptrs);
         }
     };
+
+#if defined(__NVCC__)
+    /* Device-only PerThreadRead / PerThreadWrite specializations for the CUDA
+     * bf16 types (__nv_bfloat16 and __nv_bfloat162).
+     *
+     * bf16 is not part of the FK core type-system: it has no VectorTraits /
+     * VBase entry (and no 1/3/4-channel vector form), so it cannot travel the
+     * generic ThreadFusion path the primary PerThreadRead/Write<D,T> use — that
+     * path instantiates ThreadFusionType<bf16,...> -> VBase<bf16>, which is
+     * undefined. These specs disable ThreadFusion (TF::DISABLED) and move the
+     * single element directly. They are guarded by __NVCC__ because the bf16
+     * types only exist under the CUDA toolchain; the host-only CPU backend never
+     * sees them. Element type is bf16 in / bf16 out (no widening). */
+#define FK_DECLARE_BF_PERTHREAD(BFTYPE)                                                                  \
+    template <ND D>                                                                                      \
+    struct PerThreadRead<D, BFTYPE> {                                                                    \
+    private:                                                                                             \
+        using Parent = ReadOperation<BFTYPE, RawPtr<D, BFTYPE>, BFTYPE, TF::DISABLED, PerThreadRead<D, BFTYPE>>; \
+        using SelfType = PerThreadRead<D, BFTYPE>;                                                       \
+    public:                                                                                              \
+        FK_STATIC_STRUCT(PerThreadRead, SelfType)                                                        \
+        DECLARE_READ_PARENT                                                                              \
+        FK_DEVICE_FUSE BFTYPE exec(const Point thread, const ParamsType& params) {                       \
+            return *PtrAccessor<D>::template cr_point<BFTYPE, BFTYPE>(thread, params);                    \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {      \
+            return opData.params.dims.width;                                                             \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint num_elems_y(const Point thread, const OperationDataType& opData) {      \
+            if constexpr (D == ND::_1D) { return 1; } else { return opData.params.dims.height; }         \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint num_elems_z(const Point thread, const OperationDataType& opData) {      \
+            if constexpr (D == ND::_1D || D == ND::_2D) { return 1; } else { return opData.params.dims.planes; } \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {            \
+            return opData.params.dims.pitch;                                                             \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE ActiveThreads getActiveThreads(const OperationDataType& opData) {            \
+            return { num_elems_x(Point{0,0,0}, opData), num_elems_y(Point{0,0,0}, opData), num_elems_z(Point{0,0,0}, opData) }; \
+        }                                                                                                \
+    };                                                                                                  \
+    template <ND D>                                                                                      \
+    struct PerThreadWrite<D, BFTYPE> {                                                                   \
+    private:                                                                                             \
+        using Parent = WriteOperation<BFTYPE, RawPtr<D, BFTYPE>, BFTYPE, TF::DISABLED, PerThreadWrite<D, BFTYPE>>; \
+        using SelfType = PerThreadWrite<D, BFTYPE>;                                                      \
+    public:                                                                                              \
+        FK_STATIC_STRUCT(PerThreadWrite, SelfType)                                                       \
+        DECLARE_WRITE_PARENT                                                                             \
+        FK_DEVICE_FUSE void exec(const Point thread, const BFTYPE input, const ParamsType& params) {     \
+            *PtrAccessor<D>::template point<BFTYPE, BFTYPE>(thread, params) = input;                      \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint num_elems_x(const Point thread, const OperationDataType& opData) {      \
+            return opData.params.dims.width;                                                             \
+        }                                                                                                \
+        FK_HOST_DEVICE_FUSE uint pitch(const Point thread, const OperationDataType& opData) {            \
+            return opData.params.dims.pitch;                                                             \
+        }                                                                                                \
+        FK_HOST_FUSE InstantiableType build(const Ptr<D, BFTYPE>& ptr) { return { {ptr.ptr()} }; }       \
+    };
+
+    FK_DECLARE_BF_PERTHREAD(__nv_bfloat16)
+    FK_DECLARE_BF_PERTHREAD(__nv_bfloat162)
+#undef FK_DECLARE_BF_PERTHREAD
+#endif // __NVCC__
 
     template <typename T>
     struct TensorRead {

--- a/include/fused_kernel/algorithms/collective/async_copy.h
+++ b/include/fused_kernel/algorithms/collective/async_copy.h
@@ -1,0 +1,192 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_ASYNC_COPY_H
+#define FK_COLLECTIVE_ASYNC_COPY_H
+
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct AsyncCopyDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+    static_assert((Layout::size() * sizeof(T)) % 16 == 0,
+                  "Async-copy local storage must be a multiple of 16 bytes");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int origin;
+    int elementCount;
+    T boundaryValue;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct AsyncCopyDPP;
+
+template <typename DPPDetails>
+struct AsyncCopyDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = AsyncCopyDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        for (uint index = 0; index < DPPDetails::TILE_ELEMENTS; ++index) {
+            tile.at(index / Layout::cols, index % Layout::cols) =
+                static_cast<int>(index) < details.elementCount
+                ? ReadIOp::Operation::exec(
+                      Point{details.origin + static_cast<int>(index), 0, 0},
+                      input)
+                : details.boundaryValue;
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct AsyncCopyDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = AsyncCopyDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+    static constexpr int ELEMENTS_PER_CHUNK = 16 / sizeof(T);
+    static constexpr int CHUNKS = DPPDetails::TILE_ELEMENTS /
+                                  ELEMENTS_PER_CHUNK;
+
+    template <typename ReadIOp>
+    static constexpr bool ADDRESSABLE_READ =
+        std::is_same_v<typename ReadIOp::Operation,
+                       PerThreadRead<ND::_1D, T>>;
+
+    FK_DEVICE_STATIC void copy16(void* destination,
+                                 const void* source,
+                                 const int sourceBytes) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        const uint32_t sharedAddress = static_cast<uint32_t>(
+            __cvta_generic_to_shared(destination));
+        asm volatile(
+            "cp.async.cg.shared.global [%0], [%1], 16, %2;"
+            :: "r"(sharedAddress), "l"(source), "r"(sourceBytes));
+#else
+        if (sourceBytes == 16) {
+            *reinterpret_cast<int4*>(destination) =
+                *reinterpret_cast<const int4*>(source);
+        } else {
+            char* dst = reinterpret_cast<char*>(destination);
+            const char* src = reinterpret_cast<const char*>(source);
+            for (int byte = 0; byte < 16; ++byte)
+                dst[byte] = byte < sourceBytes ? src[byte] : 0;
+        }
+#endif
+    }
+
+    FK_DEVICE_STATIC void commitAndWait() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+#endif
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void fallback(const DPPDetails& details,
+                                   const ReadIOp& input,
+                                   Tile<T, Layout> tile) {
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            tile.at(index / Layout::cols, index % Layout::cols) =
+                static_cast<int>(index) < details.elementCount
+                ? ReadIOp::Operation::exec(
+                      Point{details.origin + static_cast<int>(index), 0, 0},
+                      input)
+                : details.boundaryValue;
+        }
+    }
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void load(const DPPDetails& details,
+                               const ReadIOp& input,
+                               Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        static_assert(sizeof(T) <= 16 && 16 % sizeof(T) == 0,
+                      "AsyncCopyDPP requires an element size dividing 16");
+
+        if constexpr (ADDRESSABLE_READ<ReadIOp>) {
+            const bool aligned =
+                (reinterpret_cast<uintptr_t>(
+                     input.params.data + details.origin) & 0xFu) == 0;
+            if (aligned) {
+                for (int chunk = threadIdx.x;
+                     chunk < CHUNKS;
+                     chunk += DPPDetails::BLOCK_THREADS) {
+                    const int first = chunk * ELEMENTS_PER_CHUNK;
+                    int valid = details.elementCount - first;
+                    valid = valid < 0 ? 0 : valid;
+                    valid = valid > ELEMENTS_PER_CHUNK
+                        ? ELEMENTS_PER_CHUNK : valid;
+                    const T* source = valid > 0
+                        ? input.params.data + details.origin + first
+                        : input.params.data + details.origin;
+                    copy16(tile.data() + first, source,
+                           valid * static_cast<int>(sizeof(T)));
+                }
+                commitAndWait();
+                for (int index = details.elementCount + threadIdx.x;
+                     index < static_cast<int>(DPPDetails::TILE_ELEMENTS);
+                     index += DPPDetails::BLOCK_THREADS) {
+                    if (index >= 0) {
+                        tile.at(index / Layout::cols,
+                                index % Layout::cols) = details.boundaryValue;
+                    }
+                }
+            } else {
+                fallback(details, input, tile);
+            }
+        } else {
+            fallback(details, input, tile);
+        }
+        __syncthreads();
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_ASYNC_COPY_H

--- a/include/fused_kernel/algorithms/collective/async_copy.h
+++ b/include/fused_kernel/algorithms/collective/async_copy.h
@@ -43,6 +43,27 @@ struct AsyncCopyDPPDetails {
     T boundaryValue;
 };
 
+// Row-strided source policy used by tiled MMA staging. validCols/validRows
+// provide deterministic zero/boundary fill for K tails without over-reading.
+template <typename T, typename Layout, int BLOCK_SIZE = 32>
+struct AsyncCopy2DDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+    static_assert((Layout::cols * sizeof(T)) % 16 == 0,
+                  "Each async-copy row must be a multiple of 16 bytes");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int originX;
+    int originY;
+    int validCols;
+    int validRows;
+    T boundaryValue;
+};
+
 template <ParArch PA, typename DPPDetails>
 struct AsyncCopyDPP;
 
@@ -70,6 +91,39 @@ public:
                       Point{details.origin + static_cast<int>(index), 0, 0},
                       input)
                 : details.boundaryValue;
+        }
+    }
+};
+
+// CPU row-strided specialization, primarily for semantic parity tests.
+template <typename T, typename Layout, int BLOCK_SIZE>
+struct AsyncCopyDPP<ParArch::CPU,
+                    AsyncCopy2DDPPDetails<T, Layout, BLOCK_SIZE>> {
+private:
+    using DPPDetails = AsyncCopy2DDPPDetails<T, Layout, BLOCK_SIZE>;
+    using SelfType = AsyncCopyDPP<ParArch::CPU, DPPDetails>;
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                tile.at(row, col) =
+                    static_cast<int>(row) < details.validRows &&
+                    static_cast<int>(col) < details.validCols
+                    ? ReadIOp::Operation::exec(
+                          Point{details.originX + static_cast<int>(col),
+                                details.originY + static_cast<int>(row), 0},
+                          input)
+                    : details.boundaryValue;
+            }
         }
     }
 };
@@ -183,6 +237,131 @@ public:
             fallback(details, input, tile);
         }
         __syncthreads();
+    }
+};
+
+// GPU row-strided specialization with split issue/commit/wait/complete phases
+// so a composing mainloop can keep one cp.async group in flight.
+template <typename T, typename Layout, int BLOCK_SIZE>
+struct AsyncCopyDPP<ParArch::GPU_NVIDIA,
+                    AsyncCopy2DDPPDetails<T, Layout, BLOCK_SIZE>> {
+private:
+    using DPPDetails = AsyncCopy2DDPPDetails<T, Layout, BLOCK_SIZE>;
+    using SelfType = AsyncCopyDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    static constexpr int ELEMENTS_PER_CHUNK = 16 / sizeof(T);
+    static constexpr int CHUNKS_PER_ROW =
+        static_cast<int>(Layout::cols) / ELEMENTS_PER_CHUNK;
+    static constexpr int CHUNKS =
+        static_cast<int>(Layout::rows) * CHUNKS_PER_ROW;
+
+    template <typename ReadIOp>
+    static constexpr bool ADDRESSABLE_READ =
+        std::is_same_v<typename ReadIOp::Operation,
+                       PerThreadRead<ND::_2D, T>>;
+
+    FK_DEVICE_STATIC void copy16(void* destination,
+                                 const void* source,
+                                 const int sourceBytes) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        const uint32_t sharedAddress = static_cast<uint32_t>(
+            __cvta_generic_to_shared(destination));
+        asm volatile(
+            "cp.async.cg.shared.global [%0], [%1], 16, %2;"
+            :: "r"(sharedAddress), "l"(source), "r"(sourceBytes));
+#else
+        if (sourceBytes == 16) {
+            *reinterpret_cast<int4*>(destination) =
+                *reinterpret_cast<const int4*>(source);
+        } else {
+            char* dst = reinterpret_cast<char*>(destination);
+            const char* src = reinterpret_cast<const char*>(source);
+            for (int byte = 0; byte < 16; ++byte)
+                dst[byte] = byte < sourceBytes ? src[byte] : 0;
+        }
+#endif
+    }
+
+public:
+    FK_STATIC_STRUCT(AsyncCopyDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void issue(const DPPDetails& details,
+                                const ReadIOp& input,
+                                Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "AsyncCopyDPP requires a complete Read IOp");
+        static_assert(sizeof(T) <= 16 && 16 % sizeof(T) == 0,
+                      "AsyncCopyDPP requires an element size dividing 16");
+        if constexpr (ADDRESSABLE_READ<ReadIOp>) {
+            const uintptr_t firstAddress = reinterpret_cast<uintptr_t>(
+                reinterpret_cast<const char*>(input.params.data) +
+                details.originY * input.params.dims.pitch) +
+                static_cast<uintptr_t>(details.originX * sizeof(T));
+            const bool aligned = (firstAddress & 0xFu) == 0 &&
+                                 (input.params.dims.pitch & 0xFu) == 0;
+            if (aligned) {
+                for (int chunk = threadIdx.x; chunk < CHUNKS;
+                     chunk += DPPDetails::BLOCK_THREADS) {
+                    const int row = chunk / CHUNKS_PER_ROW;
+                    const int chunkInRow = chunk % CHUNKS_PER_ROW;
+                    const int firstCol = chunkInRow * ELEMENTS_PER_CHUNK;
+                    const bool validRow = row < details.validRows;
+                    int valid = validRow ? details.validCols - firstCol : 0;
+                    valid = valid < 0 ? 0 : valid;
+                    valid = valid > ELEMENTS_PER_CHUNK
+                        ? ELEMENTS_PER_CHUNK : valid;
+                    const char* rowBase =
+                        reinterpret_cast<const char*>(input.params.data) +
+                        (details.originY + (validRow ? row : 0)) *
+                            input.params.dims.pitch;
+                    const T* source = valid > 0
+                        ? reinterpret_cast<const T*>(rowBase) +
+                              details.originX + firstCol
+                        : input.params.data;
+                    copy16(tile.data() + row * Layout::cols + firstCol,
+                           source, valid * static_cast<int>(sizeof(T)));
+                }
+                return;
+            }
+        }
+        for (uint index = threadIdx.x; index < Layout::size();
+             index += DPPDetails::BLOCK_THREADS) {
+            const int row = static_cast<int>(index / Layout::cols);
+            const int col = static_cast<int>(index % Layout::cols);
+            tile.at(row, col) = row < details.validRows &&
+                                col < details.validCols
+                ? ReadIOp::Operation::exec(
+                      Point{details.originX + col, details.originY + row, 0},
+                      input)
+                : details.boundaryValue;
+        }
+    }
+
+    FK_DEVICE_STATIC void commit() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        asm volatile("cp.async.commit_group;");
+#endif
+    }
+
+    template <int PendingGroups>
+    FK_DEVICE_STATIC void wait() {
+        static_assert(PendingGroups >= 0 && PendingGroups <= 7,
+                      "cp.async supports 0 through 7 pending groups");
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+        asm volatile("cp.async.wait_group %0;" :: "n"(PendingGroups));
+#endif
+    }
+
+    FK_DEVICE_STATIC void complete(const DPPDetails& details,
+                                   Tile<T, Layout> tile) {
+        for (uint index = threadIdx.x; index < Layout::size();
+             index += DPPDetails::BLOCK_THREADS) {
+            const int row = static_cast<int>(index / Layout::cols);
+            const int col = static_cast<int>(index % Layout::cols);
+            if (row >= details.validRows || col >= details.validCols)
+                tile.at(row, col) = details.boundaryValue;
+        }
     }
 };
 #endif // defined(__NVCC__)

--- a/include/fused_kernel/algorithms/collective/attention_tile.h
+++ b/include/fused_kernel/algorithms/collective/attention_tile.h
@@ -1,0 +1,467 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_ATTENTION_TILE_H
+#define FK_COLLECTIVE_ATTENTION_TILE_H
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/cta_raster.h>
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/reduce.h>
+#include <fused_kernel/core/execution_model/executor_details/dpp_launch_config.h>
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#include <cfloat>
+#endif
+
+namespace fk {
+
+/**
+ * Static attention policy plus runtime launch state.
+ *
+ * Q/K/V are supplied as one Tuple of Read IOps. O is supplied only as the
+ * final Write IOp. qTile and bh are per-block fields updated internally by
+ * AttentionTileDPP after applying SchedulerOperation.
+ */
+template <
+    int HEAD_DIMENSION,
+    int QUERIES_PER_TILE,
+    typename MmaDetailsType = MmaDPPDetails<MmaBf16_16x8x16>,
+    typename QStageLayoutType =
+        RowMajorLayout<QUERIES_PER_TILE, HEAD_DIMENSION>,
+    typename KStageLayoutType = RowMajorLayout<16, HEAD_DIMENSION>,
+    typename VStageLayoutType = ColumnMajorLayout<16, HEAD_DIMENSION>,
+    typename PStageLayoutType = RowMajorLayout<16, 16>,
+    typename SchedulerOperationT = CtaTileScheduler<RowMajorCtaTileRaster>,
+    template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP,
+    template <ParArch, typename> class CopyPolicyTemplate = CopyTileDPP,
+    template <ParArch, typename> class ReducePolicyTemplate = ReduceWarpDPP>
+struct AttentionDPPDetails {
+    static_assert(HEAD_DIMENSION == 32 || HEAD_DIMENSION == 64,
+                  "AttentionTileDPP supports head dimensions 32 and 64");
+    static_assert(QUERIES_PER_TILE > 0 && QUERIES_PER_TILE % 16 == 0,
+                  "query tile must contain whole m16 MMA atoms");
+
+    static constexpr int HEAD_DIM = HEAD_DIMENSION;
+    static constexpr int QUERY_ROWS = QUERIES_PER_TILE;
+    static constexpr int KEY_ROWS = 16;
+    static constexpr int BLOCK_THREADS = 32;
+    static constexpr int QUERY_ATOMS = QUERY_ROWS / 16;
+    static constexpr int OUTPUT_ATOMS = HEAD_DIM / 8;
+
+    using MmaDetails = MmaDetailsType;
+    using QStageLayout = QStageLayoutType;
+    using KStageLayout = KStageLayoutType;
+    using VStageLayout = VStageLayoutType;
+    using PStageLayout = PStageLayoutType;
+    using SchedulerOperation = SchedulerOperationT;
+    using SchedulerIOp = decltype(SchedulerOperation::build());
+    using ReduceDetails = ReduceDPPDetails<float, BLOCK_THREADS>;
+
+    template <typename Layout>
+    using CopyDetails = CopyTileDPPDetails<float, Layout, BLOCK_THREADS>;
+    template <ParArch PA, typename Details>
+    using MmaPolicy = MmaPolicyTemplate<PA, Details>;
+    template <ParArch PA, typename Details>
+    using CopyPolicy = CopyPolicyTemplate<PA, Details>;
+    template <ParArch PA, typename Details>
+    using ReducePolicy = ReducePolicyTemplate<PA, Details>;
+
+    int batchHeads;
+    int seqQ;
+    int seqK;
+    float scale;
+    bool causal;
+    int qTile;
+    int bh;
+
+    FK_HOST_DEVICE_CNST bool valid() const {
+        return batchHeads > 0 && seqQ > 0 && seqK > 0 && scale > 0.f;
+    }
+
+    FK_HOST_DEVICE_CNST int queryTileCount() const {
+        return (seqQ + QUERY_ROWS - 1) / QUERY_ROWS;
+    }
+};
+
+template <ParArch PA, typename AttentionDetailsType>
+struct AttentionTileDPP;
+
+template <typename AttentionDetailsType>
+struct AttentionTileDPP<ParArch::CPU, AttentionDetailsType> {
+private:
+    using SelfType = AttentionTileDPP<ParArch::CPU, AttentionDetailsType>;
+    using Details = AttentionDetailsType;
+
+    template <typename Inputs, typename Output, typename... ComputeIOps>
+    FK_HOST_STATIC void executeBlock(const Details& details,
+                                     const Inputs& inputs,
+                                     const Output& output,
+                                     const ComputeIOps&...) {
+        const auto& q = get<0>(inputs);
+        const auto& k = get<1>(inputs);
+        const auto& v = get<2>(inputs);
+        using Q = std::decay_t<decltype(q)>;
+        using K = std::decay_t<decltype(k)>;
+        using V = std::decay_t<decltype(v)>;
+
+        const int qRow0 = details.qTile * Details::QUERY_ROWS;
+        const int qHead = details.bh * details.seqQ;
+        const int kHead = details.bh * details.seqK;
+        for (int localRow = 0;
+             localRow < Details::QUERY_ROWS && qRow0 + localRow < details.seqQ;
+             ++localRow) {
+            const int queryRow = qRow0 + localRow;
+            const int keyEnd = details.causal
+                ? std::min(details.seqK, queryRow + 1) : details.seqK;
+            double rowMax = -std::numeric_limits<double>::infinity();
+            for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                double dot = 0.0;
+                for (int d = 0; d < Details::HEAD_DIM; ++d) {
+                    dot += static_cast<double>(Q::Operation::exec(
+                               Point{d, qHead + queryRow, 0}, q)) *
+                           static_cast<double>(K::Operation::exec(
+                               Point{d, kHead + keyRow, 0}, k));
+                }
+                rowMax = std::max(rowMax, dot * details.scale);
+            }
+            double denominator = 0.0;
+            for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                double dot = 0.0;
+                for (int d = 0; d < Details::HEAD_DIM; ++d) {
+                    dot += static_cast<double>(Q::Operation::exec(
+                               Point{d, qHead + queryRow, 0}, q)) *
+                           static_cast<double>(K::Operation::exec(
+                               Point{d, kHead + keyRow, 0}, k));
+                }
+                denominator += std::exp(dot * details.scale - rowMax);
+            }
+            const double inverse = denominator > 0.0 ? 1.0 / denominator : 0.0;
+            for (int d = 0; d < Details::HEAD_DIM; d += 2) {
+                double first = 0.0;
+                double second = 0.0;
+                for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                    double dot = 0.0;
+                    for (int inner = 0; inner < Details::HEAD_DIM; ++inner) {
+                        dot += static_cast<double>(Q::Operation::exec(
+                                   Point{inner, qHead + queryRow, 0}, q)) *
+                               static_cast<double>(K::Operation::exec(
+                                   Point{inner, kHead + keyRow, 0}, k));
+                    }
+                    const double probability =
+                        std::exp(dot * details.scale - rowMax) * inverse;
+                    first += probability * static_cast<double>(V::Operation::exec(
+                        Point{d, kHead + keyRow, 0}, v));
+                    second += probability * static_cast<double>(V::Operation::exec(
+                        Point{d + 1, kHead + keyRow, 0}, v));
+                }
+                Output::Operation::exec(
+                    Point{d / 2, qHead + queryRow, 0},
+                    float2{static_cast<float>(first),
+                           static_cast<float>(second)}, output);
+            }
+        }
+    }
+
+public:
+    FK_STATIC_STRUCT(AttentionTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const Details&) { return {}; }
+
+    template <typename Inputs, typename Output, typename... ComputeIOps>
+    FK_HOST_STATIC void exec(const Details& launchDetails,
+                             const Inputs& inputs,
+                             const Output& output,
+                             const ComputeIOps&... computeIOps) {
+        if (!launchDetails.valid()) return;
+        const int qTiles = launchDetails.queryTileCount();
+        const typename Details::SchedulerIOp scheduler{};
+        for (int block = 0; block < launchDetails.batchHeads * qTiles; ++block) {
+            const CtaTileAssignment tile =
+                make_tuple(block, launchDetails.batchHeads, qTiles) | scheduler;
+            if (!tile.valid) continue;
+            Details details = launchDetails;
+            details.bh = tile.mTile;
+            details.qTile = tile.nTile;
+            executeBlock(details, inputs, output, computeIOps...);
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename AttentionDetailsType>
+struct AttentionTileDPP<ParArch::GPU_NVIDIA, AttentionDetailsType> {
+private:
+    using SelfType = AttentionTileDPP<ParArch::GPU_NVIDIA, AttentionDetailsType>;
+    using Details = AttentionDetailsType;
+    using Mma = typename Details::template MmaPolicy<
+        ParArch::GPU_NVIDIA, typename Details::MmaDetails>;
+    using Reduce = typename Details::template ReducePolicy<
+        ParArch::GPU_NVIDIA, typename Details::ReduceDetails>;
+    using AddOp = Add<float, float, float, UnaryType>;
+    using MaxOp = Max<float, float, float, UnaryType>;
+
+    template <typename T>
+    FK_DEVICE_FUSE RawPtr<ND::_2D, T> sharedView(
+            T* storage, const uint width, const uint height) {
+        RawPtr<ND::_2D, T> result;
+        result.data = storage;
+        result.dims.width = width;
+        result.dims.height = height;
+        result.dims.pitch = width * sizeof(T);
+        return result;
+    }
+
+    FK_DEVICE_FUSE float rowScore(
+            const typename Mma::AccumulatorFragment& low,
+            const typename Mma::AccumulatorFragment& high,
+            const int row, const int lane) {
+        const int ownerGroup = row & 7;
+        const bool upperRow = row >= 8;
+        const int sourceLane = ownerGroup * 4 + ((lane & 7) >> 1);
+        const float lowEven = upperRow ? low.values[2] : low.values[0];
+        const float lowOdd = upperRow ? low.values[3] : low.values[1];
+        const float highEven = upperRow ? high.values[2] : high.values[0];
+        const float highOdd = upperRow ? high.values[3] : high.values[1];
+        const bool highKey = lane >= 8;
+        const float shuffledLowEven = __shfl_sync(
+            0xffffffffu, lowEven, sourceLane);
+        const float shuffledLowOdd = __shfl_sync(
+            0xffffffffu, lowOdd, sourceLane);
+        const float shuffledHighEven = __shfl_sync(
+            0xffffffffu, highEven, sourceLane);
+        const float shuffledHighOdd = __shfl_sync(
+            0xffffffffu, highOdd, sourceLane);
+        const float even = highKey ? shuffledHighEven : shuffledLowEven;
+        const float odd = highKey ? shuffledHighOdd : shuffledLowOdd;
+        return lane & 1 ? odd : even;
+    }
+
+public:
+    FK_STATIC_STRUCT(AttentionTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const Details& details) {
+        const unsigned int blocks = details.valid()
+            ? static_cast<unsigned int>(
+                  details.batchHeads * details.queryTileCount())
+            : 1u;
+        return {blocks, 1, 1,
+                static_cast<unsigned int>(Details::BLOCK_THREADS), 1, 1, 0};
+    }
+
+    template <typename Inputs, typename Output, typename... ComputeIOps>
+    static __device__ __forceinline__ void exec(
+            const Details& launchDetails,
+            const Inputs& inputs,
+            const Output& output,
+            const ComputeIOps&...) {
+        if (!launchDetails.valid()) return;
+        const int qTiles = launchDetails.queryTileCount();
+        const typename Details::SchedulerIOp scheduler{};
+        const CtaTileAssignment tile =
+            make_tuple(static_cast<int>(blockIdx.x),
+                       launchDetails.batchHeads, qTiles) | scheduler;
+        if (!tile.valid) return;
+        Details details = launchDetails;
+        details.bh = tile.mTile;
+        details.qTile = tile.nTile;
+
+        const auto& qInput = get<0>(inputs);
+        const auto& kInput = get<1>(inputs);
+        const auto& vInput = get<2>(inputs);
+        const int qRow0 = details.qTile * Details::QUERY_ROWS;
+        const int qHead = details.bh * details.seqQ;
+        const int kHead = details.bh * details.seqK;
+        const int lane = static_cast<int>(threadIdx.x) & 31;
+
+        __shared__ float qStorage[Details::QStageLayout::size()];
+        __shared__ float kStorage[Details::KStageLayout::size()];
+        __shared__ float vStorage[Details::VStageLayout::size()];
+        __shared__ float probabilities[Details::PStageLayout::size()];
+        __shared__ float outputStorage[
+            Details::QUERY_ROWS * Details::HEAD_DIM];
+        float runningMax[Details::QUERY_ROWS];
+        float runningSum[Details::QUERY_ROWS];
+
+        for (int index = lane;
+             index < Details::QUERY_ROWS * Details::HEAD_DIM;
+             index += Details::BLOCK_THREADS) {
+            outputStorage[index] = 0.f;
+        }
+        #pragma unroll
+        for (int row = 0; row < Details::QUERY_ROWS; ++row) {
+            runningMax[row] = -FLT_MAX;
+            runningSum[row] = 0.f;
+        }
+        __syncthreads();
+
+        Tile<float, typename Details::QStageLayout> qTile(qStorage);
+        Tile<float, typename Details::KStageLayout> kTile(kStorage);
+        Tile<float, typename Details::VStageLayout> vTile(vStorage);
+        Tile<float, typename Details::PStageLayout> pTile(probabilities);
+
+        using QCopyDetails = typename Details::template CopyDetails<
+            typename Details::QStageLayout>;
+        using KCopyDetails = typename Details::template CopyDetails<
+            typename Details::KStageLayout>;
+        using VCopyDetails = typename Details::template CopyDetails<
+            typename Details::VStageLayout>;
+        using QCopy = typename Details::template CopyPolicy<
+            ParArch::GPU_NVIDIA, QCopyDetails>;
+        using KCopy = typename Details::template CopyPolicy<
+            ParArch::GPU_NVIDIA, KCopyDetails>;
+        using VCopy = typename Details::template CopyPolicy<
+            ParArch::GPU_NVIDIA, VCopyDetails>;
+
+        QCopy::load(QCopyDetails{
+                        0, qHead + qRow0,
+                        Details::HEAD_DIM, qHead + details.seqQ, 0.f},
+                    qInput, qTile);
+
+        const auto qRead = typename PerThreadRead<ND::_2D, float>::InstantiableType{
+            {sharedView(qStorage, Details::HEAD_DIM, Details::QUERY_ROWS)}};
+        const auto kRead = typename PerThreadRead<ND::_2D, float>::InstantiableType{
+            {sharedView(kStorage, Details::HEAD_DIM, Details::KEY_ROWS)}};
+
+        const typename MaxOp::InstantiableType maxOp{};
+        const typename AddOp::InstantiableType addOp{};
+        const typename Details::ReduceDetails maxReduction{
+            1, 16, -FLT_MAX, 0};
+        const typename Details::ReduceDetails sumReduction{1, 16, 0.f, 0};
+
+        for (int key0 = 0; key0 < details.seqK;
+             key0 += Details::KEY_ROWS) {
+            KCopy::load(KCopyDetails{
+                            0, kHead + key0,
+                            Details::HEAD_DIM, kHead + details.seqK, 0.f},
+                        kInput, kTile);
+            VCopy::load(VCopyDetails{
+                            0, kHead + key0,
+                            Details::HEAD_DIM, kHead + details.seqK, 0.f},
+                        vInput, vTile);
+
+            #pragma unroll
+            for (int queryAtom = 0;
+                 queryAtom < Details::QUERY_ATOMS; ++queryAtom) {
+                typename Mma::AccumulatorFragment scoresLow;
+                typename Mma::AccumulatorFragment scoresHigh;
+                Mma::clear(scoresLow);
+                Mma::clear(scoresHigh);
+                #pragma unroll
+                for (int d = 0; d < Details::HEAD_DIM;
+                     d += Details::MmaDetails::K) {
+                    Mma::accumulate(
+                        typename Details::MmaDetails{
+                            d, queryAtom * 16, d, 0, 0, 0},
+                        qRead, kRead, scoresLow);
+                    Mma::accumulate(
+                        typename Details::MmaDetails{
+                            d, queryAtom * 16, d, 8, 0, 0},
+                        qRead, kRead, scoresHigh);
+                }
+
+                #pragma unroll
+                for (int row = 0; row < 16; ++row) {
+                    const int queryRow = qRow0 + queryAtom * 16 + row;
+                    const float rawScore =
+                        rowScore(scoresLow, scoresHigh, row, lane) *
+                        details.scale;
+                    float score = lane < 16 ? rawScore : -FLT_MAX;
+                    const int keyRow = key0 + lane;
+                    if (lane >= 16 || keyRow >= details.seqK ||
+                        queryRow >= details.seqQ ||
+                        (details.causal && keyRow > queryRow)) {
+                        score = -FLT_MAX;
+                    }
+                    float tileMax = Reduce::exec(maxReduction, score, maxOp);
+                    tileMax = __shfl_sync(0xffffffffu, tileMax, 0);
+
+                    const int localRow = queryAtom * 16 + row;
+                    const float oldMax = runningMax[localRow];
+                    const float oldSum = runningSum[localRow];
+                    const float newMax = fmaxf(oldMax, tileMax);
+                    const float probability = lane < 16 && score > -FLT_MAX
+                        ? __expf(score - newMax) : 0.f;
+                    float tileSum = Reduce::exec(
+                        sumReduction, probability, addOp);
+                    tileSum = __shfl_sync(0xffffffffu, tileSum, 0);
+                    const float correction = oldMax > -FLT_MAX
+                        ? __expf(oldMax - newMax) : 0.f;
+
+                    for (int d = lane; d < Details::HEAD_DIM;
+                         d += Details::BLOCK_THREADS) {
+                        outputStorage[localRow * Details::HEAD_DIM + d] *=
+                            correction;
+                    }
+                    if (lane < 16)
+                        pTile.at(static_cast<uint>(row),
+                                 static_cast<uint>(lane)) = probability;
+                    runningMax[localRow] = newMax;
+                    runningSum[localRow] = oldSum * correction + tileSum;
+                    __syncwarp();
+
+                    for (int d = lane; d < Details::HEAD_DIM;
+                         d += Details::BLOCK_THREADS) {
+                        float accumulator =
+                            outputStorage[localRow * Details::HEAD_DIM + d];
+                        #pragma unroll
+                        for (int key = 0; key < 16; ++key) {
+                            accumulator += pTile.at(
+                                               static_cast<uint>(row),
+                                               static_cast<uint>(key)) *
+                                           vTile.at(
+                                               static_cast<uint>(key),
+                                               static_cast<uint>(d));
+                        }
+                        outputStorage[localRow * Details::HEAD_DIM + d] =
+                            accumulator;
+                    }
+                    __syncwarp();
+                }
+            }
+        }
+
+        for (int localRow = 0; localRow < Details::QUERY_ROWS; ++localRow) {
+            const int queryRow = qRow0 + localRow;
+            if (queryRow >= details.seqQ) continue;
+            const float inverse = runningSum[localRow] > 0.f
+                ? 1.f / runningSum[localRow] : 0.f;
+            for (int pair = lane; pair < Details::HEAD_DIM / 2;
+                 pair += Details::BLOCK_THREADS) {
+                const int d = pair * 2;
+                Output::Operation::exec(
+                    Point{pair, qHead + queryRow, 0},
+                    float2{
+                        outputStorage[localRow * Details::HEAD_DIM + d] * inverse,
+                        outputStorage[localRow * Details::HEAD_DIM + d + 1] * inverse},
+                    output);
+            }
+        }
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_ATTENTION_TILE_H

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -21,5 +21,6 @@
 #include <fused_kernel/algorithms/collective/mma.h>
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/tile_scheduler.h>
+#include <fused_kernel/algorithms/collective/register_tile.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -1,4 +1,4 @@
-/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Hguet)
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,11 +12,10 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-#ifndef FK_ALGORITHMS
-#define FK_ALGORITHMS
+#ifndef FK_COLLECTIVE
+#define FK_COLLECTIVE
 
-#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
-#include <fused_kernel/algorithms/image_processing/image_processing.h>
-#include <fused_kernel/algorithms/collective/collective.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/algorithms/collective/copy.h>
 
-#endif // FK_ALGORITHMS
+#endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -22,6 +22,8 @@
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/tile_scheduler.h>
 #include <fused_kernel/algorithms/collective/cta_raster.h>
+#include <fused_kernel/algorithms/collective/reduce.h>
+#include <fused_kernel/algorithms/collective/attention_tile.h>
 #include <fused_kernel/algorithms/collective/register_tile.h>
 #include <fused_kernel/algorithms/collective/multistage.h>
 #include <fused_kernel/algorithms/collective/epilogue.h>

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -17,5 +17,7 @@
 
 #include <fused_kernel/algorithms/collective/tile.h>
 #include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/async_copy.h>
+#include <fused_kernel/algorithms/collective/mma.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -23,5 +23,7 @@
 #include <fused_kernel/algorithms/collective/tile_scheduler.h>
 #include <fused_kernel/algorithms/collective/register_tile.h>
 #include <fused_kernel/algorithms/collective/multistage.h>
+#include <fused_kernel/algorithms/collective/epilogue.h>
+#include <fused_kernel/algorithms/collective/gemm.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -21,6 +21,7 @@
 #include <fused_kernel/algorithms/collective/mma.h>
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/tile_scheduler.h>
+#include <fused_kernel/algorithms/collective/cta_raster.h>
 #include <fused_kernel/algorithms/collective/register_tile.h>
 #include <fused_kernel/algorithms/collective/multistage.h>
 #include <fused_kernel/algorithms/collective/epilogue.h>

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -22,5 +22,6 @@
 #include <fused_kernel/algorithms/collective/mainloop.h>
 #include <fused_kernel/algorithms/collective/tile_scheduler.h>
 #include <fused_kernel/algorithms/collective/register_tile.h>
+#include <fused_kernel/algorithms/collective/multistage.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -20,5 +20,6 @@
 #include <fused_kernel/algorithms/collective/async_copy.h>
 #include <fused_kernel/algorithms/collective/mma.h>
 #include <fused_kernel/algorithms/collective/mainloop.h>
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/collective.h
+++ b/include/fused_kernel/algorithms/collective/collective.h
@@ -19,5 +19,6 @@
 #include <fused_kernel/algorithms/collective/copy.h>
 #include <fused_kernel/algorithms/collective/async_copy.h>
 #include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
 
 #endif // FK_COLLECTIVE

--- a/include/fused_kernel/algorithms/collective/copy.h
+++ b/include/fused_kernel/algorithms/collective/copy.h
@@ -1,0 +1,172 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_COPY_H
+#define FK_COLLECTIVE_COPY_H
+
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, typename Layout, int BLOCK_SIZE = 256>
+struct CopyTileDPPDetails {
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024,
+                  "BLOCK_SIZE must be in (0, 1024]");
+
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+    static constexpr uint TILE_ROWS = Layout::rows;
+    static constexpr uint TILE_COLS = Layout::cols;
+    static constexpr uint TILE_ELEMENTS = Layout::size();
+
+    int originX;
+    int originY;
+    int extentWidth;
+    int extentHeight;
+    T boundaryValue;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct CopyTileDPP;
+
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_HOST_FUSE bool isValid(const DPPDetails& details,
+                              const int globalX,
+                              const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void load(const DPPDetails& details,
+                             const ReadIOp& input,
+                             Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                tile.at(row, col) = isValid(details, globalX, globalY)
+                    ? ReadIOp::Operation::exec(
+                          Point{globalX, globalY, 0}, input)
+                    : details.boundaryValue;
+            }
+        }
+    }
+
+    template <typename WriteIOp>
+    FK_HOST_STATIC void store(const DPPDetails& details,
+                              const Tile<T, Layout> tile,
+                              const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        for (uint row = 0; row < Layout::rows; ++row) {
+            for (uint col = 0; col < Layout::cols; ++col) {
+                const int globalX = details.originX + static_cast<int>(col);
+                const int globalY = details.originY + static_cast<int>(row);
+                if (isValid(details, globalX, globalY)) {
+                    WriteIOp::Operation::exec(
+                        Point{globalX, globalY, 0}, tile.at(row, col), output);
+                }
+            }
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = CopyTileDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+    using Layout = typename DPPDetails::LayoutType;
+
+    FK_DEVICE_FUSE bool isValid(const DPPDetails& details,
+                                const int globalX,
+                                const int globalY) {
+        return globalX >= 0 && globalY >= 0 &&
+               globalX < details.extentWidth &&
+               globalY < details.extentHeight;
+    }
+
+public:
+    FK_STATIC_STRUCT(CopyTileDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void load(const DPPDetails& details,
+                               const ReadIOp& input,
+                               Tile<T, Layout> tile) {
+        static_assert(isAnyCompleteReadType<ReadIOp>,
+                      "CopyTileDPP::load requires a complete Read IOp");
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            tile.at(row, col) = isValid(details, globalX, globalY)
+                ? ReadIOp::Operation::exec(
+                      Point{globalX, globalY, 0}, input)
+                : details.boundaryValue;
+        }
+        __syncthreads();
+    }
+
+    template <typename WriteIOp>
+    FK_DEVICE_STATIC void store(const DPPDetails& details,
+                                const Tile<T, Layout> tile,
+                                const WriteIOp& output) {
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "CopyTileDPP::store requires a Write IOp");
+        __syncthreads();
+        for (uint index = threadIdx.x;
+             index < DPPDetails::TILE_ELEMENTS;
+             index += DPPDetails::BLOCK_THREADS) {
+            const uint row = index / Layout::cols;
+            const uint col = index % Layout::cols;
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            if (isValid(details, globalX, globalY)) {
+                WriteIOp::Operation::exec(
+                    Point{globalX, globalY, 0}, tile.at(row, col), output);
+            }
+        }
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_COPY_H
+

--- a/include/fused_kernel/algorithms/collective/cta_raster.h
+++ b/include/fused_kernel/algorithms/collective/cta_raster.h
@@ -1,0 +1,83 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_CTA_RASTER_H
+#define FK_COLLECTIVE_CTA_RASTER_H
+
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+
+namespace fk {
+
+using CtaTileAssignment = WarpTileAssignment;
+using RowMajorCtaTileRaster = RowMajorWarpTileRaster;
+using ColumnMajorCtaTileRaster = ColumnMajorWarpTileRaster;
+
+/**
+ * Group output columns into bands and visit all M tiles inside each band.
+ * GROUP is compile-time traversal policy; grid extents remain runtime input.
+ */
+template <int GROUP>
+struct GroupedCtaTileRaster {
+private:
+    using SelfType = GroupedCtaTileRaster<GROUP>;
+
+public:
+    static_assert(GROUP > 0, "CTA raster group width must be positive");
+    FK_STATIC_STRUCT(GroupedCtaTileRaster, SelfType)
+
+    FK_HOST_DEVICE_FUSE CtaTileAssignment map(
+            const int ctaId, const int mTiles, const int nTiles) {
+        const int blocksPerFullGroup = GROUP * mTiles;
+        const int group = ctaId / blocksPerFullGroup;
+        const int firstColumn = group * GROUP;
+        const int remainingColumns = nTiles - firstColumn;
+        const int groupWidth = remainingColumns < GROUP
+            ? remainingColumns : GROUP;
+        const int inGroup = ctaId % blocksPerFullGroup;
+        return {inGroup / groupWidth,
+                firstColumn + inGroup % groupWidth,
+                true};
+    }
+};
+
+/**
+ * Pure parameterless Unary Operation mapping
+ * Tuple<ctaId, mTileExtent, nTileExtent> to an output-tile assignment.
+ */
+template <typename RasterPolicy = RowMajorCtaTileRaster>
+struct CtaTileScheduler {
+private:
+    using Input = Tuple<int, int, int>;
+    using Parent = UnaryOperation<Input, CtaTileAssignment,
+                                  CtaTileScheduler<RasterPolicy>>;
+    using SelfType = CtaTileScheduler<RasterPolicy>;
+
+public:
+    FK_STATIC_STRUCT(CtaTileScheduler, SelfType)
+    DECLARE_UNARY_PARENT
+
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+        const int ctaId = get<0>(input);
+        const int mTiles = get<1>(input);
+        const int nTiles = get<2>(input);
+        if (ctaId < 0 || mTiles <= 0 || nTiles <= 0 ||
+            ctaId >= mTiles * nTiles)
+            return {-1, -1, false};
+        return RasterPolicy::map(ctaId, mTiles, nTiles);
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_CTA_RASTER_H

--- a/include/fused_kernel/algorithms/collective/epilogue.h
+++ b/include/fused_kernel/algorithms/collective/epilogue.h
@@ -1,0 +1,41 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_EPILOGUE_H
+#define FK_COLLECTIVE_EPILOGUE_H
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+/** Build out = alpha * accumulator + beta as a fused Write IOp. */
+template <typename T, typename WriteIOp>
+FK_HOST_CNST auto scaleBiasEpilogue(const T alpha, const T beta,
+                                    const WriteIOp& write) {
+    return Mul<T>::build(alpha)
+        .then(Add<T>::build(beta))
+        .then(write);
+}
+
+/** Build out = max(accumulator, 0) as a fused Write IOp. */
+template <typename T, typename WriteIOp>
+FK_HOST_CNST auto reluEpilogue(const WriteIOp& write) {
+    return Max<T>::build(T{}).then(write);
+}
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_EPILOGUE_H

--- a/include/fused_kernel/algorithms/collective/gemm.h
+++ b/include/fused_kernel/algorithms/collective/gemm.h
@@ -16,7 +16,7 @@
 #define FK_COLLECTIVE_GEMM_H
 
 #include <fused_kernel/algorithms/collective/multistage.h>
-#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+#include <fused_kernel/algorithms/collective/cta_raster.h>
 #include <fused_kernel/core/execution_model/executor_details/dpp_launch_config.h>
 #include <fused_kernel/core/execution_model/parallel_architectures.h>
 
@@ -105,7 +105,7 @@ template <
     typename AStageLayoutType,
     typename BStageLayoutType,
     typename StageTypeT = float,
-    typename SchedulerOperationT = WarpTileScheduler<RowMajorWarpTileRaster>,
+    typename SchedulerOperationT = CtaTileScheduler<RowMajorCtaTileRaster>,
     template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP,
     template <ParArch, typename> class CopyPolicyTemplate = AsyncCopyDPP>
 struct GemmDPPDetails {
@@ -151,7 +151,7 @@ private:
 
     template <typename Inputs, typename Output>
     FK_HOST_STATIC void executeTile(const GemmDetails& details,
-                                    const WarpTileAssignment tile,
+                                    const CtaTileAssignment tile,
                                     const Inputs& inputs,
                                     const Output& output) {
         const auto& a = get<0>(inputs);
@@ -203,7 +203,7 @@ public:
             (details.N + GemmDetails::TILE_N - 1) / GemmDetails::TILE_N;
         const typename GemmDetails::SchedulerIOp scheduler{};
         for (int tileId = 0; tileId < mTiles * nTiles; ++tileId) {
-            const WarpTileAssignment tile =
+            const CtaTileAssignment tile =
                 make_tuple(tileId, mTiles, nTiles) | scheduler;
             if (tile.valid) executeTile(details, tile, inputs, output);
         }
@@ -240,7 +240,7 @@ public:
         const int nTiles =
             (details.N + GemmDetails::TILE_N - 1) / GemmDetails::TILE_N;
         const typename GemmDetails::SchedulerIOp scheduler{};
-        const WarpTileAssignment tile =
+        const CtaTileAssignment tile =
             make_tuple(static_cast<int>(blockIdx.x), mTiles, nTiles) |
             scheduler;
         if (!tile.valid) return;

--- a/include/fused_kernel/algorithms/collective/gemm.h
+++ b/include/fused_kernel/algorithms/collective/gemm.h
@@ -1,0 +1,283 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_GEMM_H
+#define FK_COLLECTIVE_GEMM_H
+
+#include <fused_kernel/algorithms/collective/multistage.h>
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+#include <fused_kernel/core/execution_model/executor_details/dpp_launch_config.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace fk {
+
+namespace gemm_detail {
+
+template <typename Input, typename T>
+struct BoundedReadOperation {
+private:
+    using SelfType = BoundedReadOperation<Input, T>;
+
+public:
+    using InputParams = std::decay_t<decltype(std::declval<Input>().params)>;
+    struct BoundedParams {
+        InputParams input;
+        int rows;
+        int columns;
+    };
+    using Parent = ReadOperation<T, BoundedParams, T,
+                                 TF::DISABLED, SelfType>;
+    FK_STATIC_STRUCT(BoundedReadOperation, SelfType)
+    DECLARE_READ_PARENT
+
+    FK_HOST_DEVICE_FUSE InstantiableType instantiate(
+            const ParamsType& params) {
+        return {{params}};
+    }
+
+    FK_HOST_DEVICE_FUSE OutputType exec(const Point point,
+                                        const ParamsType& params) {
+        if (point.x < 0 || point.y < 0 ||
+            point.x >= params.columns || point.y >= params.rows)
+            return T{};
+        return Input::Operation::exec(point, params.input);
+    }
+};
+
+template <typename Output>
+struct BoundedWriteOperation {
+private:
+    using SelfType = BoundedWriteOperation<Output>;
+
+public:
+    using OutputParams = std::decay_t<decltype(std::declval<Output>().params)>;
+    struct BoundedParams {
+        OutputParams output;
+        int rows;
+        int columns;
+    };
+    using Parent = WriteOperation<float2, BoundedParams, float2,
+                                  TF::DISABLED, SelfType>;
+    FK_STATIC_STRUCT(BoundedWriteOperation, SelfType)
+    DECLARE_WRITE_PARENT
+
+    FK_HOST_DEVICE_FUSE InstantiableType instantiate(
+            const ParamsType& params) {
+        return {{params}};
+    }
+
+    FK_HOST_DEVICE_FUSE void exec(const Point point, const InputType value,
+                                  const ParamsType& params) {
+        const int firstColumn = point.x * 2;
+        if (point.y < 0 || point.y >= params.rows ||
+            firstColumn < 0 || firstColumn >= params.columns)
+            return;
+        Output::Operation::exec(point, value, params.output);
+    }
+};
+
+} // namespace gemm_detail
+
+/**
+ * Static GEMM policy plus runtime M/N/K.
+ *
+ * A and B are supplied together as Tuple<ReadIOp, ReadIOp>. D is never part
+ * of this details object: it exists only in the final (possibly fused) Write
+ * IOp passed to GemmDPP::exec.
+ */
+template <
+    int STAGE_COUNT,
+    typename MmaDetailsType,
+    typename AStageLayoutType,
+    typename BStageLayoutType,
+    typename StageTypeT = float,
+    typename SchedulerOperationT = WarpTileScheduler<RowMajorWarpTileRaster>,
+    template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP,
+    template <ParArch, typename> class CopyPolicyTemplate = AsyncCopyDPP>
+struct GemmDPPDetails {
+    static_assert(STAGE_COUNT >= 2,
+                  "GemmDPP requires at least double buffering");
+
+    static constexpr int STAGES = STAGE_COUNT;
+    using MmaDetails = MmaDetailsType;
+    using AStageLayout = AStageLayoutType;
+    using BStageLayout = BStageLayoutType;
+    using StageType = StageTypeT;
+    using SchedulerOperation = SchedulerOperationT;
+    using SchedulerIOp = decltype(SchedulerOperation::build());
+    template <ParArch PA, typename Details>
+    using MmaPolicy = MmaPolicyTemplate<PA, Details>;
+    template <ParArch PA, typename Details>
+    using CopyPolicy = CopyPolicyTemplate<PA, Details>;
+    using MainloopDetails = MultiStageMainloopDPPDetails<
+        STAGES, MmaDetails, AStageLayout, BStageLayout, StageType,
+        MmaPolicyTemplate, CopyPolicyTemplate>;
+
+    static constexpr int TILE_M = MmaDetails::M;
+    static constexpr int TILE_N = MmaDetails::N;
+
+    int M;
+    int N;
+    int K;
+
+    FK_HOST_DEVICE_CNST bool valid() const {
+        return M > 0 && N > 0 && K > 0;
+    }
+};
+
+template <ParArch PA, typename GemmDetails>
+struct GemmDPP;
+
+template <typename GemmDetails>
+struct GemmDPP<ParArch::CPU, GemmDetails> {
+private:
+    using SelfType = GemmDPP<ParArch::CPU, GemmDetails>;
+    using Mainloop = MultiStageMainloopDPP<
+        ParArch::CPU, typename GemmDetails::MainloopDetails>;
+
+    template <typename Inputs, typename Output>
+    FK_HOST_STATIC void executeTile(const GemmDetails& details,
+                                    const WarpTileAssignment tile,
+                                    const Inputs& inputs,
+                                    const Output& output) {
+        const auto& a = get<0>(inputs);
+        const auto& b = get<1>(inputs);
+        using A = std::decay_t<decltype(a)>;
+        using B = std::decay_t<decltype(b)>;
+        using Out = std::decay_t<Output>;
+        using MmaDetails = typename GemmDetails::MmaDetails;
+        const int row = tile.mTile * GemmDetails::TILE_M;
+        const int column = tile.nTile * GemmDetails::TILE_N;
+        const typename GemmDetails::MainloopDetails mainloopDetails{
+            GemmDetails::STAGES, details.K,
+            0, row, 0, column, column / 2, row};
+        const bool fullTile = row + GemmDetails::TILE_M <= details.M &&
+                              column + GemmDetails::TILE_N <= details.N;
+        const bool fullK = details.K % MmaDetails::K == 0;
+        if (fullTile && fullK) {
+            Mainloop::exec(mainloopDetails, inputs, output);
+            return;
+        }
+        const auto boundedInputs = make_tuple(
+            gemm_detail::BoundedReadOperation<
+                A, typename GemmDetails::StageType>::instantiate(
+                    {a.params, details.M, details.K}),
+            gemm_detail::BoundedReadOperation<
+                B, typename GemmDetails::StageType>::instantiate(
+                    {b.params, details.N, details.K}));
+        const auto boundedOutput =
+            gemm_detail::BoundedWriteOperation<Out>::instantiate(
+                {output.params, details.M, details.N});
+        Mainloop::exec(mainloopDetails, boundedInputs, boundedOutput);
+    }
+
+public:
+    FK_STATIC_STRUCT(GemmDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const GemmDetails&) {
+        return {};
+    }
+
+    template <typename Inputs, typename Output>
+    FK_HOST_STATIC void exec(const GemmDetails& details,
+                             const Inputs& inputs, const Output& output) {
+        if (!details.valid()) return;
+        const int mTiles =
+            (details.M + GemmDetails::TILE_M - 1) / GemmDetails::TILE_M;
+        const int nTiles =
+            (details.N + GemmDetails::TILE_N - 1) / GemmDetails::TILE_N;
+        const typename GemmDetails::SchedulerIOp scheduler{};
+        for (int tileId = 0; tileId < mTiles * nTiles; ++tileId) {
+            const WarpTileAssignment tile =
+                make_tuple(tileId, mTiles, nTiles) | scheduler;
+            if (tile.valid) executeTile(details, tile, inputs, output);
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename GemmDetails>
+struct GemmDPP<ParArch::GPU_NVIDIA, GemmDetails> {
+private:
+    using SelfType = GemmDPP<ParArch::GPU_NVIDIA, GemmDetails>;
+    using Mainloop = MultiStageMainloopDPP<
+        ParArch::GPU_NVIDIA, typename GemmDetails::MainloopDetails>;
+
+public:
+    FK_STATIC_STRUCT(GemmDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const GemmDetails& details) {
+        const unsigned int mTiles = static_cast<unsigned int>(
+            (details.M + GemmDetails::TILE_M - 1) / GemmDetails::TILE_M);
+        const unsigned int nTiles = static_cast<unsigned int>(
+            (details.N + GemmDetails::TILE_N - 1) / GemmDetails::TILE_N);
+        // MultiStageMainloopDPP owns static shared storage internally.
+        return {mTiles * nTiles, 1, 1, 32, 1, 1, 0};
+    }
+
+    template <typename Inputs, typename Output>
+    FK_DEVICE_STATIC void exec(const GemmDetails& details,
+                               const Inputs& inputs, const Output& output) {
+        if (!details.valid()) return;
+        const int mTiles =
+            (details.M + GemmDetails::TILE_M - 1) / GemmDetails::TILE_M;
+        const int nTiles =
+            (details.N + GemmDetails::TILE_N - 1) / GemmDetails::TILE_N;
+        const typename GemmDetails::SchedulerIOp scheduler{};
+        const WarpTileAssignment tile =
+            make_tuple(static_cast<int>(blockIdx.x), mTiles, nTiles) |
+            scheduler;
+        if (!tile.valid) return;
+
+        const auto& a = get<0>(inputs);
+        const auto& b = get<1>(inputs);
+        using A = std::decay_t<decltype(a)>;
+        using B = std::decay_t<decltype(b)>;
+        using Out = std::decay_t<Output>;
+        using MmaDetails = typename GemmDetails::MmaDetails;
+        const int row = tile.mTile * GemmDetails::TILE_M;
+        const int column = tile.nTile * GemmDetails::TILE_N;
+        const typename GemmDetails::MainloopDetails mainloopDetails{
+            GemmDetails::STAGES, details.K,
+            0, row, 0, column, column / 2, row};
+        const bool fullTile = row + GemmDetails::TILE_M <= details.M &&
+                              column + GemmDetails::TILE_N <= details.N;
+        const bool fullK = details.K % MmaDetails::K == 0;
+        if (fullTile && fullK) {
+            Mainloop::exec(mainloopDetails, inputs, output);
+            return;
+        }
+        const auto boundedInputs = make_tuple(
+            gemm_detail::BoundedReadOperation<
+                A, typename GemmDetails::StageType>::instantiate(
+                    {a.params, details.M, details.K}),
+            gemm_detail::BoundedReadOperation<
+                B, typename GemmDetails::StageType>::instantiate(
+                    {b.params, details.N, details.K}));
+        const auto boundedOutput =
+            gemm_detail::BoundedWriteOperation<Out>::instantiate(
+                {output.params, details.M, details.N});
+        Mainloop::exec(mainloopDetails, boundedInputs, boundedOutput);
+    }
+};
+#endif
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_GEMM_H

--- a/include/fused_kernel/algorithms/collective/mainloop.h
+++ b/include/fused_kernel/algorithms/collective/mainloop.h
@@ -1,0 +1,143 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MAINLOOP_H
+#define FK_COLLECTIVE_MAINLOOP_H
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+/**
+ * Static mainloop policy plus runtime matrix origins and K extent.
+ *
+ * The MMA policy is part of Details so the DPP itself has only the canonical
+ * <ParArch, Details> template shape. A/B and D remain real exec-time IOps.
+ */
+template <typename MmaDetails,
+          template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP>
+struct TileMmaMainloopDPPDetails {
+    using MmaDetailsType = MmaDetails;
+    template <ParArch PA>
+    using MmaPolicy = MmaPolicyTemplate<PA, MmaDetails>;
+
+    static constexpr int M = MmaDetails::M;
+    static constexpr int N = MmaDetails::N;
+    static constexpr int K_TILE = MmaDetails::K;
+
+    int K;
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct TileMmaMainloopDPP;
+
+template <typename DPPDetails>
+struct TileMmaMainloopDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::CPU, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using MmaPolicy = typename DPPDetails::template MmaPolicy<ParArch::CPU>;
+
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const ReadIOps& reads,
+                             const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> && std::decay_t<ReadIOps>::size == 2,
+                      "TileMmaMainloopDPP requires Tuple<AReadIOp, BReadIOp>");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "TileMmaMainloopDPP requires a Write IOp");
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0) return;
+
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        typename MmaPolicy::AccumulatorFragment fragment;
+        MmaPolicy::clear(fragment);
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            const MmaDetails mmaDetails{
+                details.aOriginX + kBase, details.aOriginY,
+                details.bOriginX + kBase, details.bOriginY,
+                details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mmaDetails, a, b, fragment);
+        }
+        const MmaDetails outputDetails{
+            details.aOriginX, details.aOriginY,
+            details.bOriginX, details.bOriginY,
+            details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, fragment, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using MmaPolicy =
+        typename DPPDetails::template MmaPolicy<ParArch::GPU_NVIDIA>;
+
+public:
+    FK_STATIC_STRUCT(TileMmaMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const ReadIOps& reads,
+                               const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> && std::decay_t<ReadIOps>::size == 2,
+                      "TileMmaMainloopDPP requires Tuple<AReadIOp, BReadIOp>");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "TileMmaMainloopDPP requires a Write IOp");
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0) return;
+
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        typename MmaPolicy::AccumulatorFragment fragment;
+        MmaPolicy::clear(fragment);
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            const MmaDetails mmaDetails{
+                details.aOriginX + kBase, details.aOriginY,
+                details.bOriginX + kBase, details.bOriginY,
+                details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mmaDetails, a, b, fragment);
+        }
+        const MmaDetails outputDetails{
+            details.aOriginX, details.aOriginY,
+            details.bOriginX, details.bOriginY,
+            details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, fragment, output);
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MAINLOOP_H

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -62,45 +62,72 @@ private:
     using SelfType = MmaWarpDPP<ParArch::CPU, DPPDetails>;
 
 public:
+    struct AccumulatorFragment {
+        float values[DPPDetails::M][DPPDetails::N];
+    };
+
     FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    FK_HOST_STATIC void clear(AccumulatorFragment& fragment) {
+        for (int row = 0; row < DPPDetails::M; ++row)
+            for (int col = 0; col < DPPDetails::N; ++col)
+                fragment.values[row][col] = 0.f;
+    }
+
+    template <typename AReadIOp, typename BReadIOp>
+    FK_HOST_STATIC void accumulate(const DPPDetails& details,
+                                   const AReadIOp& a,
+                                   const BReadIOp& b,
+                                   AccumulatorFragment& fragment) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int col = 0; col < DPPDetails::N; ++col) {
+                float value = fragment.values[row][col];
+                for (int k = 0; k < DPPDetails::K; ++k) {
+                    const float av = static_cast<float>(
+                        AReadIOp::Operation::exec(
+                            Point{details.aOriginX + k,
+                                  details.aOriginY + row, 0}, a));
+                    const float bv = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + col, 0}, b));
+                    value += av * bv;
+                }
+                fragment.values[row][col] = value;
+            }
+        }
+    }
+
+    template <typename DWriteIOp>
+    FK_HOST_STATIC void store(const DPPDetails& details,
+                              const AccumulatorFragment& fragment,
+                              const DWriteIOp& d) {
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
+                DWriteIOp::Operation::exec(
+                    Point{details.dOriginX + pair,
+                          details.dOriginY + row, 0},
+                    float2{fragment.values[row][2 * pair],
+                           fragment.values[row][2 * pair + 1]}, d);
+            }
+        }
+    }
 
     template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
     FK_HOST_STATIC void exec(const DPPDetails& details,
                              const AReadIOp& a,
                              const BReadIOp& b,
                              const DWriteIOp& d) {
-        static_assert(isAnyCompleteReadType<AReadIOp> &&
-                      isAnyCompleteReadType<BReadIOp>,
-                      "MmaWarpDPP requires complete A/B Read IOps");
-        static_assert(isAnyWriteType<DWriteIOp>,
-                      "MmaWarpDPP requires a D Write IOp");
-        for (int row = 0; row < DPPDetails::M; ++row) {
-            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
-                float accum0 = 0.f;
-                float accum1 = 0.f;
-                for (int k = 0; k < DPPDetails::K; ++k) {
-                    const float av = static_cast<float>(
-                        AReadIOp::Operation::exec(
-                            Point{details.aOriginX + k,
-                                  details.aOriginY + row, 0}, a));
-                    const float bv0 = static_cast<float>(
-                        BReadIOp::Operation::exec(
-                            Point{details.bOriginX + k,
-                                  details.bOriginY + 2 * pair, 0}, b));
-                    const float bv1 = static_cast<float>(
-                        BReadIOp::Operation::exec(
-                            Point{details.bOriginX + k,
-                                  details.bOriginY + 2 * pair + 1, 0}, b));
-                    accum0 += av * bv0;
-                    accum1 += av * bv1;
-                }
-                DWriteIOp::Operation::exec(
-                    Point{details.dOriginX + pair,
-                          details.dOriginY + row, 0},
-                    float2{accum0, accum1}, d);
-            }
-        }
+        AccumulatorFragment fragment;
+        clear(fragment);
+        accumulate(details, a, b, fragment);
+        store(details, fragment, d);
     }
 };
 
@@ -146,19 +173,26 @@ private:
     }
 
 public:
+    struct AccumulatorFragment {
+        float values[4];
+    };
+
     FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
     static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
 
-    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
-    FK_DEVICE_STATIC void exec(const DPPDetails& details,
-                               const AReadIOp& aInput,
-                               const BReadIOp& bInput,
-                               const DWriteIOp& dOutput) {
+    FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) fragment.values[i] = 0.f;
+    }
+
+    template <typename AReadIOp, typename BReadIOp>
+    FK_DEVICE_STATIC void accumulate(const DPPDetails& details,
+                                     const AReadIOp& aInput,
+                                     const BReadIOp& bInput,
+                                     AccumulatorFragment& fragment) {
         static_assert(isAnyCompleteReadType<AReadIOp> &&
                       isAnyCompleteReadType<BReadIOp>,
                       "MmaWarpDPP requires complete A/B Read IOps");
-        static_assert(isAnyWriteType<DWriteIOp>,
-                      "MmaWarpDPP requires a D Write IOp");
         static_assert(std::is_same_v<typename DPPDetails::AtomType,
                                      MmaBf16_16x8x16>,
                       "GPU specialization currently supports bf16 m16n8k16");
@@ -205,19 +239,37 @@ public:
             readBf16(bInput, Point{details.bOriginX + k1 + 1,
                                     details.bOriginY + group, 0}));
 
-        float d[4]{0.f, 0.f, 0.f, 0.f};
-        mma(a, b, d);
+        mma(a, b, fragment.values);
+    }
 
-        // Each lane writes two adjacent output columns as float2. The four
-        // lanes in a group cover a full 8-column row with coalesced stores.
+    template <typename DWriteIOp>
+    FK_DEVICE_STATIC void store(const DPPDetails& details,
+                                const AccumulatorFragment& fragment,
+                                const DWriteIOp& dOutput) {
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        if (threadIdx.x >= 32) return;
+        const int group = threadIdx.x >> 2;
+        const int threadInGroup = threadIdx.x & 3;
         DWriteIOp::Operation::exec(
             Point{details.dOriginX + threadInGroup,
-                  details.dOriginY + row0, 0},
-            float2{d[0], d[1]}, dOutput);
+                  details.dOriginY + group, 0},
+            float2{fragment.values[0], fragment.values[1]}, dOutput);
         DWriteIOp::Operation::exec(
             Point{details.dOriginX + threadInGroup,
-                  details.dOriginY + row1, 0},
-            float2{d[2], d[3]}, dOutput);
+                  details.dOriginY + group + 8, 0},
+            float2{fragment.values[2], fragment.values[3]}, dOutput);
+    }
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const AReadIOp& aInput,
+                               const BReadIOp& bInput,
+                               const DWriteIOp& dOutput) {
+        AccumulatorFragment fragment;
+        clear(fragment);
+        accumulate(details, aInput, bInput, fragment);
+        store(details, fragment, dOutput);
     }
 };
 #endif // defined(__NVCC__)

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -62,6 +62,12 @@ private:
     using SelfType = MmaWarpDPP<ParArch::CPU, DPPDetails>;
 
 public:
+    struct AFragment {
+        float values[DPPDetails::M][DPPDetails::K];
+    };
+    struct BFragment {
+        float values[DPPDetails::N][DPPDetails::K];
+    };
     struct AccumulatorFragment {
         float values[DPPDetails::M][DPPDetails::N];
     };
@@ -73,6 +79,42 @@ public:
         for (int row = 0; row < DPPDetails::M; ++row)
             for (int col = 0; col < DPPDetails::N; ++col)
                 fragment.values[row][col] = 0.f;
+    }
+
+    template <typename AReadIOp>
+    FK_HOST_STATIC void loadAFragment(const DPPDetails& details,
+                                      const AReadIOp& input,
+                                      AFragment& fragment) {
+        static_assert(isAnyCompleteReadType<AReadIOp>);
+        for (int row = 0; row < DPPDetails::M; ++row)
+            for (int k = 0; k < DPPDetails::K; ++k)
+                fragment.values[row][k] = static_cast<float>(
+                    AReadIOp::Operation::exec(
+                        Point{details.aOriginX + k,
+                              details.aOriginY + row, 0}, input));
+    }
+
+    template <typename BReadIOp>
+    FK_HOST_STATIC void loadBFragment(const DPPDetails& details,
+                                      const BReadIOp& input,
+                                      BFragment& fragment) {
+        static_assert(isAnyCompleteReadType<BReadIOp>);
+        for (int col = 0; col < DPPDetails::N; ++col)
+            for (int k = 0; k < DPPDetails::K; ++k)
+                fragment.values[col][k] = static_cast<float>(
+                    BReadIOp::Operation::exec(
+                        Point{details.bOriginX + k,
+                              details.bOriginY + col, 0}, input));
+    }
+
+    FK_HOST_STATIC void multiply(const AFragment& a,
+                                 const BFragment& b,
+                                 AccumulatorFragment& accumulator) {
+        for (int row = 0; row < DPPDetails::M; ++row)
+            for (int col = 0; col < DPPDetails::N; ++col)
+                for (int k = 0; k < DPPDetails::K; ++k)
+                    accumulator.values[row][col] +=
+                        a.values[row][k] * b.values[col][k];
     }
 
     template <typename AReadIOp, typename BReadIOp>
@@ -173,6 +215,8 @@ private:
     }
 
 public:
+    struct AFragment { uint32_t values[4]; };
+    struct BFragment { uint32_t values[2]; };
     struct AccumulatorFragment {
         float values[4];
     };
@@ -183,6 +227,66 @@ public:
     FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
         #pragma unroll
         for (int i = 0; i < 4; ++i) fragment.values[i] = 0.f;
+    }
+
+    template <typename AReadIOp>
+    FK_DEVICE_STATIC void loadAFragment(const DPPDetails& details,
+                                        const AReadIOp& input,
+                                        AFragment& fragment) {
+        static_assert(isAnyCompleteReadType<AReadIOp>);
+        const int lane = threadIdx.x & 31;
+        const int group = lane >> 2;
+        const int threadInGroup = lane & 3;
+        const int k0 = 2 * threadInGroup;
+        const int k1 = k0 + 8;
+        fragment.values[0] = pack(
+            readBf16(input, Point{details.aOriginX + k0,
+                                  details.aOriginY + group, 0}),
+            readBf16(input, Point{details.aOriginX + k0 + 1,
+                                  details.aOriginY + group, 0}));
+        fragment.values[1] = pack(
+            readBf16(input, Point{details.aOriginX + k0,
+                                  details.aOriginY + group + 8, 0}),
+            readBf16(input, Point{details.aOriginX + k0 + 1,
+                                  details.aOriginY + group + 8, 0}));
+        fragment.values[2] = pack(
+            readBf16(input, Point{details.aOriginX + k1,
+                                  details.aOriginY + group, 0}),
+            readBf16(input, Point{details.aOriginX + k1 + 1,
+                                  details.aOriginY + group, 0}));
+        fragment.values[3] = pack(
+            readBf16(input, Point{details.aOriginX + k1,
+                                  details.aOriginY + group + 8, 0}),
+            readBf16(input, Point{details.aOriginX + k1 + 1,
+                                  details.aOriginY + group + 8, 0}));
+    }
+
+    template <typename BReadIOp>
+    FK_DEVICE_STATIC void loadBFragment(const DPPDetails& details,
+                                        const BReadIOp& input,
+                                        BFragment& fragment) {
+        static_assert(isAnyCompleteReadType<BReadIOp>);
+        const int lane = threadIdx.x & 31;
+        const int group = lane >> 2;
+        const int threadInGroup = lane & 3;
+        const int k0 = 2 * threadInGroup;
+        const int k1 = k0 + 8;
+        fragment.values[0] = pack(
+            readBf16(input, Point{details.bOriginX + k0,
+                                  details.bOriginY + group, 0}),
+            readBf16(input, Point{details.bOriginX + k0 + 1,
+                                  details.bOriginY + group, 0}));
+        fragment.values[1] = pack(
+            readBf16(input, Point{details.bOriginX + k1,
+                                  details.bOriginY + group, 0}),
+            readBf16(input, Point{details.bOriginX + k1 + 1,
+                                  details.bOriginY + group, 0}));
+    }
+
+    FK_DEVICE_STATIC void multiply(const AFragment& a,
+                                   const BFragment& b,
+                                   AccumulatorFragment& accumulator) {
+        mma(a.values, b.values, accumulator.values);
     }
 
     template <typename AReadIOp, typename BReadIOp>

--- a/include/fused_kernel/algorithms/collective/mma.h
+++ b/include/fused_kernel/algorithms/collective/mma.h
@@ -1,0 +1,227 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MMA_H
+#define FK_COLLECTIVE_MMA_H
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+namespace fk {
+
+struct MmaBf16_16x8x16 {
+    static constexpr int M = 16;
+    static constexpr int N = 8;
+    static constexpr int K = 16;
+    static constexpr int A_REGS = 4;
+    static constexpr int B_REGS = 2;
+    static constexpr int D_REGS = 4;
+};
+
+template <typename Atom>
+struct MmaDPPDetails {
+    using AtomType = Atom;
+    static constexpr int M = Atom::M;
+    static constexpr int N = Atom::N;
+    static constexpr int K = Atom::K;
+
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+};
+
+template <ParArch PA, typename DPPDetails>
+struct MmaWarpDPP;
+
+template <typename DPPDetails>
+struct MmaWarpDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = MmaWarpDPP<ParArch::CPU, DPPDetails>;
+
+public:
+    FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const AReadIOp& a,
+                             const BReadIOp& b,
+                             const DWriteIOp& d) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        for (int row = 0; row < DPPDetails::M; ++row) {
+            for (int pair = 0; pair < DPPDetails::N / 2; ++pair) {
+                float accum0 = 0.f;
+                float accum1 = 0.f;
+                for (int k = 0; k < DPPDetails::K; ++k) {
+                    const float av = static_cast<float>(
+                        AReadIOp::Operation::exec(
+                            Point{details.aOriginX + k,
+                                  details.aOriginY + row, 0}, a));
+                    const float bv0 = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + 2 * pair, 0}, b));
+                    const float bv1 = static_cast<float>(
+                        BReadIOp::Operation::exec(
+                            Point{details.bOriginX + k,
+                                  details.bOriginY + 2 * pair + 1, 0}, b));
+                    accum0 += av * bv0;
+                    accum1 += av * bv1;
+                }
+                DWriteIOp::Operation::exec(
+                    Point{details.dOriginX + pair,
+                          details.dOriginY + row, 0},
+                    float2{accum0, accum1}, d);
+            }
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct MmaWarpDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = MmaWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+
+    FK_DEVICE_STATIC uint32_t pack(const __nv_bfloat16 first,
+                                   const __nv_bfloat16 second) {
+        const __nv_bfloat16 pair[2]{first, second};
+        uint32_t result;
+        memcpy(&result, pair, sizeof(result));
+        return result;
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC __nv_bfloat16 readBf16(
+            const ReadIOp& input, const Point point) {
+        const auto value = ReadIOp::Operation::exec(point, input);
+        if constexpr (std::is_same_v<decltype(value), const uint16_t> ||
+                      std::is_same_v<decltype(value), uint16_t>) {
+            __nv_bfloat16 result;
+            memcpy(&result, &value, sizeof(result));
+            return result;
+        } else {
+            return __float2bfloat16(static_cast<float>(value));
+        }
+    }
+
+    // Tensor-core MMA is the narrow exception that directly updates each
+    // lane's register fragment. This helper is private to the warp DPP.
+    FK_DEVICE_STATIC void mma(const uint32_t (&a)[4],
+                              const uint32_t (&b)[2],
+                              float (&d)[4]) {
+        asm volatile(
+            "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+            "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};"
+            : "+f"(d[0]), "+f"(d[1]), "+f"(d[2]), "+f"(d[3])
+            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+              "r"(b[0]), "r"(b[1]));
+    }
+
+public:
+    FK_STATIC_STRUCT(MmaWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename AReadIOp, typename BReadIOp, typename DWriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const AReadIOp& aInput,
+                               const BReadIOp& bInput,
+                               const DWriteIOp& dOutput) {
+        static_assert(isAnyCompleteReadType<AReadIOp> &&
+                      isAnyCompleteReadType<BReadIOp>,
+                      "MmaWarpDPP requires complete A/B Read IOps");
+        static_assert(isAnyWriteType<DWriteIOp>,
+                      "MmaWarpDPP requires a D Write IOp");
+        static_assert(std::is_same_v<typename DPPDetails::AtomType,
+                                     MmaBf16_16x8x16>,
+                      "GPU specialization currently supports bf16 m16n8k16");
+        if (threadIdx.x >= 32) return;
+
+        const int lane = threadIdx.x;
+        const int group = lane >> 2;
+        const int threadInGroup = lane & 3;
+        const int k0 = 2 * threadInGroup;
+        const int k1 = k0 + 8;
+        const int row0 = group;
+        const int row1 = group + 8;
+
+        uint32_t a[4];
+        uint32_t b[2];
+        a[0] = pack(
+            readBf16(aInput, Point{details.aOriginX + k0,
+                                    details.aOriginY + row0, 0}),
+            readBf16(aInput, Point{details.aOriginX + k0 + 1,
+                                    details.aOriginY + row0, 0}));
+        a[1] = pack(
+            readBf16(aInput, Point{details.aOriginX + k0,
+                                    details.aOriginY + row1, 0}),
+            readBf16(aInput, Point{details.aOriginX + k0 + 1,
+                                    details.aOriginY + row1, 0}));
+        a[2] = pack(
+            readBf16(aInput, Point{details.aOriginX + k1,
+                                    details.aOriginY + row0, 0}),
+            readBf16(aInput, Point{details.aOriginX + k1 + 1,
+                                    details.aOriginY + row0, 0}));
+        a[3] = pack(
+            readBf16(aInput, Point{details.aOriginX + k1,
+                                    details.aOriginY + row1, 0}),
+            readBf16(aInput, Point{details.aOriginX + k1 + 1,
+                                    details.aOriginY + row1, 0}));
+        b[0] = pack(
+            readBf16(bInput, Point{details.bOriginX + k0,
+                                    details.bOriginY + group, 0}),
+            readBf16(bInput, Point{details.bOriginX + k0 + 1,
+                                    details.bOriginY + group, 0}));
+        b[1] = pack(
+            readBf16(bInput, Point{details.bOriginX + k1,
+                                    details.bOriginY + group, 0}),
+            readBf16(bInput, Point{details.bOriginX + k1 + 1,
+                                    details.bOriginY + group, 0}));
+
+        float d[4]{0.f, 0.f, 0.f, 0.f};
+        mma(a, b, d);
+
+        // Each lane writes two adjacent output columns as float2. The four
+        // lanes in a group cover a full 8-column row with coalesced stores.
+        DWriteIOp::Operation::exec(
+            Point{details.dOriginX + threadInGroup,
+                  details.dOriginY + row0, 0},
+            float2{d[0], d[1]}, dOutput);
+        DWriteIOp::Operation::exec(
+            Point{details.dOriginX + threadInGroup,
+                  details.dOriginY + row1, 0},
+            float2{d[2], d[3]}, dOutput);
+    }
+};
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MMA_H

--- a/include/fused_kernel/algorithms/collective/multistage.h
+++ b/include/fused_kernel/algorithms/collective/multistage.h
@@ -1,0 +1,322 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_MULTISTAGE_H
+#define FK_COLLECTIVE_MULTISTAGE_H
+
+#include <fused_kernel/algorithms/collective/async_copy.h>
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/tile.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <int MAX_STAGE_COUNT, typename MmaDetails,
+          typename ALayout, typename BLayout, typename StageT = float,
+          template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP,
+          template <ParArch, typename> class CopyPolicyTemplate = AsyncCopyDPP>
+struct MultiStageMainloopDPPDetails {
+    static_assert(MAX_STAGE_COUNT >= 2 && MAX_STAGE_COUNT <= 8,
+                  "MAX_STAGES must be in [2, 8]");
+    static_assert(ALayout::rows == MmaDetails::M &&
+                  ALayout::cols == MmaDetails::K,
+                  "A stage layout must be M x K_TILE");
+    static_assert(BLayout::rows == MmaDetails::N &&
+                  BLayout::cols == MmaDetails::K,
+                  "B stage layout must be N x K_TILE");
+
+    using MmaDetailsType = MmaDetails;
+    using ALayoutType = ALayout;
+    using BLayoutType = BLayout;
+    using StageType = StageT;
+    using ACopyDetails = AsyncCopy2DDPPDetails<StageT, ALayout, 32>;
+    using BCopyDetails = AsyncCopy2DDPPDetails<StageT, BLayout, 32>;
+
+    template <ParArch PA>
+    using MmaPolicy = MmaPolicyTemplate<PA, MmaDetails>;
+    template <ParArch PA>
+    using ACopyPolicy = CopyPolicyTemplate<PA, ACopyDetails>;
+    template <ParArch PA>
+    using BCopyPolicy = CopyPolicyTemplate<PA, BCopyDetails>;
+
+    static constexpr int MAX_STAGES = MAX_STAGE_COUNT;
+    static constexpr int M = MmaDetails::M;
+    static constexpr int N = MmaDetails::N;
+    static constexpr int K_TILE = MmaDetails::K;
+    static constexpr uint A_STAGE_ELEMENTS = ALayout::size();
+    static constexpr uint B_STAGE_ELEMENTS = BLayout::size();
+    static constexpr uint SHARED_ELEMENTS =
+        MAX_STAGES * (A_STAGE_ELEMENTS + B_STAGE_ELEMENTS);
+    static constexpr uint SHARED_BYTES = SHARED_ELEMENTS * sizeof(StageT);
+
+    int stages;
+    int K;
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+
+    FK_HOST_DEVICE_CNST bool valid() const {
+        return stages >= 2 && stages <= MAX_STAGES && K > 0;
+    }
+};
+
+namespace multistage_detail {
+
+template <typename T, typename Layout>
+struct SharedTileRead {
+private:
+    using Parent = ReadOperation<T, Tile<T, Layout>, T, TF::ENABLED,
+                                 SharedTileRead<T, Layout>>;
+    using SelfType = SharedTileRead<T, Layout>;
+
+public:
+    FK_STATIC_STRUCT(SharedTileRead, SelfType)
+    DECLARE_READ_PARENT
+
+    template <uint ELEMS_PER_THREAD = 1>
+    FK_HOST_DEVICE_FUSE auto exec(const Point point,
+                                  const ParamsType& tile)
+        -> ThreadFusionType<T, ELEMS_PER_THREAD, T> {
+        static_assert(ELEMS_PER_THREAD == 1,
+                      "MMA shared fragments read one scalar per access");
+        return tile.at(static_cast<uint>(point.y),
+                       static_cast<uint>(point.x));
+    }
+};
+
+} // namespace multistage_detail
+
+template <ParArch PA, typename DPPDetails>
+struct MultiStageMainloopDPP;
+
+template <typename DPPDetails>
+struct MultiStageMainloopDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = MultiStageMainloopDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::StageType;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using ALayout = typename DPPDetails::ALayoutType;
+    using BLayout = typename DPPDetails::BLayoutType;
+    using MmaPolicy = typename DPPDetails::template MmaPolicy<ParArch::CPU>;
+    using ACopyPolicy =
+        typename DPPDetails::template ACopyPolicy<ParArch::CPU>;
+    using BCopyPolicy =
+        typename DPPDetails::template BCopyPolicy<ParArch::CPU>;
+    using ACopyDetails = typename DPPDetails::ACopyDetails;
+    using BCopyDetails = typename DPPDetails::BCopyDetails;
+    using ASharedOperation = multistage_detail::SharedTileRead<T, ALayout>;
+    using BSharedOperation = multistage_detail::SharedTileRead<T, BLayout>;
+    using ASharedRead = typename ASharedOperation::InstantiableType;
+    using BSharedRead = typename BSharedOperation::InstantiableType;
+
+public:
+    FK_STATIC_STRUCT(MultiStageMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const ReadIOps& reads,
+                             const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> &&
+                      std::decay_t<ReadIOps>::size == 2,
+                      "MultiStageMainloopDPP requires Tuple<A, B> reads");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "MultiStageMainloopDPP requires a Write IOp");
+        if (!details.valid()) return;
+
+        T aStorage[DPPDetails::MAX_STAGES][ALayout::size()];
+        T bStorage[DPPDetails::MAX_STAGES][BLayout::size()];
+        const auto& aInput = get<0>(reads);
+        const auto& bInput = get<1>(reads);
+        const int tileCount =
+            (details.K + DPPDetails::K_TILE - 1) / DPPDetails::K_TILE;
+        typename MmaPolicy::AccumulatorFragment accumulator;
+        MmaPolicy::clear(accumulator);
+
+        auto stageTile = [&](const int tileIndex, const int slot) {
+            const int kBase = tileIndex * DPPDetails::K_TILE;
+            int validK = details.K - kBase;
+            validK = validK > DPPDetails::K_TILE
+                ? DPPDetails::K_TILE : validK;
+            const ACopyDetails aCopy{
+                details.aOriginX + kBase, details.aOriginY,
+                validK, DPPDetails::M, T{}};
+            const BCopyDetails bCopy{
+                details.bOriginX + kBase, details.bOriginY,
+                validK, DPPDetails::N, T{}};
+            ACopyPolicy::load(
+                aCopy, aInput, Tile<T, ALayout>{aStorage[slot]});
+            BCopyPolicy::load(
+                bCopy, bInput, Tile<T, BLayout>{bStorage[slot]});
+        };
+
+        const int prefetch = tileCount < details.stages - 1
+            ? tileCount : details.stages - 1;
+        for (int tile = 0; tile < prefetch; ++tile)
+            stageTile(tile, tile % details.stages);
+        int nextTile = prefetch;
+        for (int tile = 0; tile < tileCount; ++tile) {
+            const int slot = tile % details.stages;
+            const Tile<T, ALayout> aTile{aStorage[slot]};
+            const Tile<T, BLayout> bTile{bStorage[slot]};
+            const ASharedRead aShared{{aTile}};
+            const BSharedRead bShared{{bTile}};
+            const MmaDetails mma{0, 0, 0, 0,
+                                 details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mma, aShared, bShared, accumulator);
+            if (nextTile < tileCount) {
+                stageTile(nextTile, nextTile % details.stages);
+                ++nextTile;
+            }
+        }
+        const MmaDetails outputDetails{
+            0, 0, 0, 0, details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, accumulator, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct MultiStageMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType =
+        MultiStageMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::StageType;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using ALayout = typename DPPDetails::ALayoutType;
+    using BLayout = typename DPPDetails::BLayoutType;
+    using MmaPolicy =
+        typename DPPDetails::template MmaPolicy<ParArch::GPU_NVIDIA>;
+    using ACopyPolicy =
+        typename DPPDetails::template ACopyPolicy<ParArch::GPU_NVIDIA>;
+    using BCopyPolicy =
+        typename DPPDetails::template BCopyPolicy<ParArch::GPU_NVIDIA>;
+    using ACopyDetails = typename DPPDetails::ACopyDetails;
+    using BCopyDetails = typename DPPDetails::BCopyDetails;
+    using ASharedOperation = multistage_detail::SharedTileRead<T, ALayout>;
+    using BSharedOperation = multistage_detail::SharedTileRead<T, BLayout>;
+    using ASharedRead = typename ASharedOperation::InstantiableType;
+    using BSharedRead = typename BSharedOperation::InstantiableType;
+
+    FK_DEVICE_STATIC void waitForPending(const int pending) {
+        switch (pending) {
+            case 0: ACopyPolicy::template wait<0>(); break;
+            case 1: ACopyPolicy::template wait<1>(); break;
+            case 2: ACopyPolicy::template wait<2>(); break;
+            case 3: ACopyPolicy::template wait<3>(); break;
+            case 4: ACopyPolicy::template wait<4>(); break;
+            case 5: ACopyPolicy::template wait<5>(); break;
+            case 6: ACopyPolicy::template wait<6>(); break;
+            default: ACopyPolicy::template wait<7>(); break;
+        }
+    }
+
+public:
+    FK_STATIC_STRUCT(MultiStageMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const ReadIOps& reads,
+                               const WriteIOp& output) {
+        static_assert(isTuple_v<ReadIOps> &&
+                      std::decay_t<ReadIOps>::size == 2,
+                      "MultiStageMainloopDPP requires Tuple<A, B> reads");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "MultiStageMainloopDPP requires a Write IOp");
+        if (!details.valid() || blockDim.x != 32) return;
+
+        __shared__ T aStorage[DPPDetails::MAX_STAGES][ALayout::size()];
+        __shared__ T bStorage[DPPDetails::MAX_STAGES][BLayout::size()];
+        const auto& aInput = get<0>(reads);
+        const auto& bInput = get<1>(reads);
+        const int tileCount =
+            (details.K + DPPDetails::K_TILE - 1) / DPPDetails::K_TILE;
+        typename MmaPolicy::AccumulatorFragment accumulator;
+        MmaPolicy::clear(accumulator);
+
+        auto issueTile = [&](const int tileIndex, const int slot) {
+            const int kBase = tileIndex * DPPDetails::K_TILE;
+            int validK = details.K - kBase;
+            validK = validK > DPPDetails::K_TILE
+                ? DPPDetails::K_TILE : validK;
+            const ACopyDetails aCopy{
+                details.aOriginX + kBase, details.aOriginY,
+                validK, DPPDetails::M, T{}};
+            const BCopyDetails bCopy{
+                details.bOriginX + kBase, details.bOriginY,
+                validK, DPPDetails::N, T{}};
+            ACopyPolicy::issue(
+                aCopy, aInput, Tile<T, ALayout>{aStorage[slot]});
+            BCopyPolicy::issue(
+                bCopy, bInput, Tile<T, BLayout>{bStorage[slot]});
+            ACopyPolicy::commit();
+        };
+
+        const int prefetch = tileCount < details.stages - 1
+            ? tileCount : details.stages - 1;
+        for (int tile = 0; tile < prefetch; ++tile)
+            issueTile(tile, tile % details.stages);
+        int nextTile = prefetch;
+
+        for (int tile = 0; tile < tileCount; ++tile) {
+            const int slot = tile % details.stages;
+            const int pendingAfterCurrent = nextTile - tile - 1;
+            waitForPending(pendingAfterCurrent);
+
+            const int kBase = tile * DPPDetails::K_TILE;
+            int validK = details.K - kBase;
+            validK = validK > DPPDetails::K_TILE
+                ? DPPDetails::K_TILE : validK;
+            const ACopyDetails aCopy{
+                details.aOriginX + kBase, details.aOriginY,
+                validK, DPPDetails::M, T{}};
+            const BCopyDetails bCopy{
+                details.bOriginX + kBase, details.bOriginY,
+                validK, DPPDetails::N, T{}};
+            const Tile<T, ALayout> aTile{aStorage[slot]};
+            const Tile<T, BLayout> bTile{bStorage[slot]};
+            ACopyPolicy::complete(aCopy, aTile);
+            BCopyPolicy::complete(bCopy, bTile);
+            __syncwarp();
+
+            if (nextTile < tileCount) {
+                issueTile(nextTile, nextTile % details.stages);
+                ++nextTile;
+            }
+
+            const ASharedRead aShared{{aTile}};
+            const BSharedRead bShared{{bTile}};
+            const MmaDetails mma{0, 0, 0, 0,
+                                 details.dOriginX, details.dOriginY};
+            MmaPolicy::accumulate(mma, aShared, bShared, accumulator);
+        }
+
+        const MmaDetails outputDetails{
+            0, 0, 0, 0, details.dOriginX, details.dOriginY};
+        MmaPolicy::store(outputDetails, accumulator, output);
+    }
+};
+#endif
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_MULTISTAGE_H

--- a/include/fused_kernel/algorithms/collective/reduce.h
+++ b/include/fused_kernel/algorithms/collective/reduce.h
@@ -1,0 +1,338 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REDUCE_H
+#define FK_COLLECTIVE_REDUCE_H
+
+#include <fused_kernel/core/data/point.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <typename T, int BLOCK_SIZE = 256>
+struct ReduceDPPDetails {
+    static_assert(BLOCK_SIZE > 0, "ReduceDPP block size must be positive");
+
+    using ValueType = T;
+    static constexpr int BLOCK_THREADS = BLOCK_SIZE;
+
+    int rows;
+    int width;
+    // Must be the neutral element of the supplied compute IOp.
+    T identity;
+    int rowOffset{0};
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceWarpDPP;
+
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceBlockDPP;
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE T exec(const DPPDetails&, const T value,
+                        const ComputeIOp&, T*) {
+        return value;
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceDPP;
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::CPU, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    FK_HOST_FUSE void exec(const Details& details,
+                           const ReadIOp& input,
+                           const ComputeIOp& compute,
+                           const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS > 0,
+                      "ReduceDPP block size must be positive");
+
+        for (int localRow = 0; localRow < details.rows; ++localRow) {
+            const int row = details.rowOffset + localRow;
+            T accumulator = details.identity;
+            for (int x = 0; x < details.width; ++x) {
+                const T value = static_cast<T>(
+                    ReadIOp::Operation::exec(Point{x, row, 0}, input));
+                accumulator = make_tuple(accumulator, value) | compute;
+            }
+            WriteIOp::Operation::exec(Point{row, 0, 0}, accumulator, output);
+        }
+    }
+};
+
+template <ParArch PA, typename DPPDetails>
+struct ReduceGridDPP;
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::CPU, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ComputeIOp>
+    FK_HOST_FUSE void exec(const DPPDetails&, const T value,
+                           const ComputeIOp& compute, T*, T* accumulator) {
+        if (accumulator != nullptr) {
+            *accumulator = make_tuple(*accumulator, value) | compute;
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceWarpDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails&, T value,
+                          const ComputeIOp& compute) {
+#if defined(__CUDA_ARCH__)
+        const unsigned int mask = __activemask();
+        const int lane = static_cast<int>(threadIdx.x) & 31;
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            const T peer = __shfl_down_sync(mask, value, offset);
+            if (lane + offset < 32) {
+                value = make_tuple(value, peer) | compute;
+            }
+        }
+#else
+        (void)compute;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceBlockDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE T exec(const DPPDetails& details, T value,
+                          const ComputeIOp& compute, T* warpScratch) {
+#if defined(__CUDA_ARCH__)
+        constexpr int WARP_SIZE = 32;
+        constexpr int NUM_WARPS =
+            (DPPDetails::BLOCK_THREADS + WARP_SIZE - 1) / WARP_SIZE;
+        const int lane = static_cast<int>(threadIdx.x) & (WARP_SIZE - 1);
+        const int warp = static_cast<int>(threadIdx.x) / WARP_SIZE;
+
+        value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+            details, value, compute);
+        if (lane == 0) warpScratch[warp] = value;
+        __syncthreads();
+
+        if (warp == 0) {
+            value = lane < NUM_WARPS ? warpScratch[lane] : details.identity;
+            value = ReduceWarpDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute);
+        }
+#else
+        (void)details;
+        (void)compute;
+        (void)warpScratch;
+#endif
+        return value;
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using Details = DPPDetails;
+    using T = typename Details::ValueType;
+
+public:
+    FK_STATIC_STRUCT(ReduceDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    // Deliberately not FK_DEVICE_FUSE: CUDA rejects a function-local
+    // __shared__ declaration inside the macro's constexpr function.
+    template <typename ReadIOp, typename ComputeIOp, typename WriteIOp>
+    static __device__ __forceinline__ void exec(const Details& details,
+                                                const ReadIOp& input,
+                                                const ComputeIOp& compute,
+                                                const WriteIOp& output) {
+        static_assert(isAnyReadType<ReadIOp>,
+                      "ReduceDPP input must be a Read or ReadBack IOp");
+        static_assert(isAnyWriteType<WriteIOp>,
+                      "ReduceDPP output must be a Write IOp");
+        static_assert(Details::BLOCK_THREADS >= 32 &&
+                      Details::BLOCK_THREADS <= 1024 &&
+                      Details::BLOCK_THREADS % 32 == 0,
+                      "ReduceDPP block size must be a warp multiple in [32, 1024]");
+
+        constexpr int NUM_WARPS = Details::BLOCK_THREADS / 32;
+        __shared__ T warpScratch[NUM_WARPS];
+
+        const int localRow = static_cast<int>(blockIdx.x);
+        if (localRow >= details.rows) return;
+        const int row = details.rowOffset + localRow;
+        const int tid = static_cast<int>(threadIdx.x);
+        T accumulator = details.identity;
+        for (int x = tid; x < details.width; x += Details::BLOCK_THREADS) {
+            const T value = static_cast<T>(
+                ReadIOp::Operation::exec(Point{x, row, 0}, input));
+            accumulator = make_tuple(accumulator, value) | compute;
+        }
+
+        const T result =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, Details>::exec(
+                details, accumulator, compute, warpScratch);
+        if (tid == 0) {
+            WriteIOp::Operation::exec(Point{row, 0, 0}, result, output);
+        }
+    }
+};
+
+template <typename DPPDetails>
+struct ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = ReduceGridDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using T = typename DPPDetails::ValueType;
+
+    template <typename ComputeIOp>
+    static __device__ __forceinline__ void atomicApply(
+            T* address, const T value, const ComputeIOp& compute) {
+        static_assert(sizeof(T) == sizeof(unsigned int),
+                      "ReduceGridDPP CAS supports 32-bit value types");
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "ReduceGridDPP CAS requires a trivially copyable type");
+
+        auto* bitsAddress = reinterpret_cast<unsigned int*>(address);
+        unsigned int oldBits = atomicCAS(bitsAddress, 0u, 0u);
+        unsigned int assumedBits;
+        do {
+            assumedBits = oldBits;
+            T current;
+            __builtin_memcpy(&current, &assumedBits, sizeof(T));
+            const T next = make_tuple(current, value) | compute;
+            unsigned int nextBits;
+            __builtin_memcpy(&nextBits, &next, sizeof(T));
+            oldBits = atomicCAS(bitsAddress, assumedBits, nextBits);
+        } while (oldBits != assumedBits);
+    }
+
+public:
+    FK_STATIC_STRUCT(ReduceGridDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ComputeIOp>
+    FK_DEVICE_FUSE void exec(const DPPDetails& details, const T value,
+                             const ComputeIOp& compute, T* warpScratch,
+                             T* accumulator) {
+        const T blockPartial =
+            ReduceBlockDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+                details, value, compute, warpScratch);
+        if (threadIdx.x == 0) {
+            atomicApply(accumulator, blockPartial, compute);
+        }
+    }
+};
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+__global__ void launchReduceDPPKernel(
+        const __grid_constant__ DPPDetails details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        const __grid_constant__ WriteIOp output) {
+    ReduceDPP<ParArch::GPU_NVIDIA, DPPDetails>::exec(
+        details, input, compute, output);
+}
+
+template <typename DPPDetails, typename ReadIOp,
+          typename ComputeIOp, typename WriteIOp>
+inline void executeReduce(const DPPDetails& details,
+                          const ReadIOp& input,
+                          const ComputeIOp& compute,
+                          const WriteIOp& output,
+                          Stream_<ParArch::GPU_NVIDIA>& stream) {
+    static_assert(std::is_trivially_copyable_v<DPPDetails>,
+                  "ReduceDPP Details must be trivially copyable");
+    if (details.rows <= 0) return;
+    launchReduceDPPKernel<<<details.rows, DPPDetails::BLOCK_THREADS, 0,
+                           stream.getCUDAStream()>>>(
+        details, input, compute, output);
+    gpuErrchk(cudaGetLastError());
+}
+#endif // defined(__NVCC__)
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REDUCE_H

--- a/include/fused_kernel/algorithms/collective/register_tile.h
+++ b/include/fused_kernel/algorithms/collective/register_tile.h
@@ -1,0 +1,367 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_REGISTER_TILE_H
+#define FK_COLLECTIVE_REGISTER_TILE_H
+
+#include <fused_kernel/algorithms/collective/mma.h>
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+template <ParArch PA, typename MmaPolicy, typename MmaDetails>
+struct RegisterFragmentPolicy;
+
+struct DefaultRegisterFragmentLayout {
+    template <ParArch PA, typename MmaPolicy, typename MmaDetails>
+    using Policy = RegisterFragmentPolicy<PA, MmaPolicy, MmaDetails>;
+};
+
+template <int WM_ATOMS, int WN_ATOMS, typename MmaDetails,
+          template <ParArch, typename> class MmaPolicyTemplate = MmaWarpDPP,
+          typename FragmentLayout = DefaultRegisterFragmentLayout,
+          typename SchedulerOperation =
+              WarpTileScheduler<RowMajorWarpTileRaster>>
+struct RegisterTileMainloopDPPDetails {
+    static_assert(WM_ATOMS > 0 && WN_ATOMS > 0,
+                  "Register tile atom counts must be positive");
+
+    using MmaDetailsType = MmaDetails;
+    using FragmentLayoutType = FragmentLayout;
+    using SchedulerOperationType = SchedulerOperation;
+    template <ParArch PA>
+    using MmaPolicy = MmaPolicyTemplate<PA, MmaDetails>;
+    template <ParArch PA>
+    using FragmentPolicy = typename FragmentLayout::template Policy<
+        PA, MmaPolicy<PA>, MmaDetails>;
+
+    static constexpr int WM = WM_ATOMS;
+    static constexpr int WN = WN_ATOMS;
+    static constexpr int ATOM_M = MmaDetails::M;
+    static constexpr int ATOM_N = MmaDetails::N;
+    static constexpr int K_TILE = MmaDetails::K;
+    static constexpr int REGISTER_M = WM * ATOM_M;
+    static constexpr int REGISTER_N = WN * ATOM_N;
+
+    int K;
+    int mTileExtent;
+    int nTileExtent;
+    int outputRows;
+    int outputCols;
+    int aOriginX;
+    int aOriginY;
+    int bOriginX;
+    int bOriginY;
+    int dOriginX;
+    int dOriginY;
+};
+
+template <typename MmaPolicy, typename MmaDetails>
+struct RegisterFragmentPolicy<ParArch::CPU, MmaPolicy, MmaDetails> {
+    using AFragment = typename MmaPolicy::AFragment;
+    using BFragment = typename MmaPolicy::BFragment;
+    using AccumulatorFragment = typename MmaPolicy::AccumulatorFragment;
+
+    FK_HOST_STATIC void clear(AccumulatorFragment& fragment) {
+        MmaPolicy::clear(fragment);
+    }
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void loadA(const MmaDetails& details,
+                              const ReadIOp& input,
+                              AFragment& fragment) {
+        MmaPolicy::loadAFragment(details, input, fragment);
+    }
+
+    template <typename ReadIOp>
+    FK_HOST_STATIC void loadB(const MmaDetails& details,
+                              const ReadIOp& input,
+                              BFragment& fragment) {
+        MmaPolicy::loadBFragment(details, input, fragment);
+    }
+
+    FK_HOST_STATIC void multiply(const AFragment& a,
+                                 const BFragment& b,
+                                 AccumulatorFragment& accumulator) {
+        MmaPolicy::multiply(a, b, accumulator);
+    }
+
+    template <typename WriteIOp>
+    FK_HOST_STATIC void store(const AccumulatorFragment& fragment,
+                              const int rowBase, const int colBase,
+                              const int outputRows, const int outputCols,
+                              const int dOriginX, const int dOriginY,
+                              const WriteIOp& output) {
+        for (int row = 0; row < MmaDetails::M; ++row)
+            for (int col = 0; col < MmaDetails::N; ++col)
+                if (rowBase + row < outputRows &&
+                    colBase + col < outputCols)
+                    WriteIOp::Operation::exec(
+                        Point{dOriginX + colBase + col,
+                              dOriginY + rowBase + row, 0},
+                        fragment.values[row][col], output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename MmaPolicy, typename MmaDetails>
+struct RegisterFragmentPolicy<ParArch::GPU_NVIDIA, MmaPolicy, MmaDetails> {
+    using AFragment = typename MmaPolicy::AFragment;
+    using BFragment = typename MmaPolicy::BFragment;
+    using AccumulatorFragment = typename MmaPolicy::AccumulatorFragment;
+
+    FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
+        MmaPolicy::clear(fragment);
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void loadA(const MmaDetails& details,
+                                const ReadIOp& input,
+                                AFragment& fragment) {
+        MmaPolicy::loadAFragment(details, input, fragment);
+    }
+
+    template <typename ReadIOp>
+    FK_DEVICE_STATIC void loadB(const MmaDetails& details,
+                                const ReadIOp& input,
+                                BFragment& fragment) {
+        MmaPolicy::loadBFragment(details, input, fragment);
+    }
+
+    FK_DEVICE_STATIC void multiply(const AFragment& a,
+                                   const BFragment& b,
+                                   AccumulatorFragment& accumulator) {
+        MmaPolicy::multiply(a, b, accumulator);
+    }
+
+    template <typename WriteIOp>
+    FK_DEVICE_STATIC void store(const AccumulatorFragment& fragment,
+                                const int rowBase, const int colBase,
+                                const int outputRows, const int outputCols,
+                                const int dOriginX, const int dOriginY,
+                                const WriteIOp& output) {
+        static_assert(MmaDetails::M == 16 && MmaDetails::N == 8,
+                      "Default GPU fragment layout supports m16n8 atoms");
+        const int lane = threadIdx.x & 31;
+        const int group = lane >> 2;
+        const int threadInGroup = lane & 3;
+        const int rows[4]{group, group, group + 8, group + 8};
+        const int cols[4]{2 * threadInGroup, 2 * threadInGroup + 1,
+                          2 * threadInGroup, 2 * threadInGroup + 1};
+        #pragma unroll
+        for (int value = 0; value < 4; ++value) {
+            if (rowBase + rows[value] < outputRows &&
+                colBase + cols[value] < outputCols)
+                WriteIOp::Operation::exec(
+                    Point{dOriginX + colBase + cols[value],
+                          dOriginY + rowBase + rows[value], 0},
+                    fragment.values[value], output);
+        }
+    }
+};
+#endif
+
+template <ParArch PA, typename DPPDetails>
+struct RegisterTileMainloopDPP;
+
+template <typename DPPDetails>
+struct RegisterTileMainloopDPP<ParArch::CPU, DPPDetails> {
+private:
+    using SelfType = RegisterTileMainloopDPP<ParArch::CPU, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using FragmentPolicy = typename DPPDetails::template FragmentPolicy<
+        ParArch::CPU>;
+    using AFragment = typename FragmentPolicy::AFragment;
+    using BFragment = typename FragmentPolicy::BFragment;
+    using AccumulatorFragment = typename FragmentPolicy::AccumulatorFragment;
+
+    template <typename ReadIOps, typename WriteIOp>
+    FK_HOST_STATIC void executeAssignment(
+            const DPPDetails& details,
+            const WarpTileAssignment assignment,
+            const ReadIOps& reads, const WriteIOp& output) {
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        const int registerRow = assignment.mTile * DPPDetails::REGISTER_M;
+        const int registerCol = assignment.nTile * DPPDetails::REGISTER_N;
+        AccumulatorFragment accumulators[DPPDetails::WM][DPPDetails::WN];
+        for (int i = 0; i < DPPDetails::WM; ++i)
+            for (int j = 0; j < DPPDetails::WN; ++j)
+                FragmentPolicy::clear(accumulators[i][j]);
+
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            AFragment aFragments[DPPDetails::WM];
+            BFragment bFragments[DPPDetails::WN];
+            for (int i = 0; i < DPPDetails::WM; ++i) {
+                const MmaDetails mma{
+                    details.aOriginX + kBase,
+                    details.aOriginY + registerRow + i * DPPDetails::ATOM_M,
+                    details.bOriginX + kBase, details.bOriginY,
+                    0, 0};
+                FragmentPolicy::loadA(mma, a, aFragments[i]);
+            }
+            for (int j = 0; j < DPPDetails::WN; ++j) {
+                const MmaDetails mma{
+                    details.aOriginX + kBase, details.aOriginY,
+                    details.bOriginX + kBase,
+                    details.bOriginY + registerCol + j * DPPDetails::ATOM_N,
+                    0, 0};
+                FragmentPolicy::loadB(mma, b, bFragments[j]);
+            }
+            for (int i = 0; i < DPPDetails::WM; ++i)
+                for (int j = 0; j < DPPDetails::WN; ++j)
+                    FragmentPolicy::multiply(
+                        aFragments[i], bFragments[j], accumulators[i][j]);
+        }
+        for (int i = 0; i < DPPDetails::WM; ++i)
+            for (int j = 0; j < DPPDetails::WN; ++j)
+                FragmentPolicy::store(
+                    accumulators[i][j],
+                    registerRow + i * DPPDetails::ATOM_M,
+                    registerCol + j * DPPDetails::ATOM_N,
+                    details.outputRows, details.outputCols,
+                    details.dOriginX, details.dOriginY, output);
+    }
+
+public:
+    FK_STATIC_STRUCT(RegisterTileMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename ReadIOps, typename WriteIOp, typename SchedulerIOp>
+    FK_HOST_STATIC void exec(const DPPDetails& details,
+                             const ReadIOps& reads,
+                             const WriteIOp& output,
+                             const SchedulerIOp& scheduler) {
+        static_assert(isTuple_v<ReadIOps> &&
+                      std::decay_t<ReadIOps>::size == 2);
+        static_assert(isAnyWriteType<WriteIOp>);
+        static_assert(std::is_same_v<
+            typename std::decay_t<SchedulerIOp>::Operation,
+            typename DPPDetails::SchedulerOperationType>);
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0 ||
+            details.mTileExtent <= 0 || details.nTileExtent <= 0 ||
+            details.outputRows <= 0 || details.outputCols <= 0) return;
+        const int warpCount = details.mTileExtent * details.nTileExtent;
+        for (int warpId = 0; warpId < warpCount; ++warpId) {
+            const WarpTileAssignment assignment =
+                make_tuple(warpId, details.mTileExtent,
+                           details.nTileExtent) | scheduler;
+            if (assignment.valid)
+                executeAssignment(details, assignment, reads, output);
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename DPPDetails>
+struct RegisterTileMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails> {
+private:
+    using SelfType = RegisterTileMainloopDPP<ParArch::GPU_NVIDIA, DPPDetails>;
+    using MmaDetails = typename DPPDetails::MmaDetailsType;
+    using FragmentPolicy = typename DPPDetails::template FragmentPolicy<
+        ParArch::GPU_NVIDIA>;
+    using AFragment = typename FragmentPolicy::AFragment;
+    using BFragment = typename FragmentPolicy::BFragment;
+    using AccumulatorFragment = typename FragmentPolicy::AccumulatorFragment;
+
+public:
+    FK_STATIC_STRUCT(RegisterTileMainloopDPP, SelfType)
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    template <typename ReadIOps, typename WriteIOp, typename SchedulerIOp>
+    FK_DEVICE_STATIC void exec(const DPPDetails& details,
+                               const ReadIOps& reads,
+                               const WriteIOp& output,
+                               const SchedulerIOp& scheduler) {
+        static_assert(isTuple_v<ReadIOps> &&
+                      std::decay_t<ReadIOps>::size == 2);
+        static_assert(isAnyWriteType<WriteIOp>);
+        static_assert(std::is_same_v<
+            typename std::decay_t<SchedulerIOp>::Operation,
+            typename DPPDetails::SchedulerOperationType>);
+        if (details.K <= 0 || details.K % DPPDetails::K_TILE != 0 ||
+            details.mTileExtent <= 0 || details.nTileExtent <= 0 ||
+            details.outputRows <= 0 || details.outputCols <= 0 ||
+            blockDim.x % 32 != 0) return;
+
+        const int warpsPerBlock = blockDim.x / 32;
+        const int warpId = blockIdx.x * warpsPerBlock + threadIdx.x / 32;
+        const WarpTileAssignment assignment =
+            make_tuple(warpId, details.mTileExtent,
+                       details.nTileExtent) | scheduler;
+        if (!assignment.valid) return;
+
+        const auto& a = get<0>(reads);
+        const auto& b = get<1>(reads);
+        const int registerRow = assignment.mTile * DPPDetails::REGISTER_M;
+        const int registerCol = assignment.nTile * DPPDetails::REGISTER_N;
+        AccumulatorFragment accumulators[DPPDetails::WM][DPPDetails::WN];
+        #pragma unroll
+        for (int i = 0; i < DPPDetails::WM; ++i)
+            #pragma unroll
+            for (int j = 0; j < DPPDetails::WN; ++j)
+                FragmentPolicy::clear(accumulators[i][j]);
+
+        for (int kBase = 0; kBase < details.K;
+             kBase += DPPDetails::K_TILE) {
+            AFragment aFragments[DPPDetails::WM];
+            BFragment bFragments[DPPDetails::WN];
+            #pragma unroll
+            for (int i = 0; i < DPPDetails::WM; ++i) {
+                const MmaDetails mma{
+                    details.aOriginX + kBase,
+                    details.aOriginY + registerRow + i * DPPDetails::ATOM_M,
+                    details.bOriginX + kBase, details.bOriginY,
+                    0, 0};
+                FragmentPolicy::loadA(mma, a, aFragments[i]);
+            }
+            #pragma unroll
+            for (int j = 0; j < DPPDetails::WN; ++j) {
+                const MmaDetails mma{
+                    details.aOriginX + kBase, details.aOriginY,
+                    details.bOriginX + kBase,
+                    details.bOriginY + registerCol + j * DPPDetails::ATOM_N,
+                    0, 0};
+                FragmentPolicy::loadB(mma, b, bFragments[j]);
+            }
+            #pragma unroll
+            for (int i = 0; i < DPPDetails::WM; ++i)
+                #pragma unroll
+                for (int j = 0; j < DPPDetails::WN; ++j)
+                    FragmentPolicy::multiply(
+                        aFragments[i], bFragments[j], accumulators[i][j]);
+        }
+        #pragma unroll
+        for (int i = 0; i < DPPDetails::WM; ++i)
+            #pragma unroll
+            for (int j = 0; j < DPPDetails::WN; ++j)
+                FragmentPolicy::store(
+                    accumulators[i][j],
+                    registerRow + i * DPPDetails::ATOM_M,
+                    registerCol + j * DPPDetails::ATOM_N,
+                    details.outputRows, details.outputCols,
+                    details.dOriginX, details.dOriginY, output);
+    }
+};
+#endif
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_REGISTER_TILE_H

--- a/include/fused_kernel/algorithms/collective/tile.h
+++ b/include/fused_kernel/algorithms/collective/tile.h
@@ -1,0 +1,76 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_TILE_H
+#define FK_COLLECTIVE_TILE_H
+
+#include <fused_kernel/core/utils/utils.h>
+
+#include <type_traits>
+
+namespace fk {
+
+// Layout policies map logical tile coordinates to local element offsets.
+template <uint ROWS, uint COLS>
+struct RowMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return row * COLS + col;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+template <uint ROWS, uint COLS>
+struct ColumnMajorLayout {
+    static_assert(ROWS > 0 && COLS > 0, "Tile dimensions must be positive");
+    static constexpr uint rows = ROWS;
+    static constexpr uint cols = COLS;
+
+    FK_HOST_DEVICE_FUSE uint offset(const uint row, const uint col) {
+        return col * ROWS + row;
+    }
+
+    FK_HOST_DEVICE_FUSE uint size() { return ROWS * COLS; }
+};
+
+// A Tile is only a statically shaped view over DPP-owned local storage.
+// It does not own memory and is neither an Operation nor a DPP.
+template <typename T, typename Layout>
+struct Tile {
+    using ValueType = T;
+    using LayoutType = Layout;
+    static constexpr uint rows = Layout::rows;
+    static constexpr uint cols = Layout::cols;
+    static constexpr uint elements = Layout::size();
+
+    T* storage;
+
+    FK_HOST_DEVICE_CNST explicit Tile(T* localStorage)
+        : storage(localStorage) {}
+
+    FK_HOST_DEVICE_CNST T& at(const uint row, const uint col) const {
+        return storage[Layout::offset(row, col)];
+    }
+
+    FK_HOST_DEVICE_CNST T* data() const { return storage; }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_TILE_H
+

--- a/include/fused_kernel/algorithms/collective/tile_scheduler.h
+++ b/include/fused_kernel/algorithms/collective/tile_scheduler.h
@@ -1,0 +1,86 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_COLLECTIVE_TILE_SCHEDULER_H
+#define FK_COLLECTIVE_TILE_SCHEDULER_H
+
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/utils/utils.h>
+
+namespace fk {
+
+struct WarpTileAssignment {
+    int mTile;
+    int nTile;
+    bool valid;
+};
+
+struct RowMajorWarpTileRaster {
+private:
+    using SelfType = RowMajorWarpTileRaster;
+
+public:
+    FK_STATIC_STRUCT(RowMajorWarpTileRaster, SelfType)
+
+    FK_HOST_DEVICE_FUSE WarpTileAssignment map(
+        const int warpId, const int, const int nTiles) {
+        return {warpId / nTiles, warpId % nTiles, true};
+    }
+};
+
+struct ColumnMajorWarpTileRaster {
+private:
+    using SelfType = ColumnMajorWarpTileRaster;
+
+public:
+    FK_STATIC_STRUCT(ColumnMajorWarpTileRaster, SelfType)
+
+    FK_HOST_DEVICE_FUSE WarpTileAssignment map(
+        const int warpId, const int mTiles, const int) {
+        return {warpId % mTiles, warpId / mTiles, true};
+    }
+};
+
+/**
+ * Parameterless Unary Operation mapping
+ * Tuple<warpId, mTileExtent, nTileExtent> to a tile assignment.
+ * Raster is a static traversal policy; all extents remain runtime inputs.
+ */
+template <typename RasterPolicy = RowMajorWarpTileRaster>
+struct WarpTileScheduler {
+private:
+    using Input = Tuple<int, int, int>;
+    using Parent = UnaryOperation<Input, WarpTileAssignment,
+                                  WarpTileScheduler<RasterPolicy>>;
+    using SelfType = WarpTileScheduler<RasterPolicy>;
+
+public:
+    FK_STATIC_STRUCT(WarpTileScheduler, SelfType)
+    DECLARE_UNARY_PARENT
+
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input) {
+        const int warpId = get<0>(input);
+        const int mTiles = get<1>(input);
+        const int nTiles = get<2>(input);
+        if (warpId < 0 || mTiles <= 0 || nTiles <= 0 ||
+            warpId >= mTiles * nTiles)
+            return {-1, -1, false};
+        return RasterPolicy::map(warpId, mTiles, nTiles);
+    }
+};
+
+} // namespace fk
+
+#endif // FK_COLLECTIVE_TILE_SCHEDULER_H

--- a/include/fused_kernel/core/execution_model/executor_details/dpp_launch_config.h
+++ b/include/fused_kernel/core/execution_model/executor_details/dpp_launch_config.h
@@ -1,0 +1,41 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_DPP_LAUNCH_CONFIG_H
+#define FK_DPP_LAUNCH_CONFIG_H
+
+#include <cstddef>
+
+namespace fk {
+
+/**
+ * Launch metadata contract for generic GPU DPP execution.
+ *
+ * A DPP using the primary Executor must expose:
+ *   static DPPLaunchConfig launchConfig(const DPPDetails&);
+ * CPU execution ignores this metadata and calls DPP::exec directly.
+ */
+struct DPPLaunchConfig {
+    unsigned int gridX{1};
+    unsigned int gridY{1};
+    unsigned int gridZ{1};
+    unsigned int blockX{1};
+    unsigned int blockY{1};
+    unsigned int blockZ{1};
+    std::size_t sharedMemoryBytes{0};
+};
+
+} // namespace fk
+
+#endif // FK_DPP_LAUNCH_CONFIG_H

--- a/include/fused_kernel/core/execution_model/executor_details/executor_kernels.h
+++ b/include/fused_kernel/core/execution_model/executor_details/executor_kernels.h
@@ -17,6 +17,15 @@
 
 #if defined(__NVCC__)
 namespace fk {
+
+/** Generic DPP kernel. Launch geometry is owned by DPP::launchConfig(details).
+ * The kernel deliberately contains no indexing or algorithm logic. */
+template <typename DPP, typename DPPDetails, typename... IOps>
+__global__ void launchDPPKernel(const __grid_constant__ DPPDetails details,
+                                const __grid_constant__ IOps... iOps) {
+    DPP::exec(details, iOps...);
+}
+
 template <ParArch PA, typename SequenceSelector, typename DPPDetails, typename... IOpSequences>
 __global__ void launchDivergentBatchTransformDPP_Kernel(const __grid_constant__ DPPDetails details,
                                                         const __grid_constant__ IOpSequences... iOpSequences) {

--- a/include/fused_kernel/core/execution_model/executors.h
+++ b/include/fused_kernel/core/execution_model/executors.h
@@ -22,6 +22,7 @@
 #include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/basic_ops/set.h>
 #include <fused_kernel/core/execution_model/stream.h>
+#include <fused_kernel/core/execution_model/executor_details/dpp_launch_config.h>
 
 #if defined(__NVCC__)
 #include <fused_kernel/core/execution_model/executor_details/executor_kernels.h>
@@ -142,23 +143,58 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
     Parent::executeOperations(input, output, stream, iOps...); \
 }
 
-#ifdef NVRTC_ENABLED
     template <typename DataParallelPattern>
     struct Executor {
+    private:
+        template <typename DPPDetails, typename... IOps>
+        FK_HOST_FUSE void executeOperationsFused(
+                Stream_<DataParallelPattern::PAR_ARCH>& stream,
+                const DPPDetails& details, const IOps&... iOps) {
+            if constexpr (DataParallelPattern::PAR_ARCH == ParArch::CPU) {
+                DataParallelPattern::exec(details, iOps...);
+#if defined(__NVCC__)
+            } else if constexpr (DataParallelPattern::PAR_ARCH ==
+                                 ParArch::GPU_NVIDIA) {
+                const DPPLaunchConfig launch =
+                    DataParallelPattern::launchConfig(details);
+                const dim3 grid{launch.gridX, launch.gridY, launch.gridZ};
+                const dim3 block{launch.blockX, launch.blockY, launch.blockZ};
+                launchDPPKernel<DataParallelPattern, DPPDetails, IOps...>
+                    <<<grid, block, launch.sharedMemoryBytes,
+                       stream.getCUDAStream()>>>(details, iOps...);
+                gpuErrchk(cudaGetLastError());
+#endif
+            }
+        }
+
+    public:
         FK_STATIC_STRUCT(Executor, Executor)
+#ifdef NVRTC_ENABLED
         static_assert(DataParallelPattern::PAR_ARCH == ParArch::GPU_NVIDIA ||
                       DataParallelPattern::PAR_ARCH == ParArch::CPU ||
-                      DataParallelPattern::PAR_ARCH == ParArch::GPU_NVIDIA_JIT, "Only GPU_NVIDIA, CPU and GPU_NVIDIA_JIT are supported");
-    };
+                      DataParallelPattern::PAR_ARCH == ParArch::GPU_NVIDIA_JIT,
+                      "Only GPU_NVIDIA, CPU and GPU_NVIDIA_JIT are supported");
 #else
-    template <typename DataParallelPattern>
-    struct Executor {
-        FK_STATIC_STRUCT(Executor, Executor)
         static_assert(DataParallelPattern::PAR_ARCH == ParArch::GPU_NVIDIA ||
                       DataParallelPattern::PAR_ARCH == ParArch::CPU,
                       "Only GPU_NVIDIA and CPU supported");
-    };
 #endif
+
+        template <typename DPPDetails, typename... IOps>
+        FK_HOST_FUSE void executeOperations(
+                Stream_<DataParallelPattern::PAR_ARCH>& stream,
+                const DPPDetails& details, const IOps&... iOps) {
+            // Details is deliberately excluded: only IOps enter BackFuser.
+            const auto fusedIOps = BackFuser::fuse_back(iOps...);
+            apply([&](const auto&... fused) {
+                executeOperationsFused(stream, details, fused...);
+            }, fusedIOps);
+        }
+
+        FK_HOST_FUSE ParArch parArch() {
+            return DataParallelPattern::PAR_ARCH;
+        }
+    };
 
     template <enum TF TFEN>
     struct Executor<TransformDPP<ParArch::CPU, TFEN, void>> {

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -39,6 +39,7 @@
 #define FK_HOST_FUSE __host__ __forceinline__ static constexpr
 #define FK_HOST_CNST __host__ __forceinline__ constexpr
 #define FK_HOST_STATIC __host__ __forceinline__ static
+#define FK_DEVICE_STATIC __device__ __forceinline__ static
 #define FK_HOST_INLINE __host__ __forceinline__
 #define FK_HOST_DEVICE_STATIC __host__ __device__ __forceinline__ static
 #define FK_RESTRICT __restrict__
@@ -50,6 +51,7 @@
 #define FK_HOST_FUSE static constexpr __forceinline__
 #define FK_HOST_CNST constexpr __forceinline__
 #define FK_HOST_STATIC static constexpr __forceinline__
+#define FK_DEVICE_STATIC static __forceinline__
 #define FK_HOST_INLINE constexpr __forceinline__
 #define FK_HOST_DEVICE_STATIC static __forceinline__
 #define FK_RESTRICT __restrict__
@@ -61,6 +63,7 @@
 #define FK_HOST_FUSE static constexpr inline
 #define FK_HOST_CNST constexpr inline
 #define FK_HOST_STATIC static inline
+#define FK_DEVICE_STATIC static inline
 #define FK_HOST_INLINE inline
 #define FK_HOST_DEVICE_STATIC static inline
 #ifdef _MSC_VER

--- a/tests/collective/test_attention_tile.h
+++ b/tests/collective/test_attention_tile.h
@@ -1,0 +1,223 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/fused_kernel.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/attention_tile.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+constexpr float Q_SCALE = 1.125f;
+constexpr float K_BIAS = -0.0625f;
+constexpr float V_SCALE = 0.875f;
+constexpr float O_SCALE = 1.25f;
+constexpr float O_BIAS = -0.03125f;
+
+float qSource(const int bh, const int row, const int d) {
+    return ((bh * 17 + row * 11 + d * 7) % 29 - 14) * 0.03125f;
+}
+
+float kSource(const int bh, const int row, const int d) {
+    if (row == 32) return 16.f * qSource(bh, 0, d);
+    return ((bh * 13 + row * 5 + d * 3) % 23 - 11) * 0.0390625f;
+}
+
+float vSource(const int bh, const int row, const int d) {
+    return ((bh * 19 + row * 7 + d * 2) % 31 - 15) * 0.02734375f;
+}
+
+struct CaseResult {
+    bool oraclePassed;
+    std::vector<float> output;
+    double maxError;
+};
+
+template <ParArch PA, int HEAD_DIM>
+CaseResult runCase(const int batchHeads, const int seqQ, const int seqK,
+                   const bool causal) {
+    constexpr int QUERY_ROWS = 32;
+    using Details = AttentionDPPDetails<HEAD_DIM, QUERY_ROWS>;
+    using DPP = AttentionTileDPP<PA, Details>;
+    constexpr bool GPU = PA == ParArch::GPU_NVIDIA;
+    const MemType memoryType = GPU ? MemType::DeviceAndPinned : MemType::Host;
+
+    Ptr2D<float> q(HEAD_DIM, batchHeads * seqQ, 0, memoryType);
+    Ptr2D<float> k(HEAD_DIM, batchHeads * seqK, 0, memoryType);
+    Ptr2D<float> v(HEAD_DIM, batchHeads * seqK, 0, memoryType);
+    Ptr2D<float2> output(HEAD_DIM / 2, batchHeads * seqQ, 0, memoryType);
+    for (int bh = 0; bh < batchHeads; ++bh) {
+        for (int row = 0; row < seqQ; ++row)
+            for (int d = 0; d < HEAD_DIM; ++d)
+                q.at(Point{d, bh * seqQ + row, 0}) = qSource(bh, row, d);
+        for (int row = 0; row < seqK; ++row) {
+            for (int d = 0; d < HEAD_DIM; ++d) {
+                k.at(Point{d, bh * seqK + row, 0}) = kSource(bh, row, d);
+                v.at(Point{d, bh * seqK + row, 0}) = vSource(bh, row, d);
+            }
+        }
+    }
+    for (int row = 0; row < batchHeads * seqQ; ++row)
+        for (int pair = 0; pair < HEAD_DIM / 2; ++pair)
+            output.at(Point{pair, row, 0}) = float2{-999.f, -999.f};
+
+    Stream_<PA> stream;
+#if defined(__NVCC__)
+    if constexpr (GPU) {
+        q.upload(stream);
+        k.upload(stream);
+        v.upload(stream);
+        output.upload(stream);
+    }
+#endif
+    const auto inputs = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(q)
+            .then(Mul<float>::build(Q_SCALE)),
+        PerThreadRead<ND::_2D, float>::build(k)
+            .then(Add<float>::build(K_BIAS)),
+        PerThreadRead<ND::_2D, float>::build(v)
+            .then(Mul<float>::build(V_SCALE)));
+    const auto outputIOp =
+        Mul<float2>::build(float2{O_SCALE, O_SCALE})
+            .then(Add<float2>::build(float2{O_BIAS, O_BIAS}))
+            .then(PerThreadWrite<ND::_2D, float2>::build(output));
+    const float scale = 1.f / std::sqrt(static_cast<float>(HEAD_DIM));
+    executeOperations<DPP>(
+        stream,
+        Details{batchHeads, seqQ, seqK, scale, causal, -77, -91},
+        inputs, outputIOp);
+#if defined(__NVCC__)
+    if constexpr (GPU) output.download(stream);
+#endif
+    stream.sync();
+
+    std::vector<float> actual(
+        static_cast<std::size_t>(batchHeads * seqQ * HEAD_DIM));
+    for (int bh = 0; bh < batchHeads; ++bh) {
+        for (int row = 0; row < seqQ; ++row) {
+            for (int d = 0; d < HEAD_DIM; ++d) {
+                const float2 packed = output.at(
+                    Point{d / 2, bh * seqQ + row, 0});
+                actual[static_cast<std::size_t>(
+                    (bh * seqQ + row) * HEAD_DIM + d)] =
+                    d & 1 ? packed.y : packed.x;
+            }
+        }
+    }
+
+    double maxError = 0.0;
+    int maxBh = 0;
+    int maxRow = 0;
+    int maxD = 0;
+    double maxExpected = 0.0;
+    double maxActual = 0.0;
+    std::vector<double> logits(static_cast<std::size_t>(seqK));
+    for (int bh = 0; bh < batchHeads; ++bh) {
+        for (int row = 0; row < seqQ; ++row) {
+            const int keyEnd = causal ? std::min(seqK, row + 1) : seqK;
+            double rowMax = -1e300;
+            for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                double dot = 0.0;
+                for (int d = 0; d < HEAD_DIM; ++d) {
+                    const double qv = qSource(bh, row, d) * Q_SCALE;
+                    const double kv = kSource(bh, keyRow, d) + K_BIAS;
+                    dot += qv * kv;
+                }
+                logits[static_cast<std::size_t>(keyRow)] = dot * scale;
+                rowMax = std::max(rowMax, dot * scale);
+            }
+            double denominator = 0.0;
+            for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                auto& probability = logits[static_cast<std::size_t>(keyRow)];
+                probability = std::exp(probability - rowMax);
+                denominator += probability;
+            }
+            for (int d = 0; d < HEAD_DIM; ++d) {
+                double expected = 0.0;
+                for (int keyRow = 0; keyRow < keyEnd; ++keyRow) {
+                    expected += logits[static_cast<std::size_t>(keyRow)] *
+                                vSource(bh, keyRow, d) * V_SCALE;
+                }
+                expected = (expected / denominator) * O_SCALE + O_BIAS;
+                const double value = actual[static_cast<std::size_t>(
+                    (bh * seqQ + row) * HEAD_DIM + d)];
+                const double error = std::abs(value - expected);
+                if (error > maxError) {
+                    maxError = error;
+                    maxBh = bh;
+                    maxRow = row;
+                    maxD = d;
+                    maxExpected = expected;
+                    maxActual = value;
+                }
+            }
+        }
+    }
+    const double tolerance = GPU ? 3.0e-2 : 2.0e-5;
+    if constexpr (GPU) {
+        if (maxError > tolerance) {
+            std::printf("max mismatch bh=%d row=%d d=%d expected=%g actual=%g\n",
+                        maxBh, maxRow, maxD, maxExpected, maxActual);
+        }
+    }
+    return {maxError <= tolerance, std::move(actual), maxError};
+}
+
+template <int HEAD_DIM>
+bool verifyShape(const int batchHeads, const int seqQ, const int seqK,
+                 const bool causal) {
+    const auto cpu = runCase<ParArch::CPU, HEAD_DIM>(
+        batchHeads, seqQ, seqK, causal);
+    bool ok = cpu.oraclePassed;
+#if defined(__NVCC__)
+    const auto gpu = runCase<ParArch::GPU_NVIDIA, HEAD_DIM>(
+        batchHeads, seqQ, seqK, causal);
+    double directError = 0.0;
+    for (std::size_t i = 0; i < cpu.output.size(); ++i)
+        directError = std::max(
+            directError,
+            std::abs(static_cast<double>(cpu.output[i]) - gpu.output[i]));
+    ok = gpu.oraclePassed && directError <= 3.0e-2 && ok;
+    std::printf(
+        "Attention D=%d BH=%d Q=%d K=%d causal=%d cpu=%g gpu=%g direct=%g %s\n",
+        HEAD_DIM, batchHeads, seqQ, seqK, causal,
+        cpu.maxError, gpu.maxError, directError, ok ? "PASS" : "FAIL");
+#else
+    std::printf(
+        "Attention CPU D=%d BH=%d Q=%d K=%d causal=%d error=%g %s\n",
+        HEAD_DIM, batchHeads, seqQ, seqK, causal,
+        cpu.maxError, ok ? "PASS" : "FAIL");
+#endif
+    return ok;
+}
+
+} // namespace
+
+int launch() {
+    bool ok = true;
+    ok = verifyShape<32>(1, 7, 5, false) && ok;
+    ok = verifyShape<32>(2, 35, 19, true) && ok;
+    ok = verifyShape<64>(2, 33, 41, false) && ok;
+    ok = verifyShape<64>(1, 17, 17, true) && ok;
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_bf16_memory_ops.h
+++ b/tests/collective/test_bf16_memory_ops.h
@@ -1,0 +1,80 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#define __ONLY_CU__
+#include <tests/main.h>
+
+#include <fused_kernel/fused_kernel.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+
+#include <cuda_bf16.h>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
+using namespace fk;
+
+struct Bf16CopyDetails { int count; };
+
+struct Bf16CopyDPP {
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const Bf16CopyDetails& details) {
+        const unsigned int count = static_cast<unsigned int>(details.count);
+        return {(count + 31) / 32, 1, 1, 32, 1, 1, 0};
+    }
+
+    template <typename ReadIOp, typename WriteIOp>
+    FK_DEVICE_STATIC void exec(const Bf16CopyDetails& details,
+                               const ReadIOp& input,
+                               const WriteIOp& output) {
+        const int index = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+        if (index >= details.count) return;
+        const auto value = ReadIOp::Operation::exec(Point{index, 0, 0}, input);
+        WriteIOp::Operation::exec(Point{index, 0, 0}, value, output);
+    }
+};
+
+template <typename T>
+bool roundTrip(const int count) {
+    Ptr1D<T> input(static_cast<uint>(count));
+    Ptr1D<T> output(static_cast<uint>(count));
+    for (int i = 0; i < count; ++i) {
+        if constexpr (std::is_same_v<T, __nv_bfloat16>) {
+            input.at(Point{i, 0, 0}) = __float2bfloat16(0.125f * i - 1.f);
+        } else {
+            input.at(Point{i, 0, 0}) = __floats2bfloat162_rn(
+                0.125f * i - 1.f, 0.25f * i + 0.5f);
+        }
+    }
+    Stream stream;
+    input.upload(stream);
+    executeOperations<Bf16CopyDPP>(
+        stream, Bf16CopyDetails{count},
+        PerThreadRead<ND::_1D, T>::build(input),
+        PerThreadWrite<ND::_1D, T>::build(output));
+    output.download(stream);
+    stream.sync();
+    for (int i = 0; i < count; ++i) {
+        const T expected = input.at(Point{i, 0, 0});
+        const T actual = output.at(Point{i, 0, 0});
+        if (std::memcmp(&expected, &actual, sizeof(T)) != 0) return false;
+    }
+    return true;
+}
+
+int launch() {
+    return roundTrip<__nv_bfloat16>(35) &&
+           roundTrip<__nv_bfloat162>(17) ? 0 : -1;
+}

--- a/tests/collective/test_collective_epilogue.h
+++ b/tests/collective/test_collective_epilogue.h
@@ -1,0 +1,319 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/epilogue.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+using namespace fk;
+
+namespace {
+
+using MmaDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+using MainloopDetails = TileMmaMainloopDPPDetails<MmaDetails>;
+
+enum class EpilogueCase { BARE, AFFINE, RELU, LONG };
+
+float transform(const EpilogueCase testCase, const float value) {
+    if (testCase == EpilogueCase::AFFINE) return 2.f * value - 0.5f;
+    if (testCase == EpilogueCase::RELU) return value > 0.f ? value : 0.f;
+    if (testCase == EpilogueCase::LONG) {
+        const float affine = 2.f * value - 0.5f;
+        return 0.25f * (affine > 0.f ? affine : 0.f);
+    }
+    return value;
+}
+
+template <EpilogueCase CASE, typename DPP, typename Reads, typename Write>
+void executeMainloop(const MainloopDetails& details,
+                     const Reads& reads, const Write& write) {
+    if constexpr (CASE == EpilogueCase::BARE) {
+        DPP::exec(details, reads, write);
+    } else if constexpr (CASE == EpilogueCase::AFFINE) {
+        DPP::exec(details, reads,
+            scaleBiasEpilogue<float2>(
+                float2{2.f, 2.f}, float2{-0.5f, -0.5f}, write));
+    } else if constexpr (CASE == EpilogueCase::RELU) {
+        DPP::exec(details, reads, reluEpilogue<float2>(write));
+    } else {
+        const auto chain = Mul<float2>::build(float2{2.f, 2.f})
+            .then(Add<float2>::build(float2{-0.5f, -0.5f}))
+            .then(Max<float2>::build(float2{0.f, 0.f}))
+            .then(Mul<float2>::build(float2{0.25f, 0.25f}))
+            .then(write);
+        DPP::exec(details, reads, chain);
+    }
+}
+
+#if defined(__NVCC__)
+template <typename Reads, typename Write>
+__global__ void mainloopKernel(const MainloopDetails details,
+                               const Reads reads, const Write write) {
+    TileMmaMainloopDPP<ParArch::GPU_NVIDIA, MainloopDetails>::exec(
+        details, reads, write);
+}
+#endif
+
+void initialize(std::vector<float>& a, std::vector<float>& b, const int k) {
+    for (int row = 0; row < 16; ++row)
+        for (int x = 0; x < k; ++x)
+            a[row * k + x] = ((row * 7 + x * 3) % 17 - 8) * 0.0625f;
+    for (int col = 0; col < 8; ++col)
+        for (int x = 0; x < k; ++x)
+            b[col * k + x] = ((col * 5 + x * 2) % 13 - 6) * 0.078125f;
+}
+
+double oracle(const std::vector<float>& a, const std::vector<float>& b,
+              const int k, const int row, const int col,
+              const bool gpuBf16) {
+    double sum = 0.0;
+    for (int x = 0; x < k; ++x) {
+        float av = a[row * k + x];
+        float bv = b[col * k + x];
+#if defined(__NVCC__)
+        if (gpuBf16) {
+            av = __bfloat162float(__float2bfloat16(av));
+            bv = __bfloat162float(__float2bfloat16(bv));
+        }
+#else
+        (void)gpuBf16;
+#endif
+        sum += static_cast<double>(av) * static_cast<double>(bv);
+    }
+    return sum;
+}
+
+template <EpilogueCase CASE>
+bool checkCpuMainloop() {
+    constexpr int K = 32;
+    std::vector<float> a(16 * K), b(8 * K), output(16 * 8, -99.f);
+    initialize(a, b, K);
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, 16, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, 8, K * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        reinterpret_cast<float2*>(output.data()),
+        PtrDims<ND::_2D>(4, 16, 8 * sizeof(float))};
+    const auto reads = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(aPtr),
+        PerThreadRead<ND::_2D, float>::build(bPtr));
+    const auto write = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    const MainloopDetails details{K, 0, 0, 0, 0, 0, 0};
+    executeMainloop<CASE,
+        TileMmaMainloopDPP<ParArch::CPU, MainloopDetails>>(
+            details, reads, write);
+    for (int row = 0; row < 16; ++row)
+        for (int col = 0; col < 8; ++col) {
+            const double expected = transform(
+                CASE, static_cast<float>(oracle(a, b, K, row, col, false)));
+            if (std::abs(output[row * 8 + col] - expected) > 1e-5)
+                return false;
+        }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <EpilogueCase CASE>
+bool checkGpuMainloop() {
+    constexpr int K = 32;
+    std::vector<float> a(16 * K), b(8 * K);
+    initialize(a, b, K);
+    Ptr2D<float> aGpu(K, 16), bGpu(K, 8);
+    Ptr2D<float> outputGpu(8, 16);
+    for (int row = 0; row < 16; ++row)
+        for (int x = 0; x < K; ++x)
+            aGpu.at(Point{x, row, 0}) = a[row * K + x];
+    for (int row = 0; row < 8; ++row)
+        for (int x = 0; x < K; ++x)
+            bGpu.at(Point{x, row, 0}) = b[row * K + x];
+    Stream stream;
+    aGpu.upload(stream);
+    bGpu.upload(stream);
+    const auto reads = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(aGpu),
+        PerThreadRead<ND::_2D, float>::build(bGpu));
+    RawPtr<ND::_2D, float2> dPtr{
+        reinterpret_cast<float2*>(outputGpu.ptr().data),
+        PtrDims<ND::_2D>(4, 16, outputGpu.ptr().dims.pitch)};
+    const auto write = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    const MainloopDetails details{K, 0, 0, 0, 0, 0, 0};
+    if constexpr (CASE == EpilogueCase::BARE) {
+        mainloopKernel<<<1, 32>>>(details, reads, write);
+    } else if constexpr (CASE == EpilogueCase::AFFINE) {
+        const auto output = scaleBiasEpilogue<float2>(
+            float2{2.f, 2.f}, float2{-0.5f, -0.5f}, write);
+        mainloopKernel<<<1, 32>>>(details, reads, output);
+    } else if constexpr (CASE == EpilogueCase::RELU) {
+        const auto output = reluEpilogue<float2>(write);
+        mainloopKernel<<<1, 32>>>(details, reads, output);
+    } else {
+        const auto output = Mul<float2>::build(float2{2.f, 2.f})
+            .then(Add<float2>::build(float2{-0.5f, -0.5f}))
+            .then(Max<float2>::build(float2{0.f, 0.f}))
+            .then(Mul<float2>::build(float2{0.25f, 0.25f}))
+            .then(write);
+        mainloopKernel<<<1, 32>>>(details, reads, output);
+    }
+    outputGpu.download(stream);
+    stream.sync();
+    for (int row = 0; row < 16; ++row)
+        for (int col = 0; col < 8; ++col) {
+            const float expected = transform(
+                CASE, static_cast<float>(oracle(a, b, K, row, col, true)));
+            if (std::abs(outputGpu.at(Point{col, row, 0}) - expected) > 0.02f)
+                return false;
+        }
+    return true;
+}
+#endif
+
+struct PairTailDetails { int width; };
+
+template <ParArch PA, typename Details>
+struct PairTailStoreDPP;
+
+template <typename Details>
+struct PairTailStoreDPP<ParArch::CPU, Details> {
+    template <typename Read, typename PairWrite, typename TailWrite>
+    FK_HOST_STATIC void exec(const Details& details, const Read& input,
+                             const PairWrite& pairs, const TailWrite& tail) {
+        for (int pair = 0; pair < details.width / 2; ++pair) {
+            const float2 value{
+                Read::Operation::exec(Point{2 * pair, 0, 0}, input),
+                Read::Operation::exec(Point{2 * pair + 1, 0, 0}, input)};
+            PairWrite::Operation::exec(Point{pair, 0, 0}, value, pairs);
+        }
+        if (details.width & 1) {
+            TailWrite::Operation::exec(
+                Point{0, 0, 0},
+                Read::Operation::exec(Point{details.width - 1, 0, 0}, input),
+                tail);
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <typename Details>
+struct PairTailStoreDPP<ParArch::GPU_NVIDIA, Details> {
+    template <typename Read, typename PairWrite, typename TailWrite>
+    FK_DEVICE_STATIC void exec(const Details& details, const Read& input,
+                               const PairWrite& pairs, const TailWrite& tail) {
+        const int pair = threadIdx.x;
+        if (pair < details.width / 2) {
+            const float2 value{
+                Read::Operation::exec(Point{2 * pair, 0, 0}, input),
+                Read::Operation::exec(Point{2 * pair + 1, 0, 0}, input)};
+            PairWrite::Operation::exec(Point{pair, 0, 0}, value, pairs);
+        }
+        if (threadIdx.x == 0 && (details.width & 1)) {
+            TailWrite::Operation::exec(
+                Point{0, 0, 0},
+                Read::Operation::exec(Point{details.width - 1, 0, 0}, input),
+                tail);
+        }
+    }
+};
+
+template <typename Read, typename PairWrite, typename TailWrite>
+__global__ void pairTailKernel(const PairTailDetails details,
+                               const Read input,
+                               const PairWrite pairs,
+                               const TailWrite tail) {
+    PairTailStoreDPP<ParArch::GPU_NVIDIA, PairTailDetails>::exec(
+        details, input, pairs, tail);
+}
+#endif
+
+bool checkPairTail() {
+    constexpr int WIDTH = 9;
+    std::vector<float> input(WIDTH), output(WIDTH, -99.f);
+    for (int i = 0; i < WIDTH; ++i) input[i] = i * 0.5f - 1.f;
+    const RawPtr<ND::_2D, float> inPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, 1, WIDTH * sizeof(float))};
+    const RawPtr<ND::_2D, float2> pairPtr{
+        reinterpret_cast<float2*>(output.data()),
+        PtrDims<ND::_2D>(WIDTH / 2, 1, WIDTH * sizeof(float))};
+    const RawPtr<ND::_2D, float> tailPtr{
+        output.data() + WIDTH - 1,
+        PtrDims<ND::_2D>(1, 1, sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inPtr);
+    const auto pairWrite = scaleBiasEpilogue<float2>(
+        float2{2.f, 2.f}, float2{1.f, 1.f},
+        PerThreadWrite<ND::_2D, float2>::build(pairPtr));
+    const auto tailWrite = scaleBiasEpilogue<float>(
+        2.f, 1.f, PerThreadWrite<ND::_2D, float>::build(tailPtr));
+    PairTailStoreDPP<ParArch::CPU, PairTailDetails>::exec(
+        PairTailDetails{WIDTH}, read, pairWrite, tailWrite);
+    for (int i = 0; i < WIDTH; ++i)
+        if (output[i] != 2.f * input[i] + 1.f) return false;
+
+#if defined(__NVCC__)
+    Ptr2D<float> gpuInput(WIDTH, 1), gpuOutput(WIDTH, 1);
+    for (int i = 0; i < WIDTH; ++i)
+        gpuInput.at(Point{i, 0, 0}) = input[i];
+    Stream stream;
+    gpuInput.upload(stream);
+    const auto gpuRead = PerThreadRead<ND::_2D, float>::build(gpuInput);
+    RawPtr<ND::_2D, float2> gpuPairPtr{
+        reinterpret_cast<float2*>(gpuOutput.ptr().data),
+        PtrDims<ND::_2D>(WIDTH / 2, 1, gpuOutput.ptr().dims.pitch)};
+    RawPtr<ND::_2D, float> gpuTailPtr{
+        gpuOutput.ptr().data + WIDTH - 1,
+        PtrDims<ND::_2D>(1, 1, sizeof(float))};
+    const auto gpuPairs = scaleBiasEpilogue<float2>(
+        float2{2.f, 2.f}, float2{1.f, 1.f},
+        PerThreadWrite<ND::_2D, float2>::build(gpuPairPtr));
+    const auto gpuTail = scaleBiasEpilogue<float>(
+        2.f, 1.f, PerThreadWrite<ND::_2D, float>::build(gpuTailPtr));
+    pairTailKernel<<<1, 32>>>(
+        PairTailDetails{WIDTH}, gpuRead, gpuPairs, gpuTail);
+    gpuOutput.download(stream);
+    stream.sync();
+    for (int i = 0; i < WIDTH; ++i)
+        if (gpuOutput.at(Point{i, 0, 0}) != 2.f * input[i] + 1.f)
+            return false;
+#endif
+    return true;
+}
+
+} // namespace
+
+int launch() {
+    bool ok = checkCpuMainloop<EpilogueCase::BARE>();
+    ok = checkCpuMainloop<EpilogueCase::AFFINE>() && ok;
+    ok = checkCpuMainloop<EpilogueCase::RELU>() && ok;
+    ok = checkCpuMainloop<EpilogueCase::LONG>() && ok;
+    ok = checkPairTail() && ok;
+#if defined(__NVCC__)
+    ok = checkGpuMainloop<EpilogueCase::BARE>() && ok;
+    ok = checkGpuMainloop<EpilogueCase::AFFINE>() && ok;
+    ok = checkGpuMainloop<EpilogueCase::RELU>() && ok;
+    ok = checkGpuMainloop<EpilogueCase::LONG>() && ok;
+#endif
+    if (ok) std::printf("Fused Write-IOp epilogues: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_mainloop.h
+++ b/tests/collective/test_collective_mainloop.h
@@ -1,0 +1,237 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+struct ScaleFloat2 {
+private:
+    using SelfType = ScaleFloat2;
+public:
+    FK_STATIC_STRUCT(ScaleFloat2, SelfType)
+    using Parent = BinaryOperation<float2, float, float2, ScaleFloat2>;
+    DECLARE_BINARY_PARENT
+    FK_HOST_DEVICE_FUSE OutputType exec(const InputType input,
+                                        const ParamsType& scale) {
+        return float2{input.x * scale, input.y * scale};
+    }
+};
+
+using AtomDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+
+template <ParArch PA, typename D>
+struct DeterministicWrongMmaDPP;
+
+template <typename D>
+struct DeterministicWrongMmaDPP<ParArch::CPU, D> {
+    using Good = MmaWarpDPP<ParArch::CPU, D>;
+    using AccumulatorFragment = typename Good::AccumulatorFragment;
+    FK_HOST_STATIC void clear(AccumulatorFragment& fragment) {
+        Good::clear(fragment);
+    }
+    template <typename A, typename B>
+    FK_HOST_STATIC void accumulate(const D&, const A&, const B&,
+                                   AccumulatorFragment&) {}
+    template <typename W>
+    FK_HOST_STATIC void store(const D& details,
+                              const AccumulatorFragment& fragment,
+                              const W& output) {
+        Good::store(details, fragment, output);
+    }
+};
+
+#if defined(__NVCC__)
+template <typename D>
+struct DeterministicWrongMmaDPP<ParArch::GPU_NVIDIA, D> {
+    using Good = MmaWarpDPP<ParArch::GPU_NVIDIA, D>;
+    using AccumulatorFragment = typename Good::AccumulatorFragment;
+    FK_DEVICE_STATIC void clear(AccumulatorFragment& fragment) {
+        Good::clear(fragment);
+    }
+    template <typename A, typename B>
+    FK_DEVICE_STATIC void accumulate(const D&, const A&, const B&,
+                                     AccumulatorFragment&) {}
+    template <typename W>
+    FK_DEVICE_STATIC void store(const D& details,
+                                const AccumulatorFragment& fragment,
+                                const W& output) {
+        Good::store(details, fragment, output);
+    }
+};
+#endif
+
+using MainloopDetails = TileMmaMainloopDPPDetails<AtomDetails, MmaWarpDPP>;
+
+static_assert(MainloopDetails::M == 16 && MainloopDetails::N == 8 &&
+              MainloopDetails::K_TILE == 16);
+static_assert(std::is_trivially_copyable_v<MainloopDetails>);
+
+template <typename DPP, typename Details, typename Reads, typename Write,
+          typename = void>
+struct HasThreeArgumentExec : std::false_type {};
+
+template <typename DPP, typename Details, typename Reads, typename Write>
+struct HasThreeArgumentExec<
+    DPP, Details, Reads, Write,
+    std::void_t<decltype(DPP::exec(
+        std::declval<const Details&>(),
+        std::declval<const Reads&>(),
+        std::declval<const Write&>()))>> : std::true_type {};
+
+float valueA(const int row, const int k) {
+    return static_cast<float>((row + k) % 9 - 4) * 0.125f;
+}
+
+float valueB(const int col, const int k) {
+    return static_cast<float>((2 * col + k) % 7 - 3) * 0.25f;
+}
+
+double oracle(const int row, const int col, const int K) {
+    double sum = 0.0;
+    for (int k = 0; k < K; ++k) {
+        const double a = static_cast<double>(valueA(row, k) * 2.f);
+        const double b = static_cast<double>(valueB(col, k) + 0.25f);
+        sum += a * b;
+    }
+    return sum * 0.5;
+}
+
+template <typename GetOutput>
+bool checkOutput(const GetOutput& getOutput, const int K, const char* label) {
+    double maxError = 0.0;
+    for (int row = 0; row < 16; ++row) {
+        for (int pair = 0; pair < 4; ++pair) {
+            const float2 got = getOutput(row, pair);
+            maxError = std::max(maxError,
+                std::fabs(static_cast<double>(got.x) - oracle(row, 2 * pair, K)));
+            maxError = std::max(maxError,
+                std::fabs(static_cast<double>(got.y) - oracle(row, 2 * pair + 1, K)));
+        }
+    }
+    if (maxError > 1e-4) {
+        std::printf("%s K=%d max error=%g\n", label, K, maxError);
+        return false;
+    }
+    return true;
+}
+
+template <typename DetailsPolicy = MainloopDetails>
+bool runCpu(const int K) {
+    std::vector<float> a(16 * K);
+    std::vector<float> b(8 * K);
+    std::array<float2, 16 * 4> d{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k)
+            a[row * K + k] = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k)
+            b[col * K + k] = valueB(col, k);
+
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, 16, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, 8, K * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        d.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const auto readA = PerThreadRead<ND::_2D, float>::build(aPtr)
+        .then(Mul<float>::build(2.f));
+    const auto readB = PerThreadRead<ND::_2D, float>::build(bPtr)
+        .then(Add<float>::build(0.25f));
+    const auto reads = make_tuple(readA, readB);
+    const auto write = ScaleFloat2::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float2>::build(dPtr));
+    const DetailsPolicy details{K, 0, 0, 0, 0, 0, 0};
+
+    using DPP = TileMmaMainloopDPP<ParArch::CPU, DetailsPolicy>;
+    static_assert(HasThreeArgumentExec<DPP, DetailsPolicy,
+                  decltype(reads), decltype(write)>::value);
+    DPP::exec(details, reads, write);
+    return checkOutput(
+        [&](const int row, const int pair) { return d[row * 4 + pair]; },
+        K, "CPU");
+}
+
+#if defined(__NVCC__)
+template <typename DetailsPolicy, typename Reads, typename Write>
+__global__ void mainloopKernel(const __grid_constant__ DetailsPolicy details,
+                               const __grid_constant__ Reads reads,
+                               const __grid_constant__ Write output) {
+    TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DetailsPolicy>::exec(
+        details, reads, output);
+}
+
+template <typename DetailsPolicy = MainloopDetails>
+bool runGpu(const int K) {
+    Ptr2D<float> a(K, 16);
+    Ptr2D<float> b(K, 8);
+    Ptr2D<float2> d(4, 16);
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = valueB(col, k);
+
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const auto readA = PerThreadRead<ND::_2D, float>::build(a)
+        .then(Mul<float>::build(2.f));
+    const auto readB = PerThreadRead<ND::_2D, float>::build(b)
+        .then(Add<float>::build(0.25f));
+    const auto reads = make_tuple(readA, readB);
+    const auto write = ScaleFloat2::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float2>::build(d));
+    const DetailsPolicy details{K, 0, 0, 0, 0, 0, 0};
+
+    using DPP = TileMmaMainloopDPP<ParArch::GPU_NVIDIA, DetailsPolicy>;
+    static_assert(HasThreeArgumentExec<DPP, DetailsPolicy,
+                  decltype(reads), decltype(write)>::value);
+    mainloopKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+        details, reads, write);
+    gpuErrchk(cudaGetLastError());
+    d.download(stream);
+    stream.sync();
+    return checkOutput(
+        [&](const int row, const int pair) {
+            return d.at(Point{pair, row, 0});
+        }, K, "GPU");
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = true;
+    for (const int K : {16, 48, 128}) ok = runCpu(K) && ok;
+#if defined(__NVCC__)
+    for (const int K : {16, 48, 128}) ok = runGpu(K) && ok;
+#endif
+    if (ok) std::printf("TileMmaMainloopDPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_mma_async.h
+++ b/tests/collective/test_collective_mma_async.h
@@ -1,0 +1,268 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/async_copy.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+#include <fused_kernel/algorithms/collective/mma.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+using namespace fk;
+
+namespace {
+
+using MmaDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+using AsyncLayout = RowMajorLayout<1, 20>;
+using AsyncDetails = AsyncCopyDPPDetails<float, AsyncLayout, 128>;
+
+static_assert(MmaDetails::M == 16 && MmaDetails::N == 8 &&
+              MmaDetails::K == 16);
+static_assert(std::is_trivially_copyable_v<MmaDetails>);
+static_assert(std::is_trivially_copyable_v<AsyncDetails>);
+static_assert(MmaWarpDPP<ParArch::CPU, MmaDetails>::PAR_ARCH == ParArch::CPU);
+static_assert(AsyncCopyDPP<ParArch::CPU, AsyncDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(MmaWarpDPP<ParArch::GPU_NVIDIA, MmaDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(AsyncCopyDPP<ParArch::GPU_NVIDIA, AsyncDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+
+float valueA(const int row, const int k) {
+    return static_cast<float>((row + 2 * k) % 7 - 3) * 0.25f;
+}
+
+float valueB(const int col, const int k) {
+    return static_cast<float>((3 * col + k) % 5 - 2) * 0.5f;
+}
+
+double oracleMma(const int row, const int col) {
+    double sum = 0.0;
+    for (int k = 0; k < 16; ++k) {
+        sum += static_cast<double>(valueA(row, k)) *
+               static_cast<double>(valueB(col, k));
+    }
+    return sum;
+}
+
+template <typename Output>
+bool checkMmaOutput(const Output& output, const char* label) {
+    double maxError = 0.0;
+    for (int row = 0; row < 16; ++row) {
+        for (int pair = 0; pair < 4; ++pair) {
+            const float2 got = output(row, pair);
+            maxError = std::max(
+                maxError,
+                std::fabs(static_cast<double>(got.x) - oracleMma(row, 2 * pair)));
+            maxError = std::max(
+                maxError,
+                std::fabs(static_cast<double>(got.y) - oracleMma(row, 2 * pair + 1)));
+        }
+    }
+    if (maxError > 1e-4) {
+        std::printf("%s MMA max error=%g\n", label, maxError);
+        return false;
+    }
+    return true;
+}
+
+bool testCpuMma() {
+    std::array<float, 16 * 16> a{};
+    std::array<float, 8 * 16> b{};
+    std::array<float2, 16 * 4> d{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < 16; ++k)
+            a[row * 16 + k] = valueA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < 16; ++k)
+            b[col * 16 + k] = valueB(col, k);
+
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(16, 16, 16 * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(16, 8, 16 * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        d.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const auto readA = PerThreadRead<ND::_2D, float>::build(aPtr);
+    const auto readB = PerThreadRead<ND::_2D, float>::build(bPtr);
+    const auto writeD = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    const MmaDetails details{0, 0, 0, 0, 0, 0};
+    MmaWarpDPP<ParArch::CPU, MmaDetails>::exec(
+        details, readA, readB, writeD);
+    return checkMmaOutput(
+        [&](const int row, const int pair) { return d[row * 4 + pair]; },
+        "CPU");
+}
+
+template <typename ReadIOp>
+bool testCpuAsyncRead(const ReadIOp& read, const float scale,
+                      const float offset, const char* label) {
+    std::array<float, AsyncLayout::size()> storage{};
+    Tile<float, AsyncLayout> tile{storage.data()};
+    const AsyncDetails details{4, 18, -7.f};
+    AsyncCopyDPP<ParArch::CPU, AsyncDetails>::load(details, read, tile);
+    for (int index = 0; index < static_cast<int>(AsyncLayout::size()); ++index) {
+        const float expected = index < details.elementCount
+            ? static_cast<float>(details.origin + index) * scale + offset
+            : details.boundaryValue;
+        if (std::fabs(tile.at(0, index) - expected) > 1e-6f) {
+            std::printf("%s CPU async index=%d got=%f expected=%f\n",
+                        label, index, tile.at(0, index), expected);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testCpuAsyncCopy() {
+    std::array<float, 24> source{};
+    for (int i = 0; i < 24; ++i) source[i] = static_cast<float>(i);
+    const RawPtr<ND::_1D, float> sourcePtr{
+        source.data(), PtrDims<ND::_1D>(24, 24 * sizeof(float))};
+    const auto plain = PerThreadRead<ND::_1D, float>::build(sourcePtr);
+    const auto fused = plain.then(Mul<float>::build(2.f))
+                            .then(Add<float>::build(1.f));
+    return testCpuAsyncRead(plain, 1.f, 0.f, "plain") &&
+           testCpuAsyncRead(fused, 2.f, 1.f, "fused");
+}
+
+#if defined(__NVCC__)
+template <typename D, typename AReadIOp, typename BReadIOp, typename WriteIOp>
+__global__ void mmaKernel(const __grid_constant__ D details,
+                          const __grid_constant__ AReadIOp a,
+                          const __grid_constant__ BReadIOp b,
+                          const __grid_constant__ WriteIOp d) {
+    MmaWarpDPP<ParArch::GPU_NVIDIA, D>::exec(details, a, b, d);
+}
+
+template <typename D, typename ReadIOp, typename WriteIOp>
+__global__ void asyncCopyKernel(const __grid_constant__ D details,
+                                const __grid_constant__ ReadIOp input,
+                                const __grid_constant__ WriteIOp output) {
+    __shared__ __align__(16) float storage[AsyncLayout::size()];
+    Tile<float, AsyncLayout> tile{storage};
+    AsyncCopyDPP<ParArch::GPU_NVIDIA, D>::load(details, input, tile);
+    using StoreDetails = CopyTileDPPDetails<float, AsyncLayout, 128>;
+    const StoreDetails storeDetails{0, 0, 20, 1, 0.f};
+    CopyTileDPP<ParArch::GPU_NVIDIA, StoreDetails>::store(
+        storeDetails, tile, output);
+}
+
+bool testGpuMma() {
+    Ptr2D<uint16_t> a(16, 16);
+    Ptr2D<uint16_t> b(16, 8);
+    Ptr2D<float2> d(4, 16);
+    for (int row = 0; row < 16; ++row) {
+        for (int k = 0; k < 16; ++k) {
+            const __nv_bfloat16 value = __float2bfloat16(valueA(row, k));
+            uint16_t bits;
+            std::memcpy(&bits, &value, sizeof(bits));
+            a.at(Point{k, row, 0}) = bits;
+        }
+    }
+    for (int col = 0; col < 8; ++col) {
+        for (int k = 0; k < 16; ++k) {
+            const __nv_bfloat16 value = __float2bfloat16(valueB(col, k));
+            uint16_t bits;
+            std::memcpy(&bits, &value, sizeof(bits));
+            b.at(Point{k, col, 0}) = bits;
+        }
+    }
+
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const auto readA = PerThreadRead<ND::_2D, uint16_t>::build(a);
+    const auto readB = PerThreadRead<ND::_2D, uint16_t>::build(b);
+    const auto writeD = PerThreadWrite<ND::_2D, float2>::build(d);
+    const MmaDetails details{0, 0, 0, 0, 0, 0};
+    mmaKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+        details, readA, readB, writeD);
+    gpuErrchk(cudaGetLastError());
+    d.download(stream);
+    stream.sync();
+    return checkMmaOutput(
+        [&](const int row, const int pair) {
+            return d.at(Point{pair, row, 0});
+        },
+        "GPU");
+}
+
+template <typename ReadIOp>
+bool testGpuAsyncRead(const ReadIOp& read, Ptr2D<float>& output,
+                      const float scale, const float offset,
+                      const char* label, Stream& stream) {
+    for (int index = 0; index < 20; ++index)
+        output.at(Point{index, 0, 0}) = -99.f;
+    output.upload(stream);
+    const auto write = PerThreadWrite<ND::_2D, float>::build(output);
+    const AsyncDetails details{4, 18, -7.f};
+    asyncCopyKernel<<<1, AsyncDetails::BLOCK_THREADS, 0,
+                      stream.getCUDAStream()>>>(details, read, write);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+    for (int index = 0; index < 20; ++index) {
+        const float expected = index < details.elementCount
+            ? static_cast<float>(details.origin + index) * scale + offset
+            : details.boundaryValue;
+        const float got = output.at(Point{index, 0, 0});
+        if (std::fabs(got - expected) > 1e-6f) {
+            std::printf("%s GPU async index=%d got=%f expected=%f\n",
+                        label, index, got, expected);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testGpuAsyncCopy() {
+    Ptr1D<float> source(24);
+    Ptr2D<float> output(20, 1);
+    for (int i = 0; i < 24; ++i) source.at(Point{i, 0, 0}) = static_cast<float>(i);
+    Stream stream;
+    source.upload(stream);
+    const auto plain = PerThreadRead<ND::_1D, float>::build(source);
+    const auto fused = plain.then(Mul<float>::build(2.f))
+                            .then(Add<float>::build(1.f));
+    return testGpuAsyncRead(plain, output, 1.f, 0.f, "plain", stream) &&
+           testGpuAsyncRead(fused, output, 2.f, 1.f, "fused", stream);
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuMma() && testCpuAsyncCopy();
+#if defined(__NVCC__)
+    ok = testGpuMma() && ok;
+    ok = testGpuAsyncCopy() && ok;
+#endif
+    if (ok) std::printf("MMA + AsyncCopy DPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_multistage.h
+++ b/tests/collective/test_collective_multistage.h
@@ -1,0 +1,249 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/mainloop.h>
+#include <fused_kernel/algorithms/collective/multistage.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+using namespace fk;
+
+namespace {
+
+using AtomDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+using ALayout = RowMajorLayout<16, 16>;
+using BLayout = RowMajorLayout<8, 16>;
+using Details = MultiStageMainloopDPPDetails<
+    4, AtomDetails, ALayout, BLayout, float,
+    MmaWarpDPP, AsyncCopyDPP>;
+
+static_assert(Details::MAX_STAGES == 4);
+static_assert(Details::SHARED_ELEMENTS ==
+              4 * (ALayout::size() + BLayout::size()));
+
+float rawA(const int row, const int k) {
+    return ((row * 5 + k * 3) % 17 - 8) * 0.0625f;
+}
+
+float rawB(const int col, const int k) {
+    return ((col * 7 + k * 2) % 13 - 6) * 0.078125f;
+}
+
+float effective(const float value, const bool gpu) {
+#if defined(__NVCC__)
+    if (gpu) return __bfloat162float(__float2bfloat16(value));
+#else
+    (void)gpu;
+#endif
+    return value;
+}
+
+double oracle(const int row, const int col, const int K,
+              const bool fused, const bool gpu) {
+    double result = 0.0;
+    for (int k = 0; k < K; ++k) {
+        const float a = effective(
+            fused ? rawA(row, k) * 1.25f : rawA(row, k), gpu);
+        const float b = effective(
+            fused ? rawB(col, k) - 0.125f : rawB(col, k), gpu);
+        result += static_cast<double>(a) * static_cast<double>(b);
+    }
+    return fused ? result * 0.5 : result;
+}
+
+template <typename Get>
+bool check(const int K, const bool fused, const bool gpu, const Get& get) {
+    const double tolerance = gpu ? 0.05 * ((K + 15) / 16.0) + 1e-3 : 1e-5;
+    double maxError = 0.0;
+    for (int row = 0; row < 16; ++row)
+        for (int col = 0; col < 8; ++col)
+            maxError = std::max(maxError, std::abs(
+                static_cast<double>(get(row, col)) -
+                oracle(row, col, K, fused, gpu)));
+    if (maxError > tolerance) {
+        std::printf("multistage K=%d fused=%d gpu=%d maxError=%g tol=%g\n",
+                    K, fused, gpu, maxError, tolerance);
+        return false;
+    }
+    return true;
+}
+
+template <bool FUSED>
+bool runCpu(const int stages, const int K) {
+    std::vector<float> a(16 * K), b(8 * K);
+    std::array<float2, 16 * 4> output{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k) a[row * K + k] = rawA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k) b[col * K + k] = rawB(col, k);
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, 16, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, 8, K * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        output.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const Details details{stages, K, 0, 0, 0, 0, 0, 0};
+    const auto baseA = PerThreadRead<ND::_2D, float>::build(aPtr);
+    const auto baseB = PerThreadRead<ND::_2D, float>::build(bPtr);
+    const auto baseD = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    if constexpr (FUSED) {
+        const auto reads = make_tuple(
+            baseA.then(Mul<float>::build(1.25f)),
+            baseB.then(Add<float>::build(-0.125f)));
+        const auto write = Mul<float2>::build(float2{0.5f, 0.5f})
+            .then(baseD);
+        MultiStageMainloopDPP<ParArch::CPU, Details>::exec(
+            details, reads, write);
+    } else {
+        MultiStageMainloopDPP<ParArch::CPU, Details>::exec(
+            details, make_tuple(baseA, baseB), baseD);
+    }
+    return check(K, FUSED, false,
+        [&](const int row, const int col) {
+            const float2 value = output[row * 4 + col / 2];
+            return col & 1 ? value.y : value.x;
+        });
+}
+
+bool invalidStagesRejected() {
+    const Details tooFew{1, 17, 0, 0, 0, 0, 0, 0};
+    const Details tooMany{5, 17, 0, 0, 0, 0, 0, 0};
+    if (tooFew.valid() || tooMany.valid()) return false;
+    std::vector<float> a(16 * 17, 1.f), b(8 * 17, 1.f);
+    std::array<float2, 64> output;
+    for (auto& value : output) value = float2{-77.f, -77.f};
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(17, 16, 17 * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(17, 8, 17 * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        output.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    const auto reads = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(aPtr),
+        PerThreadRead<ND::_2D, float>::build(bPtr));
+    const auto write = PerThreadWrite<ND::_2D, float2>::build(dPtr);
+    MultiStageMainloopDPP<ParArch::CPU, Details>::exec(
+        tooFew, reads, write);
+    MultiStageMainloopDPP<ParArch::CPU, Details>::exec(
+        tooMany, reads, write);
+    for (const auto value : output)
+        if (value.x != -77.f || value.y != -77.f) return false;
+    return true;
+}
+
+bool singleStageCpuParity() {
+    constexpr int K = 32;
+    std::vector<float> a(16 * K), b(8 * K);
+    std::array<float2, 64> output{};
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k) a[row * K + k] = rawA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k) b[col * K + k] = rawB(col, k);
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, 16, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, 8, K * sizeof(float))};
+    const RawPtr<ND::_2D, float2> dPtr{
+        output.data(), PtrDims<ND::_2D>(4, 16, 4 * sizeof(float2))};
+    using SingleDetails = TileMmaMainloopDPPDetails<AtomDetails>;
+    TileMmaMainloopDPP<ParArch::CPU, SingleDetails>::exec(
+        SingleDetails{K, 0, 0, 0, 0, 0, 0},
+        make_tuple(PerThreadRead<ND::_2D, float>::build(aPtr),
+                   PerThreadRead<ND::_2D, float>::build(bPtr)),
+        PerThreadWrite<ND::_2D, float2>::build(dPtr));
+    return check(K, false, false,
+        [&](const int row, const int col) {
+            const float2 value = output[row * 4 + col / 2];
+            return col & 1 ? value.y : value.x;
+        });
+}
+
+#if defined(__NVCC__)
+template <typename Reads, typename Write>
+__global__ void multistageKernel(const Details details,
+                                 const Reads reads, const Write output) {
+    MultiStageMainloopDPP<ParArch::GPU_NVIDIA, Details>::exec(
+        details, reads, output);
+}
+
+template <bool FUSED>
+bool runGpu(const int stages, const int K) {
+    Ptr2D<float> a(K, 16), b(K, 8);
+    Ptr2D<float2> output(4, 16);
+    for (int row = 0; row < 16; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = rawA(row, k);
+    for (int col = 0; col < 8; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = rawB(col, k);
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const Details details{stages, K, 0, 0, 0, 0, 0, 0};
+    const auto baseA = PerThreadRead<ND::_2D, float>::build(a);
+    const auto baseB = PerThreadRead<ND::_2D, float>::build(b);
+    const auto baseD = PerThreadWrite<ND::_2D, float2>::build(output);
+    if constexpr (FUSED) {
+        const auto reads = make_tuple(
+            baseA.then(Mul<float>::build(1.25f)),
+            baseB.then(Add<float>::build(-0.125f)));
+        const auto write = Mul<float2>::build(float2{0.5f, 0.5f})
+            .then(baseD);
+        multistageKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+            details, reads, write);
+    } else {
+        const auto reads = make_tuple(baseA, baseB);
+        multistageKernel<<<1, 32, 0, stream.getCUDAStream()>>>(
+            details, reads, baseD);
+    }
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+    return check(K, FUSED, true,
+        [&](const int row, const int col) {
+            const float2 value = output.at(Point{col / 2, row, 0});
+            return col & 1 ? value.y : value.x;
+        });
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = invalidStagesRejected();
+    ok = singleStageCpuParity() && ok;
+    for (const int stages : {2, 3, 4}) {
+        ok = runCpu<false>(stages, 1) && ok;
+        ok = runCpu<true>(stages, 31) && ok;
+        ok = runCpu<false>(stages, 160) && ok;
+#if defined(__NVCC__)
+        ok = runGpu<false>(stages, 1) && ok;
+        ok = runGpu<true>(stages, 31) && ok;
+        ok = runGpu<false>(stages, 160) && ok;
+#endif
+    }
+    if (ok) std::printf("MultiStageMainloopDPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_reduce.h
+++ b/tests/collective/test_collective_reduce.h
@@ -1,0 +1,336 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <fused_kernel/algorithms/algorithms.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace fk;
+
+namespace {
+
+using CompileDetails = ReduceDPPDetails<float, 128>;
+static_assert(ReduceWarpDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceBlockDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceGridDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+static_assert(ReduceDPP<ParArch::CPU, CompileDetails>::PAR_ARCH ==
+              ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(ReduceWarpDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceBlockDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceGridDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+static_assert(ReduceDPP<ParArch::GPU_NVIDIA, CompileDetails>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+static_assert(std::is_trivially_copyable_v<CompileDetails>);
+
+template <typename ComputeIOp>
+bool runCpuCase(const ComputeIOp& compute,
+                const std::array<float, 3>& identity,
+                const std::array<float, 3>& expected) {
+    constexpr int ROWS = 3;
+    constexpr int WIDTH = 7;
+    constexpr int BLOCK_SIZE = 64;
+
+    std::array<float, ROWS * WIDTH> input{
+         1.f, -2.f,  3.f,  4.f, -5.f,  6.f,  7.f,
+        -9.f, -8.f, -7.f, -6.f, -5.f, -4.f, -3.f,
+         0.5f, 1.5f, -2.f, 8.f,  3.f, -1.f, 2.f
+    };
+    std::array<float, ROWS> output{123.f, 123.f, 123.f};
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, ROWS, WIDTH * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(ROWS, ROWS * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(outputPtr);
+
+    using Details = ReduceDPPDetails<float, BLOCK_SIZE>;
+    for (int row = 0; row < ROWS; ++row) {
+        const Details details{1, WIDTH, identity[row], row};
+        ReduceDPP<ParArch::CPU, Details>::exec(details, read, compute, write);
+    }
+
+    for (int row = 0; row < ROWS; ++row) {
+        if (std::fabs(output[row] - expected[row]) > 1e-6f) {
+            std::printf("CPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, output[row], expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testCpuReductionIOps() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+
+    const bool sumOk = runCpuCase(sum, {0.f, 0.f, 0.f}, {14.f, -42.f, 12.f});
+    const bool minOk = runCpuCase(min,
+        {std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity(),
+         std::numeric_limits<float>::infinity()},
+        {-5.f, -9.f, -2.f});
+    const bool maxOk = runCpuCase(max,
+        {-std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity(),
+         -std::numeric_limits<float>::infinity()},
+        {7.f, -3.f, 8.f});
+    return sumOk && minOk && maxOk;
+}
+
+bool testCpuGridTierAndFusion() {
+    std::array<float, 3> input{1.f, 2.f, 3.f};
+    std::array<float, 1> output{0.f};
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(3, 1, 3 * sizeof(float))};
+    const RawPtr<ND::_1D, float> outputPtr{
+        output.data(), PtrDims<ND::_1D>(1, sizeof(float))};
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Add<float>::build(1.f));
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = Mul<float>::build(2.f)
+        .then(PerThreadWrite<ND::_1D, float>::build(outputPtr));
+
+    using Details = ReduceDPPDetails<float, 32>;
+    const Details details{1, 3, 0.f, 0};
+    ReduceDPP<ParArch::CPU, Details>::exec(
+        details, read, sum, write);
+    if (std::fabs(output[0] - 18.f) > 1e-6f) {
+        std::printf("CPU fused row reduction got=%f expected=18\n", output[0]);
+        return false;
+    }
+
+    float gridAccumulator = 0.f;
+    for (const float value : input) {
+        ReduceGridDPP<ParArch::CPU, Details>::exec(
+            details, value, sum, nullptr, &gridAccumulator);
+    }
+    if (std::fabs(gridAccumulator - 6.f) > 1e-6f) {
+        std::printf("CPU grid partial reduction got=%f expected=6\n",
+                    gridAccumulator);
+        return false;
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <int BLOCK_SIZE, typename ReadIOp, typename ComputeIOp>
+__global__ void gridReduceDPPTestKernel(
+        const __grid_constant__ ReduceDPPDetails<float, BLOCK_SIZE> details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ ComputeIOp compute,
+        float* accumulator) {
+    __shared__ float warpScratch[BLOCK_SIZE / 32];
+    const int x = static_cast<int>(blockIdx.x) * BLOCK_SIZE +
+                  static_cast<int>(threadIdx.x);
+    float value = details.identity;
+    if (x < details.width) {
+        value = ReadIOp::Operation::exec(Point{x, 0, 0}, input);
+    }
+    ReduceGridDPP<ParArch::GPU_NVIDIA,
+                  ReduceDPPDetails<float, BLOCK_SIZE>>::exec(
+        details, value, compute, warpScratch, accumulator);
+}
+
+template <int BLOCK_SIZE, typename ComputeIOp, typename HostCombine>
+bool runGpuGridVariant(const char* name, const ComputeIOp& compute,
+                       const float identity, const HostCombine& hostCombine) {
+    constexpr int WIDTH = 4096 + 37;
+    Ptr1D<float> input(WIDTH);
+    Ptr1D<float> accumulator(1);
+    float expected = identity;
+    for (int x = 0; x < WIDTH; ++x) {
+        const float value = static_cast<float>(((x * 17) % 101) - 50) * 0.125f;
+        input.at(Point{x, 0, 0}) = value;
+        expected = hostCombine(expected, value);
+    }
+    accumulator.at(Point{0, 0, 0}) = identity;
+
+    Stream stream;
+    input.upload(stream);
+    accumulator.upload(stream);
+    const auto read = PerThreadRead<ND::_1D, float>::build(input);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{1, WIDTH, identity, 0};
+    constexpr int BLOCKS = (WIDTH + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    gridReduceDPPTestKernel<BLOCK_SIZE><<<BLOCKS, BLOCK_SIZE, 0,
+        stream.getCUDAStream()>>>(
+        details, read, compute, accumulator.ptr().data);
+    gpuErrchk(cudaGetLastError());
+    accumulator.download(stream);
+    stream.sync();
+
+    const float got = accumulator.at(Point{0, 0, 0});
+    const float tolerance = 1e-4f * std::fmax(1.f, std::fabs(expected));
+    if (std::fabs(got - expected) > tolerance) {
+        std::printf("GPU grid %s got=%f expected=%f blocks=%d\n",
+                    name, got, expected, BLOCKS);
+        return false;
+    }
+    return true;
+}
+
+bool testGpuGridReduction() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuGridVariant<128>("sum", sum, 0.f,
+               [](float a, float b) { return a + b; }) &&
+           runGpuGridVariant<128>("max", max,
+               -std::numeric_limits<float>::infinity(),
+               [](float a, float b) { return std::fmax(a, b); });
+}
+
+template <int BLOCK_SIZE, typename ComputeIOp>
+bool runGpuVariant(const char* name, const int width, const float identity,
+                   const ComputeIOp& compute) {
+    constexpr int ROWS = 3;
+    const int allocationWidth = width > 0 ? width : 1;
+    Ptr2D<float> input(allocationWidth, ROWS);
+    Ptr1D<float> output(ROWS);
+    std::array<float, ROWS> expected{};
+
+    for (int row = 0; row < ROWS; ++row) {
+        expected[row] = identity;
+        for (int x = 0; x < allocationWidth; ++x) {
+            const float value = static_cast<float>(((x * 5 + row * 13) % 37) - 18);
+            input.at(Point{x, row, 0}) = value;
+            if (x < width) expected[row] = make_tuple(expected[row], value) | compute;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{ROWS, width, identity, 0};
+    executeReduce(details, read, compute, write, stream);
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU %s B=%d W=%d row=%d got=%f expected=%f\n",
+                        name, BLOCK_SIZE, width, row, got, expected[row]);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testGpuVariants() {
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto min = Min<float, float, float, UnaryType>::build();
+    const auto max = Max<float, float, float, UnaryType>::build();
+    return runGpuVariant<32>("sum-empty", 0, 0.f, sum) &&
+           runGpuVariant<32>("sum-subwarp", 17, 0.f, sum) &&
+           runGpuVariant<32>("sum-warp", 32, 0.f, sum) &&
+           runGpuVariant<32>("sum", 33, 0.f, sum) &&
+           runGpuVariant<64>("max", 129,
+               -std::numeric_limits<float>::infinity(), max) &&
+           runGpuVariant<128>("sum", 257, 0.f, sum) &&
+           runGpuVariant<256>("min", 257,
+               std::numeric_limits<float>::infinity(), min);
+}
+
+bool testGpuRowReductionIOps() {
+    constexpr int ROWS = 4;
+    constexpr int WIDTH = 257;
+    constexpr int BLOCK_SIZE = 128;
+
+    Ptr2D<float> input(WIDTH, ROWS);
+    Ptr1D<float> output(ROWS);
+    std::array<float, ROWS> expected{};
+    for (int row = 0; row < ROWS; ++row) {
+        for (int x = 0; x < WIDTH; ++x) {
+            const float value = static_cast<float>(((x * 7 + row * 11) % 29) - 14);
+            input.at(Point{x, row, 0}) = value;
+            expected[row] += value;
+        }
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+
+    const auto read = PerThreadRead<ND::_2D, float>::build(input);
+    const auto sum = Add<float, float, float, UnaryType>::build();
+    const auto write = PerThreadWrite<ND::_1D, float>::build(output);
+    const ReduceDPPDetails<float, BLOCK_SIZE> details{ROWS, WIDTH, 0.f, 0};
+    executeReduce(details, read, sum, write, stream);
+
+    output.download(stream);
+    stream.sync();
+    for (int row = 0; row < ROWS; ++row) {
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - expected[row]) > 1e-4f) {
+            std::printf("GPU reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, expected[row]);
+            return false;
+        }
+    }
+
+    for (int row = 0; row < ROWS; ++row) {
+        output.at(Point{row, 0, 0}) = 999.f;
+    }
+    output.upload(stream);
+    const auto fusedRead = read.then(Add<float>::build(1.f));
+    const auto fusedWrite = Mul<float>::build(2.f).then(write);
+    executeReduce(details, fusedRead, sum, fusedWrite, stream);
+    output.download(stream);
+    stream.sync();
+    for (int row = 0; row < ROWS; ++row) {
+        const float fusedExpected = (expected[row] + WIDTH) * 2.f;
+        const float got = output.at(Point{row, 0, 0});
+        if (std::fabs(got - fusedExpected) > 1e-4f) {
+            std::printf("GPU fused reduction mismatch row=%d got=%f expected=%f\n",
+                        row, got, fusedExpected);
+            return false;
+        }
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testCpuReductionIOps();
+    ok = testCpuGridTierAndFusion() && ok;
+#if defined(__NVCC__)
+    ok = testGpuGridReduction() && ok;
+    ok = testGpuVariants() && ok;
+    ok = testGpuRowReductionIOps() && ok;
+#endif
+    if (ok) std::printf("ReduceDPP CPU/GPU IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_register_tile.h
+++ b/tests/collective/test_collective_register_tile.h
@@ -1,0 +1,223 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/register_tile.h>
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#if defined(__NVCC__)
+#include <cuda_bf16.h>
+#endif
+
+using namespace fk;
+
+namespace {
+
+using AtomDetails = MmaDPPDetails<MmaBf16_16x8x16>;
+using SchedulerOperation = WarpTileScheduler<RowMajorWarpTileRaster>;
+
+float rawA(const int row, const int k) {
+    return ((row * 7 + k * 3) % 19 - 9) * 0.0625f;
+}
+
+float rawB(const int col, const int k) {
+    return ((col * 5 + k * 2) % 17 - 8) * 0.078125f;
+}
+
+float effective(const float value, const bool gpuBf16) {
+#if defined(__NVCC__)
+    if (gpuBf16)
+        return __bfloat162float(__float2bfloat16(value));
+#else
+    (void)gpuBf16;
+#endif
+    return value;
+}
+
+double reference(const int row, const int col, const int K,
+                 const bool gpuBf16) {
+    double result = 0.0;
+    for (int k = 0; k < K; ++k) {
+        const float a = effective(rawA(row, k) * 1.5f, gpuBf16);
+        const float b = effective(rawB(col, k) + 0.25f, gpuBf16);
+        result += static_cast<double>(a) * static_cast<double>(b);
+    }
+    return result * 0.5;
+}
+
+bool checkSchedulerOrder() {
+    const auto scheduler = SchedulerOperation::build();
+    for (int warp = 0; warp < 6; ++warp) {
+        const WarpTileAssignment assignment =
+            make_tuple(warp, 2, 3) | scheduler;
+        if (!assignment.valid || assignment.mTile != warp / 3 ||
+            assignment.nTile != warp % 3) return false;
+    }
+    return true;
+}
+
+template <int WM, int WN>
+using Details = RegisterTileMainloopDPPDetails<
+    WM, WN, AtomDetails, MmaWarpDPP,
+    DefaultRegisterFragmentLayout, SchedulerOperation>;
+
+template <int WM, int WN, typename OutputGetter>
+bool checkOutput(const int K, const int rows, const int cols,
+                 const bool gpuBf16, const OutputGetter& output) {
+    const double tolerance = gpuBf16 ? 0.05 * (K / 16.0) + 1e-3 : 1e-5;
+    double maxError = 0.0;
+    for (int row = 0; row < rows; ++row) {
+        for (int col = 0; col < cols; ++col) {
+            maxError = std::max(maxError, std::abs(
+                static_cast<double>(output(row, col)) -
+                reference(row, col, K, gpuBf16)));
+        }
+    }
+    if (maxError > tolerance) {
+        std::printf("RegisterTile %dx%d K=%d maxError=%g tolerance=%g\n",
+                    WM, WN, K, maxError, tolerance);
+        return false;
+    }
+    return true;
+}
+
+template <int WM, int WN>
+bool runCpu(const int K) {
+    using D = Details<WM, WN>;
+    constexpr int REGISTER_M = D::REGISTER_M;
+    constexpr int REGISTER_N = D::REGISTER_N;
+    constexpr int M_TILES = 2;
+    constexpr int N_TILES = 3;
+    const int rows = REGISTER_M * M_TILES - 3;
+    const int cols = REGISTER_N * N_TILES - 1;
+    const int paddedRows = REGISTER_M * M_TILES;
+    const int paddedCols = REGISTER_N * N_TILES;
+    std::vector<float> a(paddedRows * K), b(paddedCols * K);
+    std::vector<float> output(rows * cols, -99.f);
+    for (int row = 0; row < paddedRows; ++row)
+        for (int k = 0; k < K; ++k) a[row * K + k] = rawA(row, k);
+    for (int col = 0; col < paddedCols; ++col)
+        for (int k = 0; k < K; ++k) b[col * K + k] = rawB(col, k);
+    const RawPtr<ND::_2D, float> aPtr{
+        a.data(), PtrDims<ND::_2D>(K, paddedRows, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> bPtr{
+        b.data(), PtrDims<ND::_2D>(K, paddedCols, K * sizeof(float))};
+    const RawPtr<ND::_2D, float> dPtr{
+        output.data(), PtrDims<ND::_2D>(cols, rows, cols * sizeof(float))};
+    const auto reads = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(aPtr)
+            .then(Mul<float>::build(1.5f)),
+        PerThreadRead<ND::_2D, float>::build(bPtr)
+            .then(Add<float>::build(0.25f)));
+    const auto write = Mul<float>::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float>::build(dPtr));
+    const auto scheduler = SchedulerOperation::build();
+    const D details{K, M_TILES, N_TILES, rows, cols,
+                    0, 0, 0, 0, 0, 0};
+    RegisterTileMainloopDPP<ParArch::CPU, D>::exec(
+        details, reads, write, scheduler);
+    return checkOutput<WM, WN>(K, rows, cols, false,
+        [&](const int row, const int col) {
+            return output[row * cols + col];
+        });
+}
+
+#if defined(__NVCC__)
+template <typename D, typename Reads, typename Write, typename Scheduler>
+__global__ void registerTileKernel(const D details, const Reads reads,
+                                   const Write output,
+                                   const Scheduler scheduler) {
+    RegisterTileMainloopDPP<ParArch::GPU_NVIDIA, D>::exec(
+        details, reads, output, scheduler);
+}
+
+template <int WM, int WN>
+bool runGpu(const int K) {
+    using D = Details<WM, WN>;
+    constexpr int REGISTER_M = D::REGISTER_M;
+    constexpr int REGISTER_N = D::REGISTER_N;
+    constexpr int M_TILES = 2;
+    constexpr int N_TILES = 3;
+    const int rows = REGISTER_M * M_TILES - 3;
+    const int cols = REGISTER_N * N_TILES - 1;
+    const int paddedRows = REGISTER_M * M_TILES;
+    const int paddedCols = REGISTER_N * N_TILES;
+    Ptr2D<float> a(K, paddedRows), b(K, paddedCols), output(cols, rows);
+    for (int row = 0; row < paddedRows; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = rawA(row, k);
+    for (int col = 0; col < paddedCols; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = rawB(col, k);
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    const auto reads = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(a)
+            .then(Mul<float>::build(1.5f)),
+        PerThreadRead<ND::_2D, float>::build(b)
+            .then(Add<float>::build(0.25f)));
+    const auto write = Mul<float>::build(0.5f)
+        .then(PerThreadWrite<ND::_2D, float>::build(output));
+    const auto scheduler = SchedulerOperation::build();
+    const D details{K, M_TILES, N_TILES, rows, cols,
+                    0, 0, 0, 0, 0, 0};
+    constexpr int WARPS_PER_BLOCK = 4;
+    const int blocks = (M_TILES * N_TILES + WARPS_PER_BLOCK - 1) /
+                       WARPS_PER_BLOCK;
+    registerTileKernel<<<blocks, WARPS_PER_BLOCK * 32, 0,
+                         stream.getCUDAStream()>>>(
+        details, reads, write, scheduler);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+    return checkOutput<WM, WN>(K, rows, cols, true,
+        [&](const int row, const int col) {
+            return output.at(Point{col, row, 0});
+        });
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = checkSchedulerOrder();
+    ok = runCpu<1, 1>(16) && ok;
+    ok = runCpu<1, 1>(48) && ok;
+    ok = runCpu<2, 2>(16) && ok;
+    ok = runCpu<2, 2>(48) && ok;
+    ok = runCpu<2, 4>(16) && ok;
+    ok = runCpu<2, 4>(48) && ok;
+    ok = runCpu<4, 2>(16) && ok;
+    ok = runCpu<4, 2>(48) && ok;
+#if defined(__NVCC__)
+    ok = runGpu<1, 1>(16) && ok;
+    ok = runGpu<1, 1>(48) && ok;
+    ok = runGpu<2, 2>(16) && ok;
+    ok = runGpu<2, 2>(48) && ok;
+    ok = runGpu<2, 4>(16) && ok;
+    ok = runGpu<2, 4>(48) && ok;
+    ok = runGpu<4, 2>(16) && ok;
+    ok = runGpu<4, 2>(48) && ok;
+#endif
+    if (ok) std::printf("RegisterTileMainloopDPP contracts: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_collective_tile.h
+++ b/tests/collective/test_collective_tile.h
@@ -1,0 +1,205 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/copy.h>
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+
+using namespace fk;
+
+namespace {
+
+using RowLayout = RowMajorLayout<3, 4>;
+using ColumnLayout = ColumnMajorLayout<3, 4>;
+using Details = CopyTileDPPDetails<float, RowLayout, 64>;
+
+static_assert(RowLayout::rows == 3 && RowLayout::cols == 4);
+static_assert(RowLayout::size() == 12);
+static_assert(ColumnLayout::rows == 3 && ColumnLayout::cols == 4);
+static_assert(ColumnLayout::size() == 12);
+static_assert(std::is_trivially_copyable_v<Details>);
+static_assert(std::is_trivially_copyable_v<Tile<float, RowLayout>>);
+static_assert(CopyTileDPP<ParArch::CPU, Details>::PAR_ARCH == ParArch::CPU);
+#if defined(__NVCC__)
+static_assert(CopyTileDPP<ParArch::GPU_NVIDIA, Details>::PAR_ARCH ==
+              ParArch::GPU_NVIDIA);
+#endif
+
+bool testLayoutMappings() {
+    constexpr std::array<unsigned, 12> rowExpected{
+        0, 1, 2, 3,
+        4, 5, 6, 7,
+        8, 9, 10, 11};
+    constexpr std::array<unsigned, 12> columnExpected{
+        0, 3, 6, 9,
+        1, 4, 7, 10,
+        2, 5, 8, 11};
+    for (unsigned row = 0; row < 3; ++row) {
+        for (unsigned col = 0; col < 4; ++col) {
+            const unsigned logical = row * 4 + col;
+            if (RowLayout::offset(row, col) != rowExpected[logical] ||
+                ColumnLayout::offset(row, col) != columnExpected[logical]) {
+                std::printf("layout mismatch row=%u col=%u rowOff=%u colOff=%u\n",
+                            row, col, RowLayout::offset(row, col),
+                            ColumnLayout::offset(row, col));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+template <typename Layout>
+bool runCpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    std::array<float, WIDTH * HEIGHT> input{};
+    std::array<float, WIDTH * HEIGHT> output{};
+    output.fill(-99.f);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input[row * WIDTH + col] = static_cast<float>(row * 10 + col);
+        }
+    }
+
+    const RawPtr<ND::_2D, float> inputPtr{
+        input.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const RawPtr<ND::_2D, float> outputPtr{
+        output.data(), PtrDims<ND::_2D>(WIDTH, HEIGHT, WIDTH * sizeof(float))};
+    const auto read = PerThreadRead<ND::_2D, float>::build(inputPtr)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(outputPtr));
+
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    std::array<float, Layout::size()> local{};
+    Tile<float, Layout> tile{local.data()};
+    CopyTileDPP<ParArch::CPU, D>::load(details, read, tile);
+
+    for (unsigned row = 0; row < Layout::rows; ++row) {
+        for (unsigned col = 0; col < Layout::cols; ++col) {
+            const int globalX = details.originX + static_cast<int>(col);
+            const int globalY = details.originY + static_cast<int>(row);
+            const bool valid = globalX < WIDTH && globalY < HEIGHT;
+            const float expected = valid
+                ? input[globalY * WIDTH + globalX] * 2.f + 1.f
+                : -7.f;
+            if (std::fabs(tile.at(row, col) - expected) > 1e-6f) {
+                std::printf("%s CPU load row=%u col=%u got=%f expected=%f\n",
+                            name, row, col, tile.at(row, col), expected);
+                return false;
+            }
+        }
+    }
+
+    CopyTileDPP<ParArch::CPU, D>::store(details, tile, write);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float expected = inside
+                ? (input[row * WIDTH + col] * 2.f + 1.f) * 3.f
+                : -99.f;
+            if (std::fabs(output[row * WIDTH + col] - expected) > 1e-6f) {
+                std::printf("%s CPU store row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, output[row * WIDTH + col], expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+#if defined(__NVCC__)
+template <typename Layout, typename D, typename ReadIOp, typename WriteIOp>
+__global__ void copyTileRoundTripKernel(
+        const __grid_constant__ D details,
+        const __grid_constant__ ReadIOp input,
+        const __grid_constant__ WriteIOp output) {
+    __shared__ float storage[Layout::size()];
+    Tile<float, Layout> tile{storage};
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::load(details, input, tile);
+    CopyTileDPP<ParArch::GPU_NVIDIA, D>::store(details, tile, output);
+}
+
+template <typename Layout>
+bool runGpuRoundTrip(const char* name) {
+    constexpr int WIDTH = 7;
+    constexpr int HEIGHT = 5;
+    Ptr2D<float> input(WIDTH, HEIGHT);
+    Ptr2D<float> output(WIDTH, HEIGHT);
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            input.at(Point{col, row, 0}) = static_cast<float>(row * 10 + col);
+            output.at(Point{col, row, 0}) = -99.f;
+        }
+    }
+
+    Stream stream;
+    input.upload(stream);
+    output.upload(stream);
+    const auto read = PerThreadRead<ND::_2D, float>::build(input)
+        .then(Mul<float>::build(2.f))
+        .then(Add<float>::build(1.f));
+    const auto write = Mul<float>::build(3.f)
+        .then(PerThreadWrite<ND::_2D, float>::build(output));
+    using D = CopyTileDPPDetails<float, Layout, 64>;
+    const D details{5, 3, WIDTH, HEIGHT, -7.f};
+    copyTileRoundTripKernel<Layout><<<1, D::BLOCK_THREADS, 0,
+                                      stream.getCUDAStream()>>>(
+        details, read, write);
+    gpuErrchk(cudaGetLastError());
+    output.download(stream);
+    stream.sync();
+
+    for (int row = 0; row < HEIGHT; ++row) {
+        for (int col = 0; col < WIDTH; ++col) {
+            const bool inside = row >= details.originY && col >= details.originX;
+            const float inputValue = static_cast<float>(row * 10 + col);
+            const float expected = inside
+                ? (inputValue * 2.f + 1.f) * 3.f
+                : -99.f;
+            const float got = output.at(Point{col, row, 0});
+            if (std::fabs(got - expected) > 1e-6f) {
+                std::printf("%s GPU row=%d col=%d got=%f expected=%f\n",
+                            name, row, col, got, expected);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+int launch() {
+    bool ok = testLayoutMappings();
+    ok = runCpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runCpuRoundTrip<ColumnLayout>("column-major") && ok;
+#if defined(__NVCC__)
+    ok = runGpuRoundTrip<RowLayout>("row-major") && ok;
+    ok = runGpuRoundTrip<ColumnLayout>("column-major") && ok;
+#endif
+    if (ok) std::printf("Tile layouts + CopyTileDPP IOp contract: PASS\n");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_cta_raster.h
+++ b/tests/collective/test_cta_raster.h
@@ -1,0 +1,166 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/cta_raster.h>
+#include <fused_kernel/fused_kernel.h>
+
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+struct MappingDetails {
+    int mTiles;
+    int nTiles;
+};
+
+template <ParArch PA>
+struct MappingDPP;
+
+template <>
+struct MappingDPP<ParArch::CPU> {
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const MappingDetails&) {
+        return {};
+    }
+
+    template <typename Scheduler, typename Output>
+    FK_HOST_STATIC void exec(const MappingDetails& details,
+                             const Scheduler& scheduler,
+                             const Output& output) {
+        const int total = details.mTiles * details.nTiles;
+        for (int cta = 0; cta < total; ++cta) {
+            const CtaTileAssignment tile =
+                make_tuple(cta, details.mTiles, details.nTiles) | scheduler;
+            Output::Operation::exec(
+                Point{cta, 0, 0}, int2{tile.mTile, tile.nTile},
+                output.params);
+        }
+    }
+};
+
+#if defined(__NVCC__)
+template <>
+struct MappingDPP<ParArch::GPU_NVIDIA> {
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const MappingDetails& details) {
+        const unsigned int total = static_cast<unsigned int>(
+            details.mTiles * details.nTiles);
+        return {(total + 31) / 32, 1, 1, 32, 1, 1, 0};
+    }
+
+    template <typename Scheduler, typename Output>
+    FK_DEVICE_STATIC void exec(const MappingDetails& details,
+                               const Scheduler& scheduler,
+                               const Output& output) {
+        const int cta = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+        if (cta >= details.mTiles * details.nTiles) return;
+        const CtaTileAssignment tile =
+            make_tuple(cta, details.mTiles, details.nTiles) | scheduler;
+        Output::Operation::exec(
+            Point{cta, 0, 0}, int2{tile.mTile, tile.nTile},
+            output.params);
+    }
+};
+#endif
+
+template <typename RasterOperation>
+bool mappingIsBijective(const int mTiles, const int nTiles) {
+    const auto scheduler = RasterOperation::build();
+    const int total = mTiles * nTiles;
+    std::vector<int> seen(static_cast<std::size_t>(total), -1);
+    for (int cta = 0; cta < total; ++cta) {
+        const CtaTileAssignment tile =
+            make_tuple(cta, mTiles, nTiles) | scheduler;
+        if (!tile.valid || tile.mTile < 0 || tile.mTile >= mTiles ||
+            tile.nTile < 0 || tile.nTile >= nTiles)
+            return false;
+        const int index = tile.mTile * nTiles + tile.nTile;
+        if (seen[static_cast<std::size_t>(index)] != -1) return false;
+        seen[static_cast<std::size_t>(index)] = cta;
+    }
+    for (const int owner : seen)
+        if (owner < 0) return false;
+    return true;
+}
+
+template <typename RasterOperation>
+bool mappingBackendsAgree(const int mTiles, const int nTiles) {
+    const int total = mTiles * nTiles;
+    Ptr1D<int2> cpu(static_cast<uint>(total), 0, MemType::Host);
+    Stream_<ParArch::CPU> cpuStream;
+    executeOperations<MappingDPP<ParArch::CPU>>(
+        cpuStream, MappingDetails{mTiles, nTiles}, RasterOperation::build(),
+        PerThreadWrite<ND::_1D, int2>::build(cpu));
+
+    const auto scheduler = RasterOperation::build();
+    for (int cta = 0; cta < total; ++cta) {
+        const CtaTileAssignment expected =
+            make_tuple(cta, mTiles, nTiles) | scheduler;
+        const int2 actual = cpu.at(Point{cta, 0, 0});
+        if (actual.x != expected.mTile || actual.y != expected.nTile)
+            return false;
+    }
+
+#if defined(__NVCC__)
+    Ptr1D<int2> gpu(static_cast<uint>(total));
+    Stream gpuStream;
+    executeOperations<MappingDPP<ParArch::GPU_NVIDIA>>(
+        gpuStream, MappingDetails{mTiles, nTiles}, RasterOperation::build(),
+        PerThreadWrite<ND::_1D, int2>::build(gpu));
+    gpu.download(gpuStream);
+    gpuStream.sync();
+    for (int cta = 0; cta < total; ++cta) {
+        const int2 expected = cpu.at(Point{cta, 0, 0});
+        const int2 actual = gpu.at(Point{cta, 0, 0});
+        if (actual.x != expected.x || actual.y != expected.y) return false;
+    }
+#endif
+    return true;
+}
+
+template <typename RasterOperation>
+bool mappingSuite() {
+    bool ok = true;
+    ok = mappingIsBijective<RasterOperation>(1, 1) && ok;
+    ok = mappingIsBijective<RasterOperation>(1, 9) && ok;
+    ok = mappingIsBijective<RasterOperation>(9, 1) && ok;
+    ok = mappingIsBijective<RasterOperation>(13, 7) && ok;
+    ok = mappingIsBijective<RasterOperation>(7, 13) && ok;
+    ok = mappingIsBijective<RasterOperation>(16, 16) && ok;
+    ok = mappingBackendsAgree<RasterOperation>(13, 7) && ok;
+    return ok;
+}
+
+} // namespace
+
+int launch() {
+    bool ok = true;
+    ok = mappingSuite<CtaTileScheduler<RowMajorCtaTileRaster>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<ColumnMajorCtaTileRaster>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<1>>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<2>>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<3>>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<4>>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<8>>>() && ok;
+    ok = mappingSuite<CtaTileScheduler<GroupedCtaTileRaster<16>>>() && ok;
+    std::printf("CTA raster Operation coverage + CPU/GPU parity: %s\n",
+                ok ? "PASS" : "FAIL");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_execute_gemm.h
+++ b/tests/collective/test_execute_gemm.h
@@ -114,10 +114,16 @@ bool checkGenericGpuExecutor() {
 
 enum class OutputCase { BARE, AFFINE, RELU };
 
-using GemmConfig = GemmDPPDetails<
+using DefaultCtaScheduler =
+    CtaTileScheduler<RowMajorCtaTileRaster>;
+
+template <typename SchedulerOperation = DefaultCtaScheduler>
+using ScheduledGemmConfig = GemmDPPDetails<
     3, MmaDPPDetails<MmaBf16_16x8x16>,
     RowMajorLayout<16, 16>, RowMajorLayout<8, 16>, float,
-    WarpTileScheduler<RowMajorWarpTileRaster>, MmaWarpDPP, AsyncCopyDPP>;
+    SchedulerOperation, MmaWarpDPP, AsyncCopyDPP>;
+
+using GemmConfig = ScheduledGemmConfig<>;
 
 float sourceA(const int row, const int k) {
     return ((row * 11 + k * 7) % 23 - 11) * 0.0625f;
@@ -179,9 +185,21 @@ bool checkOutput(const Ptr2D<float2>& output, const int M, const int N,
     return maxError <= tolerance;
 }
 
+void captureOutput(const Ptr2D<float2>& output, const int M, const int N,
+                   std::vector<float>& captured) {
+    captured.resize(static_cast<std::size_t>(M * N));
+    for (int row = 0; row < M; ++row) {
+        for (int col = 0; col < N; ++col) {
+            const float2 packed = output.at(Point{col / 2, row, 0});
+            captured[static_cast<std::size_t>(row * N + col)] =
+                col & 1 ? packed.y : packed.x;
+        }
+    }
+}
+
 template <OutputCase CASE, typename DPP, typename StreamType,
-          typename Inputs, typename Write>
-void dispatchGemm(StreamType& stream, const GemmConfig& details,
+          typename Details, typename Inputs, typename Write>
+void dispatchGemm(StreamType& stream, const Details& details,
                   const Inputs& inputs, const Write& write) {
     if constexpr (CASE == OutputCase::BARE) {
         executeOperations<DPP>(stream, details, inputs, write);
@@ -195,8 +213,9 @@ void dispatchGemm(StreamType& stream, const GemmConfig& details,
     }
 }
 
-template <OutputCase CASE>
-bool runCpu(const int M, const int N, const int K) {
+template <OutputCase CASE, typename SchedulerOperation = DefaultCtaScheduler>
+bool runCpu(const int M, const int N, const int K,
+            std::vector<float>* captured = nullptr) {
     Ptr2D<float> a(static_cast<uint>(K), static_cast<uint>(M),
                    0, MemType::Host);
     Ptr2D<float> b(static_cast<uint>(K), static_cast<uint>(N),
@@ -220,14 +239,18 @@ bool runCpu(const int M, const int N, const int K) {
             .then(Add<float>::build(-0.125f)));
     const auto write = PerThreadWrite<ND::_2D, float2>::build(output);
     Stream_<ParArch::CPU> stream;
-    using DPP = GemmDPP<ParArch::CPU, GemmConfig>;
-    dispatchGemm<CASE, DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+    using Config = ScheduledGemmConfig<SchedulerOperation>;
+    using DPP = GemmDPP<ParArch::CPU, Config>;
+    dispatchGemm<CASE, DPP>(stream, Config{M, N, K}, inputs, write);
+    if (captured != nullptr) captureOutput(output, M, N, *captured);
     return checkOutput<CASE, false>(output, M, N, K);
 }
 
 #if defined(__NVCC__)
-template <OutputCase CASE, bool FUSED_INPUTS = true>
-bool runGpu(const int M, const int N, const int K) {
+template <OutputCase CASE, bool FUSED_INPUTS = true,
+          typename SchedulerOperation = DefaultCtaScheduler>
+bool runGpu(const int M, const int N, const int K,
+            std::vector<float>* captured = nullptr) {
     Ptr2D<float> a(K, M), b(K, N);
     Ptr2D<float2> output((N + 1) / 2, M);
     for (int row = 0; row < M; ++row)
@@ -245,24 +268,26 @@ bool runGpu(const int M, const int N, const int K) {
     b.upload(stream);
     output.upload(stream);
     const auto write = PerThreadWrite<ND::_2D, float2>::build(output);
-    using DPP = GemmDPP<ParArch::GPU_NVIDIA, GemmConfig>;
+    using Config = ScheduledGemmConfig<SchedulerOperation>;
+    using DPP = GemmDPP<ParArch::GPU_NVIDIA, Config>;
     if constexpr (FUSED_INPUTS) {
         const auto inputs = make_tuple(
             PerThreadRead<ND::_2D, float>::build(a)
                 .then(Mul<float>::build(1.25f)),
             PerThreadRead<ND::_2D, float>::build(b)
                 .then(Add<float>::build(-0.125f)));
-        dispatchGemm<CASE, DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+        dispatchGemm<CASE, DPP>(stream, Config{M, N, K}, inputs, write);
     } else {
         static_assert(CASE == OutputCase::BARE,
                       "raw aligned regression uses the bare epilogue");
         const auto inputs = make_tuple(
             PerThreadRead<ND::_2D, float>::build(a),
             PerThreadRead<ND::_2D, float>::build(b));
-        executeOperations<DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+        executeOperations<DPP>(stream, Config{M, N, K}, inputs, write);
     }
     output.download(stream);
     stream.sync();
+    if (captured != nullptr) captureOutput(output, M, N, *captured);
     return checkOutput<CASE, true, FUSED_INPUTS>(output, M, N, K);
 }
 #endif
@@ -283,6 +308,54 @@ bool runCases() {
     return ok;
 }
 
+template <typename SchedulerOperation>
+bool runRasterCpuParityCase(const std::vector<float>& reference) {
+    std::vector<float> actual;
+    const bool valid = runCpu<OutputCase::BARE, SchedulerOperation>(
+        33, 19, 16, &actual);
+    return valid && actual == reference;
+}
+
+#if defined(__NVCC__)
+template <typename SchedulerOperation>
+bool runRasterGpuParityCase(const std::vector<float>& reference) {
+    std::vector<float> actual;
+    const bool valid = runGpu<OutputCase::BARE, true, SchedulerOperation>(
+        33, 19, 16, &actual);
+    return valid && actual == reference;
+}
+#endif
+
+bool runRasterGemmCases() {
+    using RowScheduler = CtaTileScheduler<RowMajorCtaTileRaster>;
+    using ColumnScheduler = CtaTileScheduler<ColumnMajorCtaTileRaster>;
+    using Group1Scheduler = CtaTileScheduler<GroupedCtaTileRaster<1>>;
+    using Group2Scheduler = CtaTileScheduler<GroupedCtaTileRaster<2>>;
+    using Group4Scheduler = CtaTileScheduler<GroupedCtaTileRaster<4>>;
+    using Group16Scheduler = CtaTileScheduler<GroupedCtaTileRaster<16>>;
+
+    std::vector<float> cpuReference;
+    bool ok = runCpu<OutputCase::BARE, RowScheduler>(
+        33, 19, 16, &cpuReference);
+    ok = runRasterCpuParityCase<ColumnScheduler>(cpuReference) && ok;
+    ok = runRasterCpuParityCase<Group1Scheduler>(cpuReference) && ok;
+    ok = runRasterCpuParityCase<Group2Scheduler>(cpuReference) && ok;
+    ok = runRasterCpuParityCase<Group4Scheduler>(cpuReference) && ok;
+    ok = runRasterCpuParityCase<Group16Scheduler>(cpuReference) && ok;
+
+#if defined(__NVCC__)
+    std::vector<float> gpuReference;
+    ok = runGpu<OutputCase::BARE, true, RowScheduler>(
+        33, 19, 16, &gpuReference) && ok;
+    ok = runRasterGpuParityCase<ColumnScheduler>(gpuReference) && ok;
+    ok = runRasterGpuParityCase<Group1Scheduler>(gpuReference) && ok;
+    ok = runRasterGpuParityCase<Group2Scheduler>(gpuReference) && ok;
+    ok = runRasterGpuParityCase<Group4Scheduler>(gpuReference) && ok;
+    ok = runRasterGpuParityCase<Group16Scheduler>(gpuReference) && ok;
+#endif
+    return ok;
+}
+
 } // namespace
 
 int launch() {
@@ -298,11 +371,12 @@ int launch() {
     const bool bare = runCases<OutputCase::BARE>();
     const bool affine = runCases<OutputCase::AFFINE>();
     const bool relu = runCases<OutputCase::RELU>();
+    const bool rasters = runRasterGemmCases();
     std::printf("mock_cpu=%d mock_gpu=%d raw_aligned=%d "
-                "bare=%d affine=%d relu=%d\n",
-                mock, mockGpu, rawAligned, bare, affine, relu);
+                "bare=%d affine=%d relu=%d rasters=%d\n",
+                mock, mockGpu, rawAligned, bare, affine, relu, rasters);
     const bool ok = mock && mockGpu && rawAligned &&
-                    bare && affine && relu;
+                    bare && affine && relu && rasters;
     std::printf("Generic DPP executor + GemmDPP contracts: %s\n",
                 ok ? "PASS" : "FAIL");
     return ok ? 0 : -1;

--- a/tests/collective/test_execute_gemm.h
+++ b/tests/collective/test_execute_gemm.h
@@ -1,0 +1,309 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/fused_kernel.h>
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/logical.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/collective/epilogue.h>
+#include <fused_kernel/algorithms/collective/gemm.h>
+#include <fused_kernel/algorithms/image_processing/crop.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+#include <fused_kernel/core/execution_model/stream.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <type_traits>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+struct MockDetails {
+    int* calls;
+};
+
+struct MockDPP {
+    static constexpr ParArch PAR_ARCH = ParArch::CPU;
+
+    template <typename... IOps>
+    FK_HOST_STATIC void exec(const MockDetails details, const IOps&... iOps) {
+        static_assert(sizeof...(IOps) == 3,
+                      "details must stay out of BackFuser; Read+Crop must fuse");
+        ++*details.calls;
+        const auto args = forward_as_tuple(iOps...);
+        const auto& read = get<0>(args);
+        const auto& scale = get<1>(args);
+        const auto& output = get<2>(args);
+        using Output = std::decay_t<decltype(output)>;
+        const float value = (Point{0, 0, 0} | read).input;
+        const float scaled = value | scale;
+        Output::Operation::exec(Point{0, 0, 0}, scaled, output.params);
+    }
+};
+
+bool checkGenericCpuExecutor() {
+    Ptr2D<float> input(1, 1, 0, MemType::Host);
+    Ptr2D<float> output(1, 1, 0, MemType::Host);
+    input.at(Point{0, 0, 0}) = 2.f;
+    output.at(Point{0, 0, 0}) = -1.f;
+    int calls = 0;
+    Stream_<ParArch::CPU> stream;
+    executeOperations<MockDPP>(
+        stream, MockDetails{&calls},
+        PerThreadRead<ND::_2D, float>::build(input),
+        Crop<>::build(Rect{0, 0, 1, 1}),
+        Mul<float>::build(3.f),
+        PerThreadWrite<ND::_2D, float>::build(output));
+    return calls == 1 && std::abs(output.at(Point{0, 0, 0}) - 6.f) < 1e-6f;
+}
+
+#if defined(__NVCC__)
+struct MockGpuDetails {
+    int* calls;
+};
+
+struct MockGpuDPP {
+    static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+
+    FK_HOST_FUSE DPPLaunchConfig launchConfig(const MockGpuDetails&) {
+        return {1, 1, 1, 1, 1, 1, 0};
+    }
+
+    template <typename... IOps>
+    FK_DEVICE_STATIC void exec(const MockGpuDetails details,
+                               const IOps&...) {
+        static_assert(sizeof...(IOps) == 1,
+                      "the dummy IOp must cross BackFuser exactly once");
+        atomicAdd(details.calls, 1);
+    }
+};
+
+bool checkGenericGpuExecutor() {
+    int* deviceCalls = nullptr;
+    gpuErrchk(cudaMalloc(reinterpret_cast<void**>(&deviceCalls), sizeof(int)));
+    gpuErrchk(cudaMemset(deviceCalls, 0, sizeof(int)));
+    Ptr1D<int> dummy(1, 0, MemType::Device);
+    Stream stream;
+    executeOperations<MockGpuDPP>(
+        stream, MockGpuDetails{deviceCalls},
+        PerThreadWrite<ND::_1D, int>::build(dummy));
+    gpuErrchk(cudaStreamSynchronize(stream.getCUDAStream()));
+    int calls = 0;
+    gpuErrchk(cudaMemcpy(&calls, deviceCalls, sizeof(int),
+                        cudaMemcpyDeviceToHost));
+    gpuErrchk(cudaFree(deviceCalls));
+    return calls == 1;
+}
+#endif
+
+enum class OutputCase { BARE, AFFINE, RELU };
+
+using GemmConfig = GemmDPPDetails<
+    3, MmaDPPDetails<MmaBf16_16x8x16>,
+    RowMajorLayout<16, 16>, RowMajorLayout<8, 16>, float,
+    WarpTileScheduler<RowMajorWarpTileRaster>, MmaWarpDPP, AsyncCopyDPP>;
+
+float sourceA(const int row, const int k) {
+    return ((row * 11 + k * 7) % 23 - 11) * 0.0625f;
+}
+
+float sourceB(const int col, const int k) {
+    return ((col * 13 + k * 5) % 19 - 9) * 0.0546875f;
+}
+
+template <OutputCase CASE>
+double transformOutput(double value) {
+    if constexpr (CASE == OutputCase::AFFINE) return value * 1.5 - 0.25;
+    if constexpr (CASE == OutputCase::RELU) return std::max(value, 0.0);
+    return value;
+}
+
+template <OutputCase CASE, bool GPU, bool FUSED_INPUTS = true>
+bool checkOutput(const Ptr2D<float2>& output, const int M, const int N,
+                 const int K) {
+    double maxError = 0.0;
+    int maxRow = -1, maxCol = -1;
+    double maxActual = 0.0, maxExpected = 0.0;
+    for (int row = 0; row < M; ++row) {
+        for (int col = 0; col < N; ++col) {
+            double expected = 0.0;
+            for (int k = 0; k < K; ++k) {
+                float a = sourceA(row, k);
+                float b = sourceB(col, k);
+                if constexpr (FUSED_INPUTS) {
+                    a *= 1.25f;
+                    b -= 0.125f;
+                }
+#if defined(__NVCC__)
+                if constexpr (GPU) {
+                    a = __bfloat162float(__float2bfloat16(a));
+                    b = __bfloat162float(__float2bfloat16(b));
+                }
+#endif
+                expected += static_cast<double>(a) * static_cast<double>(b);
+            }
+            expected = transformOutput<CASE>(expected);
+            const float2 packed = output.at(Point{col / 2, row, 0});
+            const double actual = col & 1 ? packed.y : packed.x;
+            const double error = std::abs(actual - expected);
+            if (error > maxError) {
+                maxError = error;
+                maxRow = row;
+                maxCol = col;
+                maxActual = actual;
+                maxExpected = expected;
+            }
+        }
+    }
+    const double tolerance = GPU ? 0.08 * ((K + 15) / 16.0) + 1e-3 : 1e-4;
+    if (maxError > tolerance)
+        std::printf("verify_fail case=%d M=%d N=%d K=%d row=%d col=%d actual=%g expected=%g max_error=%g tolerance=%g\n",
+                    static_cast<int>(CASE), M, N, K, maxRow, maxCol,
+                    maxActual, maxExpected, maxError, tolerance);
+    return maxError <= tolerance;
+}
+
+template <OutputCase CASE, typename DPP, typename StreamType,
+          typename Inputs, typename Write>
+void dispatchGemm(StreamType& stream, const GemmConfig& details,
+                  const Inputs& inputs, const Write& write) {
+    if constexpr (CASE == OutputCase::BARE) {
+        executeOperations<DPP>(stream, details, inputs, write);
+    } else if constexpr (CASE == OutputCase::AFFINE) {
+        const auto output = scaleBiasEpilogue<float2>(
+            float2{1.5f, 1.5f}, float2{-0.25f, -0.25f}, write);
+        executeOperations<DPP>(stream, details, inputs, output);
+    } else {
+        const auto output = reluEpilogue<float2>(write);
+        executeOperations<DPP>(stream, details, inputs, output);
+    }
+}
+
+template <OutputCase CASE>
+bool runCpu(const int M, const int N, const int K) {
+    Ptr2D<float> a(static_cast<uint>(K), static_cast<uint>(M),
+                   0, MemType::Host);
+    Ptr2D<float> b(static_cast<uint>(K), static_cast<uint>(N),
+                   0, MemType::Host);
+    Ptr2D<float2> output(static_cast<uint>((N + 1) / 2),
+                         static_cast<uint>(M), 0, MemType::Host);
+    for (int row = 0; row < M; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = sourceA(row, k);
+    for (int col = 0; col < N; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = sourceB(col, k);
+    for (int row = 0; row < M; ++row)
+        for (int pair = 0; pair < (N + 1) / 2; ++pair)
+            output.at(Point{pair, row, 0}) = float2{-999.f, -999.f};
+
+    const auto inputs = make_tuple(
+        PerThreadRead<ND::_2D, float>::build(a)
+            .then(Mul<float>::build(1.25f)),
+        PerThreadRead<ND::_2D, float>::build(b)
+            .then(Add<float>::build(-0.125f)));
+    const auto write = PerThreadWrite<ND::_2D, float2>::build(output);
+    Stream_<ParArch::CPU> stream;
+    using DPP = GemmDPP<ParArch::CPU, GemmConfig>;
+    dispatchGemm<CASE, DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+    return checkOutput<CASE, false>(output, M, N, K);
+}
+
+#if defined(__NVCC__)
+template <OutputCase CASE, bool FUSED_INPUTS = true>
+bool runGpu(const int M, const int N, const int K) {
+    Ptr2D<float> a(K, M), b(K, N);
+    Ptr2D<float2> output((N + 1) / 2, M);
+    for (int row = 0; row < M; ++row)
+        for (int k = 0; k < K; ++k)
+            a.at(Point{k, row, 0}) = sourceA(row, k);
+    for (int col = 0; col < N; ++col)
+        for (int k = 0; k < K; ++k)
+            b.at(Point{k, col, 0}) = sourceB(col, k);
+    for (int row = 0; row < M; ++row)
+        for (int pair = 0; pair < (N + 1) / 2; ++pair)
+            output.at(Point{pair, row, 0}) = float2{-999.f, -999.f};
+
+    Stream stream;
+    a.upload(stream);
+    b.upload(stream);
+    output.upload(stream);
+    const auto write = PerThreadWrite<ND::_2D, float2>::build(output);
+    using DPP = GemmDPP<ParArch::GPU_NVIDIA, GemmConfig>;
+    if constexpr (FUSED_INPUTS) {
+        const auto inputs = make_tuple(
+            PerThreadRead<ND::_2D, float>::build(a)
+                .then(Mul<float>::build(1.25f)),
+            PerThreadRead<ND::_2D, float>::build(b)
+                .then(Add<float>::build(-0.125f)));
+        dispatchGemm<CASE, DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+    } else {
+        static_assert(CASE == OutputCase::BARE,
+                      "raw aligned regression uses the bare epilogue");
+        const auto inputs = make_tuple(
+            PerThreadRead<ND::_2D, float>::build(a),
+            PerThreadRead<ND::_2D, float>::build(b));
+        executeOperations<DPP>(stream, GemmConfig{M, N, K}, inputs, write);
+    }
+    output.download(stream);
+    stream.sync();
+    return checkOutput<CASE, true, FUSED_INPUTS>(output, M, N, K);
+}
+#endif
+
+template <OutputCase CASE>
+bool runCases() {
+    bool ok = true;
+    ok = runCpu<CASE>(16, 8, 32) && ok;
+    ok = runCpu<CASE>(13, 7, 17) && ok;
+    ok = runCpu<CASE>(17, 9, 31) && ok;
+    ok = runCpu<CASE>(33, 19, 16) && ok;
+#if defined(__NVCC__)
+    ok = runGpu<CASE>(16, 8, 32) && ok;
+    ok = runGpu<CASE>(13, 7, 17) && ok;
+    ok = runGpu<CASE>(17, 9, 31) && ok;
+    ok = runGpu<CASE>(33, 19, 16) && ok;
+#endif
+    return ok;
+}
+
+} // namespace
+
+int launch() {
+    const bool mock = checkGenericCpuExecutor();
+#if defined(__NVCC__)
+    const bool mockGpu = checkGenericGpuExecutor();
+    const bool rawAligned =
+        runGpu<OutputCase::BARE, false>(16, 8, 32);
+#else
+    const bool mockGpu = true;
+    const bool rawAligned = true;
+#endif
+    const bool bare = runCases<OutputCase::BARE>();
+    const bool affine = runCases<OutputCase::AFFINE>();
+    const bool relu = runCases<OutputCase::RELU>();
+    std::printf("mock_cpu=%d mock_gpu=%d raw_aligned=%d "
+                "bare=%d affine=%d relu=%d\n",
+                mock, mockGpu, rawAligned, bare, affine, relu);
+    const bool ok = mock && mockGpu && rawAligned &&
+                    bare && affine && relu;
+    std::printf("Generic DPP executor + GemmDPP contracts: %s\n",
+                ok ? "PASS" : "FAIL");
+    return ok ? 0 : -1;
+}

--- a/tests/collective/test_tile_scheduler.h
+++ b/tests/collective/test_tile_scheduler.h
@@ -1,0 +1,144 @@
+/* Copyright 2026 Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/collective/tile_scheduler.h>
+
+#include <cstdio>
+#include <vector>
+
+using namespace fk;
+
+namespace {
+
+template <typename Scheduler>
+bool checkHost(const int mTiles, const int nTiles,
+               const bool columnMajor, const char* label) {
+    const Scheduler scheduler = Scheduler::Operation::build();
+    const int total = mTiles * nTiles;
+    std::vector<int> seen(total, 0);
+    bool ok = true;
+    for (int warpId = 0; warpId < total + 3; ++warpId) {
+        const WarpTileAssignment tile =
+            make_tuple(warpId, mTiles, nTiles) | scheduler;
+        if (warpId >= total) {
+            if (tile.valid) ok = false;
+            continue;
+        }
+        if (!tile.valid || tile.mTile < 0 || tile.mTile >= mTiles ||
+            tile.nTile < 0 || tile.nTile >= nTiles) {
+            ok = false;
+            continue;
+        }
+        const int expectedM = columnMajor
+            ? warpId % mTiles : warpId / nTiles;
+        const int expectedN = columnMajor
+            ? warpId / mTiles : warpId % nTiles;
+        if (tile.mTile != expectedM || tile.nTile != expectedN)
+            ok = false;
+        ++seen[tile.mTile * nTiles + tile.nTile];
+    }
+    for (const int count : seen)
+        if (count != 1) ok = false;
+    if (!ok)
+        std::printf("host mapping failed: %s %dx%d\n",
+                    label, mTiles, nTiles);
+    return ok;
+}
+
+#if defined(__NVCC__)
+template <typename Scheduler>
+__global__ void invokeScheduler(WarpTileAssignment* output,
+                                const int mTiles, const int nTiles,
+                                const Scheduler scheduler) {
+    const int warpId = threadIdx.x;
+    output[warpId] = make_tuple(warpId, mTiles, nTiles) | scheduler;
+}
+
+template <typename Scheduler>
+bool checkDevice(const int mTiles, const int nTiles,
+                 const bool columnMajor, const char* label) {
+    const int total = mTiles * nTiles;
+    const int launched = total + 3;
+    WarpTileAssignment* device = nullptr;
+    cudaMalloc(&device, launched * sizeof(WarpTileAssignment));
+    const Scheduler scheduler = Scheduler::Operation::build();
+    invokeScheduler<Scheduler><<<1, launched>>>(
+        device, mTiles, nTiles, scheduler);
+    std::vector<WarpTileAssignment> output(launched);
+    cudaMemcpy(output.data(), device,
+               launched * sizeof(WarpTileAssignment),
+               cudaMemcpyDeviceToHost);
+    const cudaError_t error = cudaDeviceSynchronize();
+    cudaFree(device);
+    if (error != cudaSuccess) return false;
+
+    std::vector<int> seen(total, 0);
+    bool ok = true;
+    for (int warpId = 0; warpId < launched; ++warpId) {
+        const auto tile = output[warpId];
+        if (warpId >= total) {
+            if (tile.valid) ok = false;
+            continue;
+        }
+        const int expectedM = columnMajor
+            ? warpId % mTiles : warpId / nTiles;
+        const int expectedN = columnMajor
+            ? warpId / mTiles : warpId % nTiles;
+        if (!tile.valid || tile.mTile != expectedM ||
+            tile.nTile != expectedN) ok = false;
+        if (tile.valid && tile.mTile >= 0 && tile.mTile < mTiles &&
+            tile.nTile >= 0 && tile.nTile < nTiles)
+            ++seen[tile.mTile * nTiles + tile.nTile];
+    }
+    for (const int count : seen)
+        if (count != 1) ok = false;
+    if (!ok)
+        std::printf("device mapping failed: %s %dx%d\n",
+                    label, mTiles, nTiles);
+    return ok;
+}
+#endif
+
+template <typename Scheduler>
+bool checkAll(const bool columnMajor, const char* label) {
+    bool ok = true;
+    const int grids[][2] = {{1, 1}, {1, 7}, {2, 3}, {3, 2}, {3, 5}, {5, 3}};
+    for (const auto& grid : grids) {
+        ok = checkHost<Scheduler>(
+            grid[0], grid[1], columnMajor, label) && ok;
+#if defined(__NVCC__)
+        ok = checkDevice<Scheduler>(
+            grid[0], grid[1], columnMajor, label) && ok;
+#endif
+    }
+    return ok;
+}
+
+} // namespace
+
+int launch() {
+    using RowScheduler = decltype(
+        WarpTileScheduler<RowMajorWarpTileRaster>::build());
+    using ColumnScheduler = decltype(
+        WarpTileScheduler<ColumnMajorWarpTileRaster>::build());
+    static_assert(RowScheduler::template is<UnaryType>);
+    static_assert(ColumnScheduler::template is<UnaryType>);
+
+    bool ok = checkAll<RowScheduler>(false, "row-major");
+    ok = checkAll<ColumnScheduler>(true, "column-major") && ok;
+    if (ok) std::printf("WarpTileScheduler contracts: PASS\n");
+    return ok ? 0 : -1;
+}


### PR DESCRIPTION
1|## Summary
2|
3|Rebuilds the one-query-tile attention integration on the repaired cooperative stack from PRs #284–#286.
4|
5|The implementation is a true `AttentionTileDPP` with explicit CPU and NVIDIA GPU specializations and is invoked exclusively through the generic `executeOperations<DPP>` path. The DPP owns its scheduler, layouts, launch configuration, and MMA/copy/reduce policies; each CTA derives its `(batch-head, query-tile)` assignment internally.
6|
7|## Architecture
8|
9|- Q/K/V enter as standard composable Read IOps.
10|- Q, K, and V staging uses `CopyTileDPP` and policy-owned layouts.
11|- QK uses the repaired `MmaWarpDPP<MmaBf16_16x8x16>` mapping.
12|- Row max and row sum use `ReduceWarpDPP`.
13|- Online softmax carries running max/sum across 16-key tiles and rescales the partial output when the maximum changes.
14|- Probabilities and V are consumed from policy-owned `Tile` layouts.
15|- The final normalized `float2` value crosses the DPP boundary through a standard composable Write IOp, so fused epilogues remain outside the DPP.
16|- Supports head dimensions 32 and 64, causal and non-causal attention, ragged Q/K lengths, multiple batch-heads, and multiple query tiles.
17|- Adds CUDA-scoped `__nv_bfloat16` / `__nv_bfloat162` `PerThreadRead` and `PerThreadWrite` support without register `memcpy` packing.
18|
19|The repaired warp reduction primitive and its standalone tests are included because the canonical parent stack did not contain the required dependency.
20|
21|## Verification
22|
23|### Full suites
24|
25|| Configuration | Executables | Failures |
26||---|---:|---:|
27|| GCC, CPU backend | 42 | 0 |
28|| Clang, CPU backend | 42 | 0 |
29|| CUDA 13.3, `sm_120` | 92 | 0 |
30|
31|### Attention coverage
32|
33|The test compares both CPU and GPU implementations against an independent FP64 attention oracle and directly compares CPU and GPU outputs.
34|
35|Coverage includes:
36|
37|- D=32 and D=64
38|- causal and non-causal attention
39|- ragged Q/K lengths
40|- multiple batch-heads
41|- multiple query tiles
42|- multiple key tiles
43|- fused transforms on every Q/K/V Read and on the final Write
44|- a deliberately late score maximum to exercise online-max rescaling
45|- output sentinels to detect missing CTA assignments or tail writes
46|
47|### Mutation tests
48|
49|The test suite rejects each of these deliberate regressions:
50|
51|- bypassing the fused Q/K/V Reads and final fused Write
52|- forcing every CTA to `(bh, qTile) = (0, 0)`
53|- omitting causal masking
54|- omitting online-max rescaling
55|
56|### Compute Sanitizer
57|
58|- Attention: `memcheck`, `racecheck`, and `synccheck` pass.
59|- bf16 memory operations: `memcheck` and `racecheck` pass.
60|
61|## Performance sanity check
62|
63|On an RTX PRO 6000 Blackwell (`sm_120`), CUDA events with 20 warmups and 100 measured iterations for BH=4, Q=128, K=128, D=64 produced:
64|
65|| Implementation | Mean time |
66||---|---:|
67|| Repaired cooperative Attention DPP | 0.152441 ms |
68|| Naive scalar CUDA baseline | 10.594936 ms |
69|
70|That is 69.502x over the explicitly scalar baseline, with max absolute difference `0.0099129` versus its FP32 output. This is a local integration sanity check, not a comparison against an optimized attention library.
71|