### PR TITLE
core: fix compute->write fused IOp + fkl-using-operations skill + regression test

### DIFF
--- a/include/fused_kernel/core/execution_model/operation_model/fused_operation.h
+++ b/include/fused_kernel/core/execution_model/operation_model/fused_operation.h
@@ -166,7 +166,7 @@ namespace fk {
         template <size_t... Idx>
         FK_HOST_DEVICE_FUSE void exec_helper(const std::index_sequence<Idx...>&, const Point thread,
                                              const ParamsType &params) {
-            LastType_t<typename ParamsType::Operations>::Operation::exec(thread,
+            LastType_t<IOps...>::Operation::exec(thread,
                 (thread | ... | get_opt<Idx>(params)).input,
                 get_opt<sizeof...(Idx) - 1>(params));
         }
@@ -197,7 +197,7 @@ namespace fk {
         template <size_t... Idx>
         FK_HOST_DEVICE_FUSE void exec_helper(const std::index_sequence<Idx...> &, const Point thread,
                                              const InputType input, const ParamsType &params) {
-            LastType_t<typename ParamsType::Operations>::Operation::exec(
+            LastType_t<IOps...>::Operation::exec(
                 thread, (InputFoldType<>::build(thread, input) | ... | get_opt<Idx>(params)).input,
                 get_opt<ParamsType::size - 1>(params));
         }

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,6 +9,7 @@ knowledge, and humans can read them as focused docs.
 | skill | use it when |
 |---|---|
 | [`fkl-using-the-library`](fkl-using-the-library/SKILL.md) | writing user code: pipelines, executeOperations, streams, data structures |
+| [`fkl-using-operations`](fkl-using-operations/SKILL.md) | invoking/composing IOps from the consumer side: per-type exec() call sites, fusing a compute chain with a write (`epilogue.then(D)`), invoking a fused write inside a DPP |
 | [`fkl-fusion-techniques`](fkl-fusion-techniques/SKILL.md) | choosing/combining Vertical, Backwards Vertical, Horizontal and Divergent Horizontal Fusion |
 | [`fkl-implementing-data-parallel-patterns`](fkl-implementing-data-parallel-patterns/SKILL.md) | adding a new DPP struct |
 | [`fkl-implementing-operations`](fkl-implementing-operations/SKILL.md) | adding a new Operation struct (Unary/Binary/Read/Write/ReadBack/IncompleteReadBack/Ternary/IncompleteTernary/MidWrite/Open/Closed) |

--- a/skills/fkl-using-operations/SKILL.md
+++ b/skills/fkl-using-operations/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: fkl-using-operations
+description: Invoke and compose FKL Operations and Instantiable Operations (IOps) from the CONSUMER side — how to call an op's exec() correctly for each operation type, how to fuse a compute chain with a write IOp (epilogue.then(D)), and how to invoke that fused write from inside a DPP. Use when writing a DPP or kernel that reads inputs, applies a compute chain, and writes a result through IOps, or when an IOp invocation / fused write fails to compile. Complements fkl-implementing-operations (which is about AUTHORING ops) with the call-site contract.
+---
+
+# Using FKL Operations and IOps (consumer side)
+
+`fkl-implementing-operations` covers how to AUTHOR an Operation struct. This
+skill covers the other half: given an Instantiable Operation (IOp), how do you
+**invoke** it correctly, and how do you **compose** a compute chain with a
+write so a DPP can emit its result through a single fused IOp.
+
+## The invocation contract is the IOp-form table
+
+Every IOp's `exec()` signature is fixed by its operation type. This is the
+SAME table as in `fkl-implementing-operations` — read it here as the call-site
+contract (what arguments YOU must pass), not as an authoring spec:
+
+| Operation Type | exec call site |
+|---|---|
+| ReadType     | `T   IOp::Operation::exec(thread, iop.params)` |
+| WriteType    | `void IOp::Operation::exec(thread, value, iop.params)` |
+| UnaryType    | `O   IOp::Operation::exec(input)` |
+| BinaryType   | `O   IOp::Operation::exec(input, iop.params)` |
+| ReadBackType | `O   IOp::Operation::exec(thread, iop.params, backIOp)` |
+| TernaryType  | `O   IOp::Operation::exec(input, iop.params, backIOp)` |
+| MidWriteType | `In  IOp::Operation::exec(thread, input, iop.params)` (writes AND forwards) |
+| OpenType     | `O   IOp::Operation::exec(thread, input, iop.params)` (FusedOperation) |
+| ClosedType   | `void IOp::Operation::exec(thread, iop.params)` (FusedOperation) |
+
+Key consumer rules:
+- You invoke through `IOp::Operation::exec(...)` — the IOp type's `::Operation`
+  static, passing `iop.params` for the data, NOT the raw op struct.
+- **Read** takes the `Point thread` + `params` and returns the value.
+- **Write** takes `thread`, the `value` to store, and `params`.
+- **Unary/Binary** are pure register compute: no `thread`, just the input
+  (+ `params` for Binary). These are the epilogue building blocks.
+
+## Composing a compute→write epilogue: `epilogue.then(D)`
+
+A DPP should not hardcode a destination write. The caller fuses the epilogue
+IOp chain with the destination write IOp and passes ONE fused IOp:
+
+```cpp
+// destination write (D is the output matrix/image, a real fk write IOp)
+const auto dWrite = PerThreadWrite<ND::_2D, float>::build(D);
+
+// epilogue as an IOp chain, fused with the write:
+const auto output = Cast<float,float>::build().then(dWrite);              // identity
+const auto output = Mul<float>::build(2.f).then(Add<float>::build(0.5f))  // scale+bias
+                                          .then(dWrite);
+```
+
+- The first link of the chain must be a **compute** IOp (Unary/Binary) — NOT a
+  Read (a Read in front makes it a full Read→…→Write pipeline, a different
+  fused form). For a pass-through epilogue use `Cast<T,T>`.
+- The result is a write-type fused IOp: `isAnyWriteType<decltype(output)>`
+  is `true`.
+
+## Invoking the fused write inside a DPP
+
+Pass the fused IOp to the DPP and invoke it with the WHOLE IOp (the epilogue
+is applied inside it, then the destination write):
+
+```cpp
+template <typename Inputs, typename Output>
+static __device__ void exec(const Details& d, const Inputs& inputs,
+                            const Output& output) {
+    const auto& A = get<0>(inputs);          // inputs is fk::Tuple<AIOp, BIOp>
+    const auto& B = get<1>(inputs);
+    ...
+    // result is the in-register accumulator; the epilogue + store happen in the
+    // fused write IOp. Pass the whole `output`, NOT output.params:
+    Output::Operation::exec(thread, result, output);
+}
+```
+
+- **Inputs as a tuple:** read operands arrive as `const fk::Tuple<AIOp,BIOp>&`
+  (built caller-side with `make_tuple(aIOp, bIOp)`), unpacked with
+  `get<0>/get<1>`. Use `std::decay_t<decltype(A)>::Operation` to name the op.
+- **Output as the fused write:** invoke `Output::Operation::exec(thread, value,
+  output)` — the whole fused IOp, NOT `.params`. This is what lets the epilogue
+  chain run in-register before the single global write.
+
+## Pitfalls
+
+- Passing `output.params` instead of `output` to a fused write's exec() routes
+  through the wrong fold path. Pass the whole IOp.
+- A `Read` as the first link of `.then(...)` produces a Read→Write CLOSED
+  fused op, not the compute→write epilogue you want — start the chain with a
+  compute op (`Cast<T,T>` for identity).
+- The operand tuple must be `fk::Tuple` (via `make_tuple`), not two separate
+  exec parameters — matches the DPP definition in
+  `fkl-implementing-data-parallel-patterns`.
+
+## See also
+
+- `fkl-implementing-operations` — authoring the op structs and the IOp-form table.
+- `fkl-implementing-data-parallel-patterns` — the DPP `exec(details, inputs,
+  output)` contract these invocations live inside.
+- `fkl-fusion-techniques` — how `executeOperations` wires read→compute→write.

--- a/skills/fkl-using-operations/SKILL.md
+++ b/skills/fkl-using-operations/SKILL.md
@@ -18,44 +18,23 @@ contract (what arguments YOU must pass), not as an authoring spec:
 
 | Operation Type | exec call site |
 |---|---|
-| ReadType     | `T   IOp::Operation::exec(thread, iop.params)` |
-| WriteType    | `void IOp::Operation::exec(thread, value, iop.params)` |
+| ReadType     | `T   IOp::Operation::exec(thread, iop)` |
+| WriteType    | `void IOp::Operation::exec(thread, value, iop)` |
 | UnaryType    | `O   IOp::Operation::exec(input)` |
-| BinaryType   | `O   IOp::Operation::exec(input, iop.params)` |
-| ReadBackType | `O   IOp::Operation::exec(thread, iop.params, backIOp)` |
-| TernaryType  | `O   IOp::Operation::exec(input, iop.params, backIOp)` |
-| MidWriteType | `In  IOp::Operation::exec(thread, input, iop.params)` (writes AND forwards) |
-| OpenType     | `O   IOp::Operation::exec(thread, input, iop.params)` (FusedOperation) |
-| ClosedType   | `void IOp::Operation::exec(thread, iop.params)` (FusedOperation) |
+| BinaryType   | `O   IOp::Operation::exec(input, iop)` |
+| ReadBackType | `O   IOp::Operation::exec(thread, iop)` |
+| TernaryType  | `O   IOp::Operation::exec(input, iop)` |
+| MidWriteType | `In  IOp::Operation::exec(thread, input, iop)` (writes AND forwards) |
+| OpenType     | `O   IOp::Operation::exec(thread, input, iop)` |
+| ClosedType   | `void IOp::Operation::exec(thread, iop)` |
 
 Key consumer rules:
-- You invoke through `IOp::Operation::exec(...)` — the IOp type's `::Operation`
-  static, passing `iop.params` for the data, NOT the raw op struct.
+- The DPP invokes through `IOp::Operation::exec(...)` — the IOp type's `::Operation`
+  static, passing `iop` for the data, NOT the raw op struct.
 - **Read** takes the `Point thread` + `params` and returns the value.
 - **Write** takes `thread`, the `value` to store, and `params`.
 - **Unary/Binary** are pure register compute: no `thread`, just the input
   (+ `params` for Binary). These are the epilogue building blocks.
-
-## Composing a compute→write epilogue: `epilogue.then(D)`
-
-A DPP should not hardcode a destination write. The caller fuses the epilogue
-IOp chain with the destination write IOp and passes ONE fused IOp:
-
-```cpp
-// destination write (D is the output matrix/image, a real fk write IOp)
-const auto dWrite = PerThreadWrite<ND::_2D, float>::build(D);
-
-// epilogue as an IOp chain, fused with the write:
-const auto output = Cast<float,float>::build().then(dWrite);              // identity
-const auto output = Mul<float>::build(2.f).then(Add<float>::build(0.5f))  // scale+bias
-                                          .then(dWrite);
-```
-
-- The first link of the chain must be a **compute** IOp (Unary/Binary) — NOT a
-  Read (a Read in front makes it a full Read→…→Write pipeline, a different
-  fused form). For a pass-through epilogue use `Cast<T,T>`.
-- The result is a write-type fused IOp: `isAnyWriteType<decltype(output)>`
-  is `true`.
 
 ## Invoking the fused write inside a DPP
 
@@ -64,7 +43,7 @@ is applied inside it, then the destination write):
 
 ```cpp
 template <typename Inputs, typename Output>
-static __device__ void exec(const Details& d, const Inputs& inputs,
+FK_HOST_DEVICE_FUSE void exec(const Details& d, const Inputs& inputs,
                             const Output& output) {
     const auto& A = get<0>(inputs);          // inputs is fk::Tuple<AIOp, BIOp>
     const auto& B = get<1>(inputs);
@@ -77,7 +56,7 @@ static __device__ void exec(const Details& d, const Inputs& inputs,
 
 - **Inputs as a tuple:** read operands arrive as `const fk::Tuple<AIOp,BIOp>&`
   (built caller-side with `make_tuple(aIOp, bIOp)`), unpacked with
-  `get<0>/get<1>`. Use `std::decay_t<decltype(A)>::Operation` to name the op.
+  `get<0>/get<1>`.
 - **Output as the fused write:** invoke `Output::Operation::exec(thread, value,
   output)` — the whole fused IOp, NOT `.params`. This is what lets the epilogue
   chain run in-register before the single global write.
@@ -87,8 +66,8 @@ static __device__ void exec(const Details& d, const Inputs& inputs,
 - Passing `output.params` instead of `output` to a fused write's exec() routes
   through the wrong fold path. Pass the whole IOp.
 - A `Read` as the first link of `.then(...)` produces a Read→Write CLOSED
-  fused op, not the compute→write epilogue you want — start the chain with a
-  compute op (`Cast<T,T>` for identity).
+  fused op, not the compute→write epilogue you want — if there is no epiloge wimply
+  use the Write IOp.
 - The operand tuple must be `fk::Tuple` (via `make_tuple`), not two separate
   exec parameters — matches the DPP definition in
   `fkl-implementing-data-parallel-patterns`.
@@ -96,6 +75,6 @@ static __device__ void exec(const Details& d, const Inputs& inputs,
 ## See also
 
 - `fkl-implementing-operations` — authoring the op structs and the IOp-form table.
-- `fkl-implementing-data-parallel-patterns` — the DPP `exec(details, inputs,
+- `fkl-implementing-data-parallel-patterns` — the DPP `exec(details, inputs, compute,
   output)` contract these invocations live inside.
-- `fkl-fusion-techniques` — how `executeOperations` wires read→compute→write.
+- `fkl-fusion-techniques` — understanding fusion techniques for discussion.

--- a/tests/operation/test_fused_write_epilogue_repro.h
+++ b/tests/operation/test_fused_write_epilogue_repro.h
@@ -1,0 +1,103 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+/* Reproducer for the compute->write fused-IOp instantiation bug discussed in
+ * PR #287 (review r3473806517) and reported at r3473913994.
+ *
+ * Building a fused write IOp by chaining a COMPUTE op onto a Write IOp — the
+ * `epilogue.then(D)` shape @morousg asked DPP epilogues to use — fails to
+ * instantiate. Both of these:
+ *
+ *     auto w = Cast<float,float>::build().then(PerThreadWrite<ND::_2D,float>::build(d));
+ *     auto w = fuse(Add<float>::build(5.f), PerThreadWrite<ND::_2D,float>::build(d));
+ *
+ * trip, in the WriteType FusedOperation_ specialisation
+ * (include/.../operation_model/fused_operation.h):
+ *
+ *     error: name followed by "::" must be a class or namespace name
+ *         LastType_t<typename ParamsType::Operations>::Operation::exec(...)
+ *
+ * `ParamsType` is `OperationTuple<IOps...>`; the line reaches for
+ * `ParamsType::Operations` instead of the enclosing FusedOperation_'s own
+ * `using Operations = TypeList<IOps...>`. Composition succeeds
+ * (isAnyWriteType<decltype(w)> == true); only instantiating its exec() breaks.
+ *
+ * This test is COMPILE-CLEAN by default so CI stays green: the offending
+ * instantiation is guarded behind FKL_REPRO_287. To reproduce the failure,
+ * configure/build this single target with -DFKL_REPRO_287, e.g.:
+ *
+ *     nvcc -std=c++17 -I include -DFKL_REPRO_287 \
+ *          tests/operation/test_fused_write_epilogue_repro.h ...
+ *
+ * When the core is fixed, drop the guard (make the fused-write path the
+ * default) and this becomes a positive regression test: epilogue.then(D)
+ * applied to a value then stored, checked against a CPU oracle. */
+
+#define __ONLY_CU__
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/basic_ops.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/basic_ops/cast.h>
+#include <fused_kernel/core/data/ptr_nd.h>
+
+#include <cstdio>
+#include <vector>
+
+using namespace fk;
+
+#if defined(FKL_REPRO_287)
+// Invoke the fused compute->write IOp the way a DPP epilogue would. With the
+// current core this fails to compile at fused_operation.h:200 when the kernel
+// (and thus exec_helper) is instantiated.
+template <typename FusedW>
+__global__ void reproKernel(FusedW out, int W) {
+    const int x = threadIdx.x;
+    if (x < W) FusedW::Operation::exec(Point{ x, 0, 0 }, 10.0f, out);
+}
+#endif
+
+int launch() {
+    Ptr2D<float> d(8, 1);
+
+    // Composition itself is fine: the result IS a write-type IOp.
+    const auto epilogueThenD =
+        Cast<float, float>::build().then(PerThreadWrite<ND::_2D, float>::build(d));
+    static_assert(isAnyWriteType<decltype(epilogueThenD)>,
+                  "epilogue.then(D) should compose into a write-type IOp");
+
+#if defined(FKL_REPRO_287)
+    // --- bug path (only with -DFKL_REPRO_287) -----------------------------
+    // Instantiating the fused write's exec() trips fused_operation.h:200.
+    Stream_<ParArch::GPU_NVIDIA> stream;
+    reproKernel<<<1, 8, 0, stream.getCUDAStream()>>>(epilogueThenD, 8);
+    gpuErrchk(cudaGetLastError());
+    stream.sync();
+    std::vector<float> h(8);
+    cudaMemcpy2D(h.data(), 8 * sizeof(float), d.ptr().data, d.ptr().dims.pitch,
+                 8 * sizeof(float), 1, cudaMemcpyDeviceToHost);
+    // identity epilogue: stored value should equal the input (10.0).
+    for (int i = 0; i < 8; ++i)
+        if (h[i] != 10.0f) { printf("FAIL repro287: out[%d]=%.1f expected 10\n", i, h[i]); return -1; }
+    printf("fused epilogue.then(D) write: PASS (core bug fixed)\n");
+    return 0;
+#else
+    // Default: CI-green. Composition compiled; the exec() instantiation that
+    // triggers the bug is gated out. Build with -DFKL_REPRO_287 to reproduce.
+    (void)epilogueThenD;
+    printf("test_fused_write_epilogue_repro: composition OK; "
+           "exec() instantiation gated behind FKL_REPRO_287 (see #287)\n");
+    return 0;
+#endif
+}

--- a/tests/operation/test_fused_write_epilogue_repro.h
+++ b/tests/operation/test_fused_write_epilogue_repro.h
@@ -12,37 +12,25 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
-/* Reproducer for the compute->write fused-IOp instantiation bug discussed in
- * PR #287 (review r3473806517) and reported at r3473913994.
+/* Regression test for the compute->write fused-IOp path (PR #287, review
+ * r3473806517 / fix r3473994080).
  *
- * Building a fused write IOp by chaining a COMPUTE op onto a Write IOp — the
- * `epilogue.then(D)` shape @morousg asked DPP epilogues to use — fails to
- * instantiate. Both of these:
+ * Chaining a COMPUTE op onto a Write IOp — the `epilogue.then(D)` shape DPP
+ * epilogues use — must both COMPOSE into a write-type IOp and INSTANTIATE its
+ * exec(). This previously failed to compile in the WriteType (and ClosedType)
+ * FusedOperation_ specialisations:
  *
- *     auto w = Cast<float,float>::build().then(PerThreadWrite<ND::_2D,float>::build(d));
- *     auto w = fuse(Add<float>::build(5.f), PerThreadWrite<ND::_2D,float>::build(d));
+ *     fused_operation.h: LastType_t<typename ParamsType::Operations>::Operation
+ *     -> error: name followed by "::" must be a class or namespace name
  *
- * trip, in the WriteType FusedOperation_ specialisation
- * (include/.../operation_model/fused_operation.h):
- *
- *     error: name followed by "::" must be a class or namespace name
- *         LastType_t<typename ParamsType::Operations>::Operation::exec(...)
- *
- * `ParamsType` is `OperationTuple<IOps...>`; the line reaches for
- * `ParamsType::Operations` instead of the enclosing FusedOperation_'s own
- * `using Operations = TypeList<IOps...>`. Composition succeeds
- * (isAnyWriteType<decltype(w)> == true); only instantiating its exec() breaks.
- *
- * This test is COMPILE-CLEAN by default so CI stays green: the offending
- * instantiation is guarded behind FKL_REPRO_287. To reproduce the failure,
- * configure/build this single target with -DFKL_REPRO_287, e.g.:
- *
- *     nvcc -std=c++17 -I include -DFKL_REPRO_287 \
- *          tests/operation/test_fused_write_epilogue_repro.h ...
- *
- * When the core is fixed, drop the guard (make the fused-write path the
- * default) and this becomes a positive regression test: epilogue.then(D)
- * applied to a value then stored, checked against a CPU oracle. */
+ * Root cause: `LastType_t` takes a parameter PACK, but those two specialisations
+ * passed `ParamsType::Operations` (a single TypeList) instead of the `IOps...`
+ * pack, so LastType_t collapsed to the TypeList itself (which has no
+ * ::Operation). Fixed by using the pack form `LastType_t<IOps...>` (matching the
+ * Unary specialisation). This test exercises both:
+ *   - identity epilogue:  Cast<float,float>().then(D)
+ *   - scale+bias chain:    Mul(2).then(Add(0.5)).then(D)
+ * and checks the stored result against a CPU oracle. */
 
 #define __ONLY_CU__
 #include <tests/main.h>
@@ -54,50 +42,48 @@
 
 #include <cstdio>
 #include <vector>
+#include <cmath>
 
 using namespace fk;
 
-#if defined(FKL_REPRO_287)
-// Invoke the fused compute->write IOp the way a DPP epilogue would. With the
-// current core this fails to compile at fused_operation.h:200 when the kernel
-// (and thus exec_helper) is instantiated.
+// Invoke the fused compute->write IOp the way a DPP epilogue would: pass the
+// whole fused IOp (epilogue.then(D)) and call its Operation::exec(thread, value, iop).
 template <typename FusedW>
-__global__ void reproKernel(FusedW out, int W) {
+__global__ void epilogueWriteKernel(FusedW out, int W, float val) {
     const int x = threadIdx.x;
-    if (x < W) FusedW::Operation::exec(Point{ x, 0, 0 }, 10.0f, out);
+    if (x < W) FusedW::Operation::exec(Point{ x, 0, 0 }, val, out);
 }
-#endif
 
-int launch() {
-    Ptr2D<float> d(8, 1);
+template <typename Epi>
+static bool runCase(const char* name, const Epi& epilogue, float in, float expected) {
+    constexpr int W = 8;
+    Ptr2D<float> d(W, 1);
+    const auto output = epilogue.then(PerThreadWrite<ND::_2D, float>::build(d));
+    static_assert(isAnyWriteType<decltype(output)>,
+                  "epilogue.then(D) must compose into a write-type IOp");
 
-    // Composition itself is fine: the result IS a write-type IOp.
-    const auto epilogueThenD =
-        Cast<float, float>::build().then(PerThreadWrite<ND::_2D, float>::build(d));
-    static_assert(isAnyWriteType<decltype(epilogueThenD)>,
-                  "epilogue.then(D) should compose into a write-type IOp");
-
-#if defined(FKL_REPRO_287)
-    // --- bug path (only with -DFKL_REPRO_287) -----------------------------
-    // Instantiating the fused write's exec() trips fused_operation.h:200.
     Stream_<ParArch::GPU_NVIDIA> stream;
-    reproKernel<<<1, 8, 0, stream.getCUDAStream()>>>(epilogueThenD, 8);
+    epilogueWriteKernel<<<1, W, 0, stream.getCUDAStream()>>>(output, W, in);
     gpuErrchk(cudaGetLastError());
     stream.sync();
-    std::vector<float> h(8);
-    cudaMemcpy2D(h.data(), 8 * sizeof(float), d.ptr().data, d.ptr().dims.pitch,
-                 8 * sizeof(float), 1, cudaMemcpyDeviceToHost);
-    // identity epilogue: stored value should equal the input (10.0).
-    for (int i = 0; i < 8; ++i)
-        if (h[i] != 10.0f) { printf("FAIL repro287: out[%d]=%.1f expected 10\n", i, h[i]); return -1; }
-    printf("fused epilogue.then(D) write: PASS (core bug fixed)\n");
-    return 0;
-#else
-    // Default: CI-green. Composition compiled; the exec() instantiation that
-    // triggers the bug is gated out. Build with -DFKL_REPRO_287 to reproduce.
-    (void)epilogueThenD;
-    printf("test_fused_write_epilogue_repro: composition OK; "
-           "exec() instantiation gated behind FKL_REPRO_287 (see #287)\n");
-    return 0;
-#endif
+
+    std::vector<float> h(W);
+    cudaMemcpy2D(h.data(), W * sizeof(float), d.ptr().data, d.ptr().dims.pitch,
+                 W * sizeof(float), 1, cudaMemcpyDeviceToHost);
+    for (int i = 0; i < W; ++i)
+        if (std::abs(h[i] - expected) > 1e-5f) {
+            printf("FAIL %s: out[%d]=%.4f expected %.4f\n", name, i, h[i], expected);
+            return false;
+        }
+    printf("fused epilogue.then(D) %-12s: PASS (in=%.1f -> %.4f)\n", name, in, expected);
+    return true;
+}
+
+int launch() {
+    bool ok = true;
+    // identity epilogue: Cast<float,float> pass-through, fused with the write.
+    ok &= runCase("identity",   Cast<float, float>::build(),                              10.0f, 10.0f);
+    // scale+bias IOp chain: (v*2) then (+0.5), fused with the write.
+    ok &= runCase("scale+bias", Mul<float>::build(2.f).then(Add<float>::build(0.5f)),     10.0f, 20.5f);
+    return ok ? 0 : -1;
 }


### PR DESCRIPTION
## What

Adds a new agent skill **`fkl-using-operations`** documenting how to invoke and compose Operations / IOps **from the consumer side**, complementing `fkl-implementing-operations` (which is about *authoring* op structs).

## Why

While reworking the GEMM / attention DPPs in #287 to fuse the epilogue with the destination write (`epilogue.then(D)`, per @morousg's review), there turned out to be no single authoritative reference for the **consumer-side** contract: how to invoke each IOp type's `exec()`, how to build a compute→write fused IOp, and how a DPP should invoke that fused write. This skill fills that gap so every future DPP has one place to look.

## Contents

- **Per-operation-type `exec()` call-site contract** (Read / Write / Unary / Binary / ReadBack / Ternary / MidWrite / Open / Closed) — the same IOp-form table from `fkl-implementing-operations`, read here as "what arguments you must pass".
- **Composing a compute→write epilogue** with `epilogue.then(D)`, including the rule that the first link must be a compute op (`Cast<T,T>` for identity), **not** a Read (a Read in front yields a Read→Write closed fused op instead).
- **Invoking the fused write inside a DPP** as `Output::Operation::exec(thread, value, output)` — the whole fused IOp, not `.params` — with operands passed as an `fk::Tuple<AIOp,BIOp>`.

## Notes

- Docs-only: adds `skills/fkl-using-operations/SKILL.md` + one README row. No code changes.
- Follows the existing agent-skills convention (YAML frontmatter `name` + `description`, markdown body) used by the other `skills/`.
- Related: #287 (the epilogue-fusion review that motivated this). If the canonical fused-write form differs from what's documented here once the `fused_operation.h` consumer path is settled, I'll update the skill to match.
