### PR TITLE
Instantiable DPPs: DPP::build() -> InstantiableDPP, compile-time IO contracts, and a generic execution path

### DIFF
--- a/.github/skills/fkl-implementing-data-parallel-patterns/SKILL.md
+++ b/.github/skills/fkl-implementing-data-parallel-patterns/SKILL.md
@@ -1,20 +1,99 @@
 ---
 name: fkl-implementing-data-parallel-patterns
-description: Implement a new Data Parallel Pattern (DPP) for the Fused Kernel Library. Covers the anatomy of a DPP struct, device-side invocation of IOps (the IOp-form table, reading inputs, fusing epilogues into the write), compile-time vs runtime types, vector types, and testing. Use when adding an algorithm to FKL that requires thread coordination, or when debugging a DPP's internal device execution.
+description: Implement a new Data Parallel Pattern (DPP) for the Fused Kernel Library. Covers the InstantiableDPP protocol (DPP::build() -> InstantiableDPP, the DPPIOSpec IO contract, the generic fk::execute path), the anatomy of a DPP struct, device-side invocation of IOps (the IOp-form table, reading inputs, fusing epilogues into the write), compile-time vs runtime types, vector types, and testing. Use when adding an algorithm to FKL that requires thread coordination, or when debugging a DPP's internal device execution.
 ---
 
 # Implementing FKL Data Parallel Patterns
 
+## DPPs are instantiable values (the InstantiableDPP model)
+
+DPPs follow the same design language as Operations: **types define the kernel;
+`build()` values are runtime parameters**.
+
+- An Operation is a stateless static struct; `Op::build(params)` produces an
+  **IOp** (Operation type + runtime `OperationData`).
+- A DPP is a stateless static struct; `DPP::build(iOps...)` produces an
+  **InstantiableDPP** (DPP type + runtime `Details` + the IOps it will execute).
+
+An InstantiableDPP is executed with the generic entry point:
+
+```cpp
+#include <fused_kernel/fused_kernel.h>
+
+const auto iDPP = TransformDPP<>::build(readIOp, mulIOp, writeIOp);
+fk::execute(stream, iDPP);
+```
+
+`fk::execute` (executors.h) is ONE generic executor path for every conforming
+DPP: on CPU it calls `DPP::exec(details, iOps...)` directly (the DPP implements
+the whole sequential loop); on GPU it launches the single generic
+`launchInstantiableDPP_Kernel` trampoline with the grid/block returned by the
+DPP's `getLaunchConfig()`. **A new conforming DPP needs NO hand-written
+`Executor<DPP>` specialization and NO dedicated `__global__` kernel.**
+
+`executeOperations<TransformDPP<...>>(stream, iOps...)` keeps working unchanged
+(legacy Executor path).
+
+## The InstantiableDPP protocol (what a conforming DPP must implement)
+
+A DPP front type (per `ParArch` backend) provides:
+
+| Member | Kind | Purpose |
+|---|---|---|
+| `static constexpr ParArch PAR_ARCH` | constant | the backend this specialization implements |
+| `static constexpr DPPIOSpec IO_SPEC` | constant | the compile-time IO contract (see below) |
+| `build_details(iOps...)` | `FK_HOST_FUSE` | builds the runtime Details (non-data parameters); may return an empty struct |
+| `build(iOps...)` | `FK_HOST_FUSE` | usually one line: `return buildInstantiableDPP<SelfType>(iOps...);` |
+| `exec(details, iOps...)` | `FK_DEVICE_FUSE` / coop / `FK_HOST_FUSE` | the pattern itself (GPU device code / CPU sequential loop) |
+| `getLaunchConfig(details, iOps...)` | `FK_HOST_FUSE`, GPU only | returns a `DPPLaunchConfig{ grid, block }`; `defaultDPPLaunchConfig(activeThreads)` gives the TransformDPP heuristic |
+
+`buildInstantiableDPP<DPP>(iOps...)` (core/execution_model/instantiable_dpp.h)
+does three things: it brings the IOps to canonical form (fusing ReadBack stacks
+via Backwards Vertical Fusion), it static_asserts the IO contract, and it calls
+`DPP::build_details` to produce the `InstantiableDPP` value.
+
+## The IO contract (DPPIOSpec): what goes in and what comes out
+
+Every DPP declares its IO API as a compile-time contract. All data enters and
+leaves a DPP through IOps — inputs through complete Read/ReadBack IOps, outputs
+through Write IOps, never through raw pointers.
+
+```cpp
+struct DPPIOSpec {
+    size_t inputIOps;         // exact number of leading Read/ReadBack IOps consumed
+    size_t outputIOps;        // exact number of trailing Write IOps produced into
+    bool acceptsComputeIOps;  // whether a compute/MidWrite IOp chain is accepted in between
+    bool argsAreIOpSequences; // whether the DPP consumes whole IOpSequences (one per
+                              // divergent branch); the counts then apply to EACH sequence
+};
+```
+
+Current contracts:
+
+| DPP | IO_SPEC | Meaning |
+|---|---|---|
+| `TransformDPP` | `{1, 1, true, false}` | 1 Read/ReadBack in, optional compute chain, 1 Write out |
+| `DivergentBatchTransformDPP` (GPU) | `{1, 1, true, true}` | N IOpSequences, each: 1 Read + compute chain + 1 Write |
+| `RowReduceDPP` | `{1, 1, false, false}` | 1 Read/ReadBack in (2D only), 1 Write out, NO compute chain (fuse preprocessing into the read: `readIOp.then(...)`); ReduceOp must be associative + commutative (see below) |
+
+Conformance is enforced with granular `static_assert` messages ("DPP IO
+contract violation: ...") when `build()`ing and when `fk::execute()`ing. The
+soft (non-asserting) check `dppIOContractSatisfied<DPP, IOps...>()` is usable
+in tests and SFINAE. The repo has no compile-fail test infra, so utests
+document the failing `build()` calls as comments next to soft-check
+static_asserts (see utest_instantiable_dpp.h, utest_row_reduce_dpp.h).
+
 ## Anatomy of a DPP
 
-A DPP is composed of three parts:
+A DPP is composed of:
 
-- Executor implementation: as in include/fused_kernel/core/execution_model/executors.h
-- For GPU implementations, a kernel function that gets the DPP parameters and internally calls the DPP (for CPU, nothing).
-- The DPP implementation.
+- The DPP implementation (one specialization per ParArch backend).
+- Its `DPPIOSpec IO_SPEC` and the other InstantiableDPP protocol members.
+- Nothing else: the generic executor and generic kernel do the launching.
 
 Every DPP must always have a single thread CPU implementation using the ParArch::CPU and then it can have implementations
 for other ParArchs, as in include/fused_kernel/core/execution_model/parallel_architectures.h
+(exception so far: DivergentBatchTransformDPP is GPU-only in practice — its CPU exec is not implemented).
 
 Every DPP is a STATELESS struct: static `exec()`. The exec function will get as parameters, DPP details which are external parameters
 not directly related to the data being processed, and IOps (Instantiable Operations) which will contain the implementation
@@ -30,15 +109,53 @@ as well as applying any thread synchronization or using any shared memory.
 Each one of the IOps can contain a single Operation, or a FusedOperation (several consecutive Operations), or a fk::Tuple of IOps,
 depending on the structure the DPP requires.
 
-Each DPP defines the number of input ReadOperations and or ReadBackOperations it requires.
-Each DPP defines the number of compute Operations (non Read/ReadBack and non Write) it requires.
-Each DPP defines the number of output WriteOperations it requires.
-
 Never pass a raw pointer (T*) to device (global) memory as an input or output parameter to exec function.
 Device pointers must be passed as part of a Read/ReadBack or Write IOps.
 
-Example TransformDPP which is a special case, because it does not require any specific structure in the IOps passed as parameters.
-The IOps in this DPP will be executed one after the other by all the threads that have to participate.
+Cooperative exec bodies (`__shared__` + barriers) cannot be constexpr: use
+`FK_COOP_DEVICE_FUSE` (= `static __device__ __forceinline__ void`) instead of
+`FK_DEVICE_FUSE` for the GPU exec in that case.
+
+## Reference implementation of a new DPP: RowReduceDPP
+
+`include/fused_kernel/algorithms/reductions/row_reduce.h` is the reference for
+authoring a DPP through the pure InstantiableDPP API: CPU + GPU backends,
+`IO_SPEC{1, 1, false, false}`, empty Details, `build()` =
+`buildInstantiableDPP<SelfType>(iOps...)`, a `getLaunchConfig` that maps one
+thread block per row, and a cooperative shared-memory tree reduction on GPU vs
+a plain sequential loop on CPU. It is not in any umbrella header; include it
+directly.
+
+Semantic requirements the type system cannot check (documented, not
+static_asserted):
+
+- The reduction ORDER is backend-dependent (strict sequential left fold on CPU;
+  strided per-lane accumulation + shared-memory tree on GPU), so the ReduceOp
+  must be **associative and commutative** (Add, Max, Min...). A non-commutative
+  BinaryType Operation (e.g. Sub) compiles cleanly but produces
+  backend-dependent results. For floating-point types both backends are
+  correct, but reassociation means their rounding may differ, so exact bitwise
+  equality between backends is not guaranteed.
+- **2D inputs only**: both backends fix the Point z coordinate to 0, so
+  `build()` throws `std::invalid_argument` if the input IOp's ActiveThreads.z
+  is not 1 (a batched/3D read would otherwise silently reduce only plane
+  z == 0).
+
+Usage:
+
+```cpp
+#include <fused_kernel/algorithms/reductions/row_reduce.h>
+
+const auto iDPP = RowReduceDPP<Add<int>>::build(
+    PerThreadRead<ND::_2D, int>::build(input),   // or a fused prologue: .then(Mul<int>::build(3))
+    PerThreadWrite<ND::_1D, int>::build(output)); // one element per row, written at Point{row, 0, 0}
+fk::execute(stream, iDPP);
+```
+
+Example TransformDPP GPU exec, which is a special case because it does not
+require any specific structure in the IOps passed as parameters. The IOps in
+this DPP will be executed one after the other by all the threads that have to
+participate:
 
 ```cpp
 #include <cooperative_groups.h>
@@ -102,7 +219,7 @@ Key rules for DPP authors invoking these:
 
 ## Invoking Operations Inside the DPP (Device Side)
 
-Inside the DPP's execution logic, you must invoke the IOps passed to the `exec()` function. If the executor pre-fused a compute chain into the write operation (the epilogue), you invoke it as a single `OutputIOp` type:
+Inside the DPP's execution logic, you must invoke the IOps passed to the `exec()` function. If the compute chain was fused into the input or output IOp (prologue/epilogue), you invoke it as a single IOp type:
 
 ```cpp
 template <typename DPPDetails, typename InputIOp, typename OutputIOp>
@@ -131,6 +248,8 @@ struct MyDPP {
 ## Pitfalls
 
 - **Passing `iop.params` instead of `iop`:** If you are writing a DPP and pass `iop.params` to an operation's `exec()`, it will route through the wrong template fold path and fail to compile. Always pass the whole IOp wrapper.
+- **Forgetting `IO_SPEC`:** `DPP::build()`/`fk::execute()` static_assert that the DPP declares `static constexpr DPPIOSpec IO_SPEC{...}`.
+- **GPU DPP without `getLaunchConfig`:** `fk::execute(gpuStream, iDPP)` static_asserts its presence.
 
 ## Runtime values vs compile-time types (the golden rule)
 
@@ -138,7 +257,9 @@ Anything users may change per call (factors, rects, matrices, sizes) goes
 in ParamsType. Anything that changes the generated code (dtype, channel
 count, batch size, interpolation mode) is a template parameter. Getting
 this wrong either recompiles on every value change or silently bakes
-stale values into kernels.
+stale values into kernels. The same rule applies to DPPs: runtime values go in
+the Details struct (built by `build_details`), code-shaping choices (the reduce
+Operation, BLOCK_SIZE, thread fusion enablement) are template parameters.
 
 ## Vector types
 
@@ -161,13 +282,20 @@ apply([](const auto&... iOps) { return BackFuser::fuse_back(iOps...); }, tup);
 
 ## Testing a new DPP
 
-1. Add a utest header under `utests/<area>/`.
-2. Register it in the test list before `STOP_ADDING_TESTS`.
+1. Add a utest header under `utests/<area>/`. Exercise `DPP::build()` +
+   `fk::execute()` on BOTH backends (the harness compiles every test as
+   `_cpp` and `_cu`; GPU-only DPPs use `#define __ONLY_CU__`).
+2. Add compile-time contract checks with
+   `static_assert(dppIOContractSatisfied<DPP, IOps...>() == expected)` for both
+   conforming and non-conforming packs, plus commented compile-fail
+   documentation of the `build()` static_assert messages.
 3. Build and run: see the fkl-build-and-test skill.
 
 ## Checklist before opening a PR
 
 - [ ] `FK_STATIC_STRUCT`
-- [ ] CPU exec() is `FK_HOST_FUSE`; GPU exec() is `FK_DEVICE_FUSE`
-- [ ] utest instantiating every public alias/build path
+- [ ] `IO_SPEC`, `build_details()`, `build()` (= `buildInstantiableDPP<SelfType>`), `getLaunchConfig()` on GPU
+- [ ] CPU exec() is `FK_HOST_FUSE`; GPU exec() is `FK_DEVICE_FUSE` (or `FK_COOP_DEVICE_FUSE` if it needs shared memory/barriers)
+- [ ] No `Executor` specialization and no dedicated `__global__` kernel (the generic path handles both)
+- [ ] utest instantiating every public alias/build path, on both backends, plus contract checks
 - [ ] compiles warning-clean on nvcc AND clang (CUDA 12.x and 13.x)

--- a/include/fused_kernel/algorithms/reductions/row_reduce.h
+++ b/include/fused_kernel/algorithms/reductions/row_reduce.h
@@ -1,0 +1,207 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_REDUCTIONS_ROW_REDUCE_H
+#define FK_REDUCTIONS_ROW_REDUCE_H
+
+/* RowReduceDPP: row-wise reduction as a Data Parallel Pattern, implemented purely
+ * against the InstantiableDPP protocol (see core/execution_model/instantiable_dpp.h):
+ * it needs NO Executor specialization and NO dedicated __global__ kernel.
+ *
+ * For each row y of the input, it combines all the elements of the row with a
+ * BinaryType compute Operation (the ReduceOp, e.g. Add<int>) and writes the single
+ * per-row result at Point{ y, 0, 0 } of the output Write IOp (so the natural output
+ * container is a Ptr1D with one element per input row).
+ *
+ * ReduceOp requirements: the combination ORDER is backend-dependent. The CPU backend
+ * is a strict sequential left fold over each row, while the GPU backend interleaves a
+ * strided per-lane accumulation across lanes with a shared-memory tree reduction. The
+ * ReduceOp must therefore be ASSOCIATIVE and COMMUTATIVE (e.g. Add, Max, Min): a
+ * non-commutative BinaryType Operation such as Sub compiles cleanly but produces
+ * backend-dependent results. For floating-point types both backends are correct, but
+ * reassociation means their rounding may differ, so exact bitwise equality between
+ * backends is not guaranteed.
+ *
+ * 2D inputs only: the input IOp's ActiveThreads.z must be 1. build() throws
+ * std::invalid_argument for batched/3D inputs, which would otherwise silently reduce
+ * only plane z == 0.
+ *
+ * IO contract (IO_SPEC): exactly one complete Read/ReadBack IOp in and one Write IOp
+ * out; NO compute IOp chain is accepted (it would be ambiguous whether it applies
+ * before or after the reduction). Per-element preprocessing must be fused into the
+ * input IOp instead: readIOp.then(computeIOp...) runs in-register at load time.
+ *
+ * Not a TransformDPP: the row reduction requires cross-thread cooperation on the GPU
+ * backend (shared memory + barriers). Like every DPP, it is a stateless struct that
+ * touches memory exclusively through the IOps it receives, and it has a single-thread
+ * CPU implementation.
+ *
+ * Usage:
+ *   const auto iDPP = RowReduceDPP<Add<int>>::build(readIOp, writeIOp);
+ *   fk::execute(stream, iDPP);
+ */
+
+#include <fused_kernel/core/execution_model/instantiable_dpp.h>
+
+#if !defined(NVRTC_COMPILER)
+#include <stdexcept>
+#endif
+
+namespace fk {
+
+// Cooperative-DPP exec bodies use __shared__ + barriers: they cannot be
+// constexpr (FK_DEVICE_FUSE). Plain static device inline qualifier:
+#ifndef FK_COOP_DEVICE_FUSE
+#define FK_COOP_DEVICE_FUSE static __device__ __forceinline__ void
+#endif
+
+    struct RowReduceDPPDetails {}; // Stateless: all geometry comes from the IOps
+
+    namespace row_reduce_detail {
+        // RowReduceDPP reduces 2D inputs only: both backends fix the Point z coordinate
+        // to 0, so a batched/3D input would silently reduce only plane z == 0.
+        template <typename InIOp>
+        FK_HOST_CNST void assertInputIs2D(const InIOp& input) {
+#if !defined(NVRTC_COMPILER)
+            if (input.getActiveThreads().z != 1) {
+                throw std::invalid_argument(
+                    "RowReduceDPP: 2D inputs only (the input IOp's ActiveThreads.z must be 1). "
+                    "A batched/3D input would silently reduce only plane z == 0.");
+            }
+#endif
+        }
+    } // namespace row_reduce_detail
+
+#define ROW_REDUCE_DPP_STATIC_INTERFACE \
+    /* The ReduceOp must also be associative and commutative: the GPU backend reorders \
+     * the combination (see the header comment). That is a semantic property the type \
+     * system cannot check, so it is a documented requirement, not a static_assert. */ \
+    static_assert(opIs<BinaryType, ReduceOp>, \
+        "RowReduceDPP: ReduceOp must be a BinaryType compute Operation (e.g. Add<int>)"); \
+    static_assert(BLOCK_SIZE > 0 && BLOCK_SIZE <= 1024, \
+        "RowReduceDPP: BLOCK_SIZE must be in (0, 1024]"); \
+    using Details = RowReduceDPPDetails; \
+    /** IO contract: one Read/ReadBack IOp in, one Write IOp out, no compute IOp chain. */ \
+    static constexpr DPPIOSpec IO_SPEC{ /*inputIOps*/ 1, /*outputIOps*/ 1, \
+                                        /*acceptsComputeIOps*/ false, /*argsAreIOpSequences*/ false }; \
+    template <typename InIOp, typename OutIOp> \
+    FK_HOST_FUSE Details build_details(const InIOp& input, const OutIOp&) { \
+        row_reduce_detail::assertInputIs2D(input); \
+        return Details{}; \
+    } \
+    /** build: creates an InstantiableDPP, enforcing IO_SPEC at compile time. \
+     *  Execute the result with fk::execute(stream, instantiableDPP). */ \
+    template <typename... IOps> \
+    FK_HOST_FUSE auto build(const IOps&... iOps) { \
+        return buildInstantiableDPP<SelfType>(iOps...); \
+    }
+
+    template <typename ReduceOp, enum ParArch PA = defaultParArch, int BLOCK_SIZE = 256>
+    struct RowReduceDPP;
+
+    template <typename ReduceOp, int BLOCK_SIZE>
+    struct RowReduceDPP<ReduceOp, ParArch::CPU, BLOCK_SIZE> {
+    private:
+        using SelfType = RowReduceDPP<ReduceOp, ParArch::CPU, BLOCK_SIZE>;
+    public:
+        FK_STATIC_STRUCT(RowReduceDPP, SelfType)
+        static constexpr ParArch PAR_ARCH = ParArch::CPU;
+        ROW_REDUCE_DPP_STATIC_INTERFACE
+
+        template <typename InIOp, typename OutIOp>
+        FK_HOST_FUSE void exec(const Details&, const InIOp& input, const OutIOp& output) {
+            using ValueType = typename InIOp::Operation::OutputType;
+            static_assert(std::is_same_v<ValueType, typename ReduceOp::InputType> &&
+                          std::is_same_v<ValueType, typename ReduceOp::ParamsType> &&
+                          std::is_same_v<ValueType, typename ReduceOp::OutputType>,
+                "RowReduceDPP: the ReduceOp Input/Params/Output types must match the input IOp OutputType");
+            const ActiveThreads activeThreads = input.getActiveThreads();
+            const int width = static_cast<int>(activeThreads.x);
+            const int rows = static_cast<int>(activeThreads.y);
+            if (width == 0) {
+                return;
+            }
+            for (int y = 0; y < rows; ++y) {
+                ValueType accumulator = InIOp::Operation::exec(Point{ 0, y, 0 }, input);
+                for (int x = 1; x < width; ++x) {
+                    accumulator = ReduceOp::exec(accumulator, InIOp::Operation::exec(Point{ x, y, 0 }, input));
+                }
+                OutIOp::Operation::exec(Point{ y, 0, 0 }, accumulator, output);
+            }
+        }
+    };
+
+#if defined(__NVCC__)
+    template <typename ReduceOp, int BLOCK_SIZE>
+    struct RowReduceDPP<ReduceOp, ParArch::GPU_NVIDIA, BLOCK_SIZE> {
+    private:
+        using SelfType = RowReduceDPP<ReduceOp, ParArch::GPU_NVIDIA, BLOCK_SIZE>;
+    public:
+        FK_STATIC_STRUCT(RowReduceDPP, SelfType)
+        static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+        ROW_REDUCE_DPP_STATIC_INTERFACE
+
+        // One thread block per row
+        template <typename InIOp, typename OutIOp>
+        FK_HOST_FUSE DPPLaunchConfig getLaunchConfig(const Details&, const InIOp& input, const OutIOp&) {
+            const ActiveThreads activeThreads = input.getActiveThreads();
+            return { ActiveThreads(activeThreads.y, 1u, 1u),
+                     ActiveThreads(static_cast<uint>(BLOCK_SIZE), 1u, 1u) };
+        }
+
+        template <typename InIOp, typename OutIOp>
+        FK_COOP_DEVICE_FUSE exec(const Details&, const InIOp& input, const OutIOp& output) {
+            using ValueType = typename InIOp::Operation::OutputType;
+            static_assert(std::is_same_v<ValueType, typename ReduceOp::InputType> &&
+                          std::is_same_v<ValueType, typename ReduceOp::ParamsType> &&
+                          std::is_same_v<ValueType, typename ReduceOp::OutputType>,
+                "RowReduceDPP: the ReduceOp Input/Params/Output types must match the input IOp OutputType");
+            __shared__ ValueType partials[BLOCK_SIZE];
+
+            const int row = static_cast<int>(blockIdx.x);
+            const int tid = static_cast<int>(threadIdx.x);
+            const int width = static_cast<int>(input.getActiveThreads().x);
+            if (width == 0) {
+                return;
+            }
+            // Each active lane sequentially combines a strided slice of the row (every
+            // lane owns at least one element, so no identity element is required).
+            const int activeLanes = width < BLOCK_SIZE ? width : BLOCK_SIZE;
+            if (tid < activeLanes) {
+                ValueType accumulator = InIOp::Operation::exec(Point{ tid, row, 0 }, input);
+                for (int x = tid + BLOCK_SIZE; x < width; x += BLOCK_SIZE) {
+                    accumulator = ReduceOp::exec(accumulator, InIOp::Operation::exec(Point{ x, row, 0 }, input));
+                }
+                partials[tid] = accumulator;
+            }
+            __syncthreads();
+            // Shared memory tree reduction over the activeLanes partials
+            for (int stride = 1; stride < activeLanes; stride *= 2) {
+                if ((tid % (2 * stride) == 0) && (tid + stride < activeLanes)) {
+                    partials[tid] = ReduceOp::exec(partials[tid], partials[tid + stride]);
+                }
+                __syncthreads();
+            }
+            if (tid == 0) {
+                OutIOp::Operation::exec(Point{ row, 0, 0 }, partials[0], output);
+            }
+        }
+    };
+#endif // defined(__NVCC__)
+
+#undef ROW_REDUCE_DPP_STATIC_INTERFACE
+
+} // namespace fk
+
+#endif // FK_REDUCTIONS_ROW_REDUCE_H

--- a/include/fused_kernel/core/execution_model/data_parallel_patterns.h
+++ b/include/fused_kernel/core/execution_model/data_parallel_patterns.h
@@ -26,6 +26,7 @@ namespace cg = cooperative_groups;
 #include <fused_kernel/core/execution_model/thread_fusion.h>
 #include <fused_kernel/core/execution_model/parallel_architectures.h>
 #include <fused_kernel/core/execution_model/active_threads.h>
+#include <fused_kernel/core/execution_model/instantiable_dpp.h>
 #include <cmath>
 
 namespace fk { // namespace FusedKernel
@@ -183,7 +184,14 @@ namespace fk { // namespace FusedKernel
 
     template <enum ParArch PA, enum TF TFEN>
     struct TransformDPP<PA, TFEN, void, true, void> {
+    private:
+        using SelfType = TransformDPP<PA, TFEN>;
+    public:
         static constexpr ParArch PAR_ARCH = PA;
+        /** IO contract: one Read/ReadBack IOp in, an optional compute IOp chain, one Write IOp out. */
+        static constexpr DPPIOSpec IO_SPEC{ /*inputIOps*/ 1, /*outputIOps*/ 1,
+                                            /*acceptsComputeIOps*/ true, /*argsAreIOpSequences*/ false };
+
         template <typename FirstIOp, typename... IOps>
         FK_HOST_FUSE auto build_details(const FirstIOp& firstIOp, const IOps&... iOps) {
             using Details = TransformDPPDetails<static_cast<bool>(TFEN), FirstIOp, IOps...>;
@@ -199,6 +207,43 @@ namespace fk { // namespace FusedKernel
                 return details;
             } else {
                 return Details{};
+            }
+        }
+
+        /**
+         * @brief build: creates an InstantiableDPP (this DPP plus its runtime details and IOps),
+         * enforcing the IO contract (IO_SPEC) at compile time. Execute the result with
+         * fk::execute(stream, instantiableDPP).
+         */
+        template <typename... IOps>
+        FK_HOST_FUSE auto build(const IOps&... iOps) {
+            return buildInstantiableDPP<SelfType>(iOps...);
+        }
+
+        template <typename RTDetails, typename FirstIOp, typename... IOps>
+        FK_HOST_FUSE DPPLaunchConfig getLaunchConfig(const RTDetails& details, const FirstIOp& firstIOp, const IOps&...) {
+            if constexpr (RTDetails::TFI::ENABLED) {
+                return defaultDPPLaunchConfig(details.activeThreads);
+            } else {
+                return defaultDPPLaunchConfig(firstIOp.getActiveThreads());
+            }
+        }
+
+        /**
+         * @brief exec: generic entry point used by the InstantiableDPP execution path.
+         * Dispatches to the Details-resolved TransformDPP implementation. When thread fusion
+         * is enabled, the thread-divisibility variant is selected with a grid-uniform branch.
+         */
+        template <typename RTDetails, typename... IOps>
+        FK_HOST_DEVICE_FUSE void exec(const RTDetails& details, const IOps&... iOps) {
+            if constexpr (RTDetails::TFI::ENABLED) {
+                if (details.threadDivisible) {
+                    TransformDPP<PA, TFEN, RTDetails, true>::exec(details, iOps...);
+                } else {
+                    TransformDPP<PA, TFEN, RTDetails, false>::exec(details, iOps...);
+                }
+            } else {
+                TransformDPP<PA, TFEN, RTDetails, true>::exec(details, iOps...);
             }
         }
     };
@@ -306,9 +351,42 @@ namespace fk { // namespace FusedKernel
     struct DivergentBatchTransformDPP<ParArch::GPU_NVIDIA, SequenceSelector> {
     private:
         using Parent = DivergentBatchTransformDPPBase<SequenceSelector>;
+        using SelfType = DivergentBatchTransformDPP<ParArch::GPU_NVIDIA, SequenceSelector>;
     public:
         using DPPDetails = DivergentBatchTransformDPPDetails<ParArch::GPU_NVIDIA>;
         static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
+        /** IO contract: N (>=1) IOpSequences; each one holds one Read/ReadBack IOp,
+         *  an optional compute IOp chain and one Write IOp. */
+        static constexpr DPPIOSpec IO_SPEC{ /*inputIOps*/ 1, /*outputIOps*/ 1,
+                                            /*acceptsComputeIOps*/ true, /*argsAreIOpSequences*/ true };
+
+        template <typename... IOpSequenceTypes>
+        FK_HOST_FUSE DPPDetails build_details(const IOpSequenceTypes&...) {
+            return DPPDetails{};
+        }
+
+        /**
+         * @brief build: creates an InstantiableDPP from one IOpSequence per divergent branch,
+         * enforcing the IO contract (IO_SPEC) at compile time on each sequence. Execute the
+         * result with fk::execute(stream, instantiableDPP).
+         */
+        template <typename... IOpSequenceTypes>
+        FK_HOST_FUSE auto build(const IOpSequenceTypes&... iOpSequences) {
+            return buildInstantiableDPP<SelfType>(iOpSequences...);
+        }
+
+        template <typename... IOpSequenceTypes>
+        FK_HOST_FUSE DPPLaunchConfig getLaunchConfig(const DPPDetails&, const IOpSequenceTypes&... iOpSequences) {
+            const uint x = cxp::max::f(get<0>(iOpSequences.iOps).getActiveThreads().x...);
+            const uint y = cxp::max::f(get<0>(iOpSequences.iOps).getActiveThreads().y...);
+            const uint z = cxp::sum::f(get<0>(iOpSequences.iOps).getActiveThreads().z...);
+            const ActiveThreads block(cxp::min::f(x, 32u), cxp::min::f(y, 8u), 1u);
+            const ActiveThreads grid(static_cast<uint>(ceil(x / static_cast<float>(block.x))),
+                                     static_cast<uint>(ceil(y / static_cast<float>(block.y))),
+                                     z);
+            return { grid, block };
+        }
+
         template <typename... IOpSequenceTypes>
         FK_DEVICE_FUSE void exec(const DPPDetails&, const IOpSequenceTypes&... iOpSequences) {
 

--- a/include/fused_kernel/core/execution_model/executor_details/executor_kernels.h
+++ b/include/fused_kernel/core/execution_model/executor_details/executor_kernels.h
@@ -29,6 +29,15 @@ __global__ void launchTransformDPP_Kernel(const __grid_constant__ TDPPDetails tD
     TransformDPP<PA, TFEN, TDPPDetails, THREAD_DIVISIBLE>::exec(tDPPDetails, operations...);
 }
 
+// Generic kernel for the InstantiableDPP execution path: any DPP conforming to the
+// InstantiableDPP protocol (see instantiable_dpp.h) is launched through this single
+// trampoline, so new DPPs do not need their own __global__ kernel.
+template <typename DPP, typename DPPDetails, typename... IOps>
+__global__ void launchInstantiableDPP_Kernel(const __grid_constant__ DPPDetails details,
+                                             const __grid_constant__ IOps... iOps) {
+    DPP::exec(details, iOps...);
+}
+
 } // namespace fk
 #endif
 

--- a/include/fused_kernel/core/execution_model/executor_details/launch_config.h
+++ b/include/fused_kernel/core/execution_model/executor_details/launch_config.h
@@ -1,0 +1,135 @@
+/* Copyright 2025 Grup Mediapro S.L.U (Oscar Amoros Huguet)
+   Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_LAUNCH_CONFIG_H
+#define FK_LAUNCH_CONFIG_H
+
+#include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/execution_model/active_threads.h>
+
+#include <climits>
+#include <cmath>
+
+namespace fk {
+
+    struct CtxDim3 {
+        uint x;
+        uint y;
+        uint z;
+#if defined(__NVCC__)
+        constexpr CtxDim3(const dim3& dims) : x(dims.x), y(dims.y), z(dims.z) {}
+#endif
+        constexpr CtxDim3() : x(1), y(1), z(1) {}
+        constexpr CtxDim3(const uint& x) : x(x), y(1), z(1) {}
+        constexpr CtxDim3(const uint& x, const uint& y) : x(x), y(y), z(1) {}
+        constexpr CtxDim3(const uint& x, const uint& y, const uint& z) : x(x), y(y), z(z) {}
+    };
+
+    struct ComputeBestSolutionBase {
+        FK_HOST_FUSE uint computeDiscardedThreads(const uint width, const uint height, const uint blockDimx, const uint blockDimy) {
+            const uint modX = width % blockDimx;
+            const uint modY = height % blockDimy;
+            const uint th_disabled_in_X = modX == 0 ? 0 : blockDimx - modX;
+            const uint th_disabled_in_Y = modY == 0 ? 0 : blockDimy - modY;
+            return (th_disabled_in_X * (modY == 0 ? height : (height + blockDimy)) + th_disabled_in_Y * width);
+        }
+    };
+
+    template <uint bxS_t, uint byS_t>
+    struct computeBestSolution {};
+
+    template <uint bxS_t>
+    struct computeBestSolution<bxS_t, 0> final : public ComputeBestSolutionBase {
+        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
+            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[bxS_t], blockDimY[0][bxS_t]);
+            if (minDiscardedThreads > currentDiscardedThreads) {
+                minDiscardedThreads = currentDiscardedThreads;
+                bxS = bxS_t;
+                byS = 0;
+                if (minDiscardedThreads == 0) return;
+            }
+            computeBestSolution<bxS_t, 1>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
+        }
+    };
+
+    template <uint bxS_t>
+    struct computeBestSolution<bxS_t, 1> final : public ComputeBestSolutionBase {
+        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
+            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[bxS_t], blockDimY[1][bxS_t]);
+            if (minDiscardedThreads > currentDiscardedThreads) {
+                minDiscardedThreads = currentDiscardedThreads;
+                bxS = bxS_t;
+                byS = 1;
+                if constexpr (bxS_t == 3) return;
+                if (minDiscardedThreads == 0) return;
+            }
+            computeBestSolution<bxS_t + 1, 0>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
+        }
+    };
+
+    template <>
+    struct computeBestSolution<3, 1> final : public ComputeBestSolutionBase {
+        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
+            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[3], blockDimY[1][3]);
+            if (minDiscardedThreads > currentDiscardedThreads) {
+                minDiscardedThreads = currentDiscardedThreads;
+                bxS = 3;
+                byS = 1;
+            }
+        }
+    };
+
+    FK_HOST_CNST CtxDim3 getDefaultBlockSize(const uint& width, const uint& height) {
+        constexpr uint blockDimX[4] = { 32, 64, 128, 256 };  // Possible block sizes in the x axis
+        constexpr uint blockDimY[2][4] = { { 8,  4,   2,   1},
+                                          { 6,  3,   3,   2} };  // Possible block sizes in the y axis according to blockDim.x
+
+        uint minDiscardedThreads = UINT_MAX;
+        uint bxS = 0; // from 0 to 3
+        uint byS = 0; // from 0 to 1
+
+        computeBestSolution<0, 0>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
+
+        return CtxDim3(blockDimX[bxS], blockDimY[byS][bxS]);
+    }
+
+    /**
+     * @brief DPPLaunchConfig: backend-agnostic launch configuration for a Data Parallel Pattern.
+     * grid is the number of thread blocks and block the number of threads per block, in each dimension.
+     * It is returned by the DPP's getLaunchConfig() so that the generic InstantiableDPP execution
+     * path can launch any conforming DPP without a hand-written Executor specialization.
+     * The CPU backend ignores it: CPU DPP exec() implementations define their own sequential loops.
+     */
+    struct DPPLaunchConfig {
+        ActiveThreads grid;
+        ActiveThreads block;
+    };
+
+    /**
+     * @brief defaultDPPLaunchConfig: one thread per output element, with the default 2D block size
+     * heuristic (getDefaultBlockSize) and one grid plane per z element. This is the configuration
+     * used by TransformDPP, and a sane default for element-wise DPPs.
+     */
+    FK_HOST_CNST DPPLaunchConfig defaultDPPLaunchConfig(const ActiveThreads& activeThreads) {
+        const CtxDim3 block = getDefaultBlockSize(activeThreads.x, activeThreads.y);
+        const ActiveThreads grid(static_cast<uint>(ceil(activeThreads.x / static_cast<float>(block.x))),
+                                 static_cast<uint>(ceil(activeThreads.y / static_cast<float>(block.y))),
+                                 activeThreads.z);
+        return { grid, ActiveThreads(block.x, block.y, 1u) };
+    }
+
+} // namespace fk
+
+#endif // FK_LAUNCH_CONFIG_H

--- a/include/fused_kernel/core/execution_model/executors.h
+++ b/include/fused_kernel/core/execution_model/executors.h
@@ -19,6 +19,7 @@
 
 #include <fused_kernel/core/execution_model/parallel_architectures.h>
 #include <fused_kernel/core/execution_model/data_parallel_patterns.h>
+#include <fused_kernel/core/execution_model/executor_details/launch_config.h>
 #include <fused_kernel/algorithms/basic_ops/memory_operations.h>
 #include <fused_kernel/algorithms/basic_ops/set.h>
 #include <fused_kernel/core/execution_model/stream.h>
@@ -28,19 +29,6 @@
 #endif
 
 namespace fk {
-
-#if defined(__NVCC__)
-    struct CtxDim3 {
-        uint x;
-        uint y;
-        uint z;
-        constexpr CtxDim3(const dim3& dims) : x(dims.x), y(dims.y), z(dims.z) {}
-        constexpr CtxDim3() : x(1), y(1), z(1) {}
-        constexpr CtxDim3(const uint& x) : x(x), y(1), z(1) {}
-        constexpr CtxDim3(const uint& x, const uint& y) : x(x), y(y), z(1) {}
-        constexpr CtxDim3(const uint& x, const uint& y, const uint& z) : x(x), y(y), z(z) {}
-    };
-#endif
 
     template <typename Child>
     struct BaseExecutor {
@@ -189,75 +177,6 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
     };
 
 #if defined(__NVCC__)
-    struct ComputeBestSolutionBase {
-        FK_HOST_FUSE uint computeDiscardedThreads(const uint width, const uint height, const uint blockDimx, const uint blockDimy) {
-            const uint modX = width % blockDimx;
-            const uint modY = height % blockDimy;
-            const uint th_disabled_in_X = modX == 0 ? 0 : blockDimx - modX;
-            const uint th_disabled_in_Y = modY == 0 ? 0 : blockDimy - modY;
-            return (th_disabled_in_X * (modY == 0 ? height : (height + blockDimy)) + th_disabled_in_Y * width);
-        }
-    };
-
-    template <uint bxS_t, uint byS_t>
-    struct computeBestSolution {};
-
-    template <uint bxS_t>
-    struct computeBestSolution<bxS_t, 0> final : public ComputeBestSolutionBase {
-        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
-            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[bxS_t], blockDimY[0][bxS_t]);
-            if (minDiscardedThreads > currentDiscardedThreads) {
-                minDiscardedThreads = currentDiscardedThreads;
-                bxS = bxS_t;
-                byS = 0;
-                if (minDiscardedThreads == 0) return;
-            }
-            computeBestSolution<bxS_t, 1>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
-        }
-    };
-
-    template <uint bxS_t>
-    struct computeBestSolution<bxS_t, 1> final : public ComputeBestSolutionBase {
-        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
-            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[bxS_t], blockDimY[1][bxS_t]);
-            if (minDiscardedThreads > currentDiscardedThreads) {
-                minDiscardedThreads = currentDiscardedThreads;
-                bxS = bxS_t;
-                byS = 1;
-                if constexpr (bxS_t == 3) return;
-                if (minDiscardedThreads == 0) return;
-            }
-            computeBestSolution<bxS_t + 1, 0>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
-        }
-    };
-
-    template <>
-    struct computeBestSolution<3, 1> final : public ComputeBestSolutionBase {
-        FK_HOST_FUSE void exec(const uint width, const uint height, uint& bxS, uint& byS, uint& minDiscardedThreads, const uint(&blockDimX)[4], const uint(&blockDimY)[2][4]) {
-            const uint currentDiscardedThreads = computeDiscardedThreads(width, height, blockDimX[3], blockDimY[1][3]);
-            if (minDiscardedThreads > currentDiscardedThreads) {
-                minDiscardedThreads = currentDiscardedThreads;
-                bxS = 3;
-                byS = 1;
-            }
-        }
-    };
-
-    FK_HOST_CNST CtxDim3 getDefaultBlockSize(const uint& width, const uint& height) {
-        constexpr uint blockDimX[4] = { 32, 64, 128, 256 };  // Possible block sizes in the x axis
-        constexpr uint blockDimY[2][4] = { { 8,  4,   2,   1},
-                                          { 6,  3,   3,   2} };  // Possible block sizes in the y axis according to blockDim.x
-
-        uint minDiscardedThreads = UINT_MAX;
-        uint bxS = 0; // from 0 to 3
-        uint byS = 0; // from 0 to 1
-
-        computeBestSolution<0, 0>::exec(width, height, bxS, byS, minDiscardedThreads, blockDimX, blockDimY);
-
-        return CtxDim3(blockDimX[bxS], blockDimY[byS][bxS]);
-    }
-#endif
-#if defined(__NVCC__)
     template <enum TF TFEN>
     struct Executor<TransformDPP<ParArch::GPU_NVIDIA, TFEN>> {
     private:
@@ -359,6 +278,63 @@ FK_HOST_FUSE void executeOperations(const std::array<Ptr2D<I>, Batch>& input, co
             executeOperations_helper(stream, iOpSequences...);
         }
     };
+#endif
+
+    // ===============================================================================
+    // Generic InstantiableDPP execution path
+    // ===============================================================================
+    // ONE executor path for every DPP that conforms to the InstantiableDPP protocol
+    // (see instantiable_dpp.h): no per-DPP Executor specialization and no per-DPP
+    // __global__ kernel are needed.
+
+    // hasGetLaunchConfig trait: detects the getLaunchConfig(details, iOps...) hook
+    template <typename DPP, typename Details, typename Enabler, typename... IOps>
+    struct HasGetLaunchConfig_ : std::false_type {};
+    template <typename DPP, typename Details, typename... IOps>
+    struct HasGetLaunchConfig_<DPP, Details,
+        std::void_t<decltype(DPP::getLaunchConfig(std::declval<const Details&>(), std::declval<const IOps&>()...))>,
+        IOps...> : std::true_type {};
+    template <typename DPP, typename Details, typename... IOps>
+    constexpr bool hasGetLaunchConfig_v = HasGetLaunchConfig_<DPP, Details, void, IOps...>::value;
+
+    /**
+     * @brief execute: executes an InstantiableDPP (built with DPP::build(iOps...)) on the
+     * CPU backend. The DPP's exec() implements the whole sequential loop.
+     */
+    template <typename DPP, typename DPPDetails, typename... IOps>
+    inline void execute(Stream_<ParArch::CPU>& stream, const InstantiableDPP<DPP, DPPDetails, IOps...>& iDPP) {
+        static_assert(DPP::PAR_ARCH == ParArch::CPU,
+            "fk::execute: the InstantiableDPP was built for a different backend than the Stream_<ParArch::CPU> provided.");
+        static_assert(dppIOContractSatisfied<DPP, IOps...>(),
+            "fk::execute: the InstantiableDPP does not conform to the IO contract (IO_SPEC) of its DPP.");
+        apply([&](const auto&... iOps) {
+            DPP::exec(iDPP.details, iOps...);
+        }, iDPP.iOps);
+        (void)stream; // CPU streams are synchronous
+    }
+
+#if defined(__NVCC__)
+    /**
+     * @brief execute: executes an InstantiableDPP (built with DPP::build(iOps...)) on the
+     * GPU_NVIDIA backend, launching the generic launchInstantiableDPP_Kernel with the
+     * grid/block configuration provided by the DPP's getLaunchConfig().
+     */
+    template <typename DPP, typename DPPDetails, typename... IOps>
+    inline void execute(Stream_<ParArch::GPU_NVIDIA>& stream, const InstantiableDPP<DPP, DPPDetails, IOps...>& iDPP) {
+        static_assert(DPP::PAR_ARCH == ParArch::GPU_NVIDIA,
+            "fk::execute: the InstantiableDPP was built for a different backend than the Stream_<ParArch::GPU_NVIDIA> provided.");
+        static_assert(dppIOContractSatisfied<DPP, IOps...>(),
+            "fk::execute: the InstantiableDPP does not conform to the IO contract (IO_SPEC) of its DPP.");
+        static_assert(hasGetLaunchConfig_v<DPP, DPPDetails, IOps...>,
+            "fk::execute: a GPU DPP must implement 'FK_HOST_FUSE DPPLaunchConfig getLaunchConfig(const Details&, const IOps&...)'.");
+        apply([&](const auto&... iOps) {
+            const DPPLaunchConfig config = DPP::getLaunchConfig(iDPP.details, iOps...);
+            const dim3 grid{ config.grid.x, config.grid.y, config.grid.z };
+            const dim3 block{ config.block.x, config.block.y, config.block.z };
+            launchInstantiableDPP_Kernel<DPP><<<grid, block, 0, stream.getCUDAStream()>>>(iDPP.details, iOps...);
+            gpuErrchk(cudaGetLastError());
+        }, iDPP.iOps);
+    }
 #endif
 } // namespace fk
 

--- a/include/fused_kernel/core/execution_model/instantiable_dpp.h
+++ b/include/fused_kernel/core/execution_model/instantiable_dpp.h
@@ -1,0 +1,317 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#ifndef FK_INSTANTIABLE_DPP_H
+#define FK_INSTANTIABLE_DPP_H
+
+/* InstantiableDPP: Data Parallel Patterns as instantiable values.
+ *
+ * Mirrors the InstantiableOperation (IOp) design: an Operation is a stateless
+ * static struct and Op::build(params) produces an IOp (Operation type + runtime
+ * OperationData). Likewise, a DPP is a stateless static struct and
+ * DPP::build(iOps...) produces an InstantiableDPP (DPP type + runtime details +
+ * the IOps it will execute). Types define the kernel; build() values are runtime
+ * parameters.
+ *
+ * Every DPP declares its IO API (what goes in and what comes out) as a
+ * compile-time contract: a `static constexpr DPPIOSpec IO_SPEC` member stating
+ * how many input (Read/ReadBack) IOps it consumes, how many output (Write) IOps
+ * it produces into, whether it accepts a chain of compute IOps in between, and
+ * whether it consumes whole InstantiableOperationSequences (one per divergent
+ * branch) instead of loose IOps. Building or executing an InstantiableDPP
+ * static_asserts conformance with that contract.
+ *
+ * A DPP that conforms to this model needs NO hand-written Executor
+ * specialization and NO dedicated __global__ kernel: the generic execution path
+ * in executors.h (fk::execute(stream, instantiableDPP)) launches it, provided
+ * the DPP implements:
+ *   - static constexpr ParArch PAR_ARCH             : the backend it implements.
+ *   - static constexpr DPPIOSpec IO_SPEC            : the IO contract.
+ *   - build_details(iOps...)                        : runtime, non-data parameters (may return an empty struct).
+ *   - exec(details, iOps...)                        : the pattern itself (device code on GPU backends,
+ *                                                     a plain sequential loop on the CPU backend).
+ *   - getLaunchConfig(details, iOps...) (GPU only)  : grid/block sizes as a DPPLaunchConfig.
+ */
+
+#include <fused_kernel/core/utils/utils.h>
+#include <fused_kernel/core/utils/type_lists.h>
+#include <fused_kernel/core/data/tuple.h>
+#include <fused_kernel/core/execution_model/parallel_architectures.h>
+#include <fused_kernel/core/execution_model/operation_model/operation_model.h>
+#include <fused_kernel/core/execution_model/executor_details/launch_config.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace fk {
+
+    /**
+     * @brief DPPIOSpec: the compile-time IO contract of a Data Parallel Pattern.
+     * It formally answers "what goes into and what comes out of this DPP".
+     * All data enters and leaves a DPP through IOps: inputs through complete
+     * Read/ReadBack IOps and outputs through Write IOps. Never through raw pointers.
+     */
+    struct DPPIOSpec {
+        /** Number of leading input IOps. They must be complete Read or ReadBack IOps. */
+        size_t inputIOps;
+        /** Number of trailing output IOps. They must be Write IOps. */
+        size_t outputIOps;
+        /** Whether a chain of compute (Unary/Binary/Ternary) or MidWrite IOps is
+         *  accepted between the input and output IOps. */
+        bool acceptsComputeIOps;
+        /** Whether the DPP consumes InstantiableOperationSequences (one per divergent
+         *  branch, see buildOperationSequence()) instead of loose IOps. In that case
+         *  inputIOps/outputIOps/acceptsComputeIOps apply to EACH sequence. */
+        bool argsAreIOpSequences;
+    };
+
+    // hasDPPIOSpec trait: detects whether a DPP declares its IO contract
+    template <typename T, typename = void>
+    struct HasDPPIOSpec : std::false_type {};
+    template <typename T>
+    struct HasDPPIOSpec<T, std::void_t<decltype(T::IO_SPEC)>>
+        : std::bool_constant<std::is_same_v<std::decay_t<decltype(T::IO_SPEC)>, DPPIOSpec>> {};
+    template <typename T>
+    constexpr bool hasDPPIOSpec_v = HasDPPIOSpec<T>::value;
+
+    // isIOpSequence trait
+    template <typename T>
+    struct IsIOpSequence : std::false_type {};
+    template <typename... IOps>
+    struct IsIOpSequence<InstantiableOperationSequence<IOps...>> : std::true_type {};
+    template <typename T>
+    constexpr bool isIOpSequence_v = IsIOpSequence<std::decay_t<T>>::value;
+
+    namespace dpp_contract_detail {
+        template <typename IOpsTL, size_t OFFSET, typename IdxSeq>
+        struct AllSlotsAreInputs;
+        template <typename IOpsTL, size_t OFFSET, size_t... Idx>
+        struct AllSlotsAreInputs<IOpsTL, OFFSET, std::index_sequence<Idx...>> {
+            static constexpr bool value = (isAnyCompleteReadType<TypeAt_t<OFFSET + Idx, IOpsTL>> && ...);
+        };
+
+        template <typename IOpsTL, size_t OFFSET, typename IdxSeq>
+        struct AllSlotsAreCompute;
+        template <typename IOpsTL, size_t OFFSET, size_t... Idx>
+        struct AllSlotsAreCompute<IOpsTL, OFFSET, std::index_sequence<Idx...>> {
+            static constexpr bool value = ((isComputeType<TypeAt_t<OFFSET + Idx, IOpsTL>> ||
+                                            opIs<MidWriteType, TypeAt_t<OFFSET + Idx, IOpsTL>>) && ...);
+        };
+
+        template <typename IOpsTL, size_t OFFSET, typename IdxSeq>
+        struct AllSlotsAreOutputs;
+        template <typename IOpsTL, size_t OFFSET, size_t... Idx>
+        struct AllSlotsAreOutputs<IOpsTL, OFFSET, std::index_sequence<Idx...>> {
+            static constexpr bool value = (opIs<WriteType, TypeAt_t<OFFSET + Idx, IOpsTL>> && ...);
+        };
+    } // namespace dpp_contract_detail
+
+    /**
+     * @brief IOPackConformance: checks a pack of IOps against the counts and kinds
+     * required by a DPPIOSpec. Exposes granular flags so that contract violations
+     * can be reported with precise static_assert messages.
+     */
+    template <size_t INPUT_IOPS, size_t OUTPUT_IOPS, bool ACCEPTS_COMPUTE, typename... IOps>
+    struct IOPackConformance {
+    private:
+        using IOpsTL = TypeList<IOps...>;
+        static constexpr size_t N = sizeof...(IOps);
+    public:
+        static constexpr bool ENOUGH_IOPS = N >= INPUT_IOPS + OUTPUT_IOPS;
+        static constexpr size_t COMPUTE_IOPS = ENOUGH_IOPS ? (N - INPUT_IOPS - OUTPUT_IOPS) : 0;
+        static constexpr bool COMPUTE_CHAIN_OK = ACCEPTS_COMPUTE || (COMPUTE_IOPS == 0);
+        static constexpr bool INPUTS_ARE_READS =
+            std::conditional_t<ENOUGH_IOPS,
+                dpp_contract_detail::AllSlotsAreInputs<IOpsTL, 0, std::make_index_sequence<INPUT_IOPS>>,
+                std::false_type>::value;
+        static constexpr bool MIDDLE_ARE_COMPUTE =
+            std::conditional_t<ENOUGH_IOPS,
+                dpp_contract_detail::AllSlotsAreCompute<IOpsTL, INPUT_IOPS, std::make_index_sequence<COMPUTE_IOPS>>,
+                std::false_type>::value;
+        static constexpr bool OUTPUTS_ARE_WRITES =
+            std::conditional_t<ENOUGH_IOPS,
+                dpp_contract_detail::AllSlotsAreOutputs<IOpsTL, INPUT_IOPS + COMPUTE_IOPS, std::make_index_sequence<OUTPUT_IOPS>>,
+                std::false_type>::value;
+        static constexpr bool CONFORMS =
+            ENOUGH_IOPS && COMPUTE_CHAIN_OK && INPUTS_ARE_READS && MIDDLE_ARE_COMPUTE && OUTPUTS_ARE_WRITES;
+    };
+
+    // Per-sequence conformance (for DPPs with IO_SPEC.argsAreIOpSequences == true)
+    template <typename DPP, typename Seq>
+    struct IOpSequenceConformance;
+    template <typename DPP, typename... IOps>
+    struct IOpSequenceConformance<DPP, InstantiableOperationSequence<IOps...>> {
+        using Check = IOPackConformance<DPP::IO_SPEC.inputIOps, DPP::IO_SPEC.outputIOps,
+                                        DPP::IO_SPEC.acceptsComputeIOps, IOps...>;
+    };
+
+    /**
+     * @brief dppIOContractSatisfied: soft (non-asserting) check of a pack of build/exec
+     * arguments against the IO contract of DPP. Usable in static_asserts and SFINAE.
+     */
+    template <typename DPP, typename... Args>
+    FK_HOST_DEVICE_CNST bool dppIOContractSatisfied() {
+        if constexpr (!hasDPPIOSpec_v<DPP>) {
+            return false;
+        } else if constexpr (DPP::IO_SPEC.argsAreIOpSequences) {
+            if constexpr (sizeof...(Args) == 0) {
+                return false;
+            } else if constexpr (!(isIOpSequence_v<Args> && ...)) {
+                return false;
+            } else {
+                return (IOpSequenceConformance<DPP, std::decay_t<Args>>::Check::CONFORMS && ...);
+            }
+        } else {
+            return IOPackConformance<DPP::IO_SPEC.inputIOps, DPP::IO_SPEC.outputIOps,
+                                     DPP::IO_SPEC.acceptsComputeIOps, std::decay_t<Args>...>::CONFORMS;
+        }
+    }
+
+    namespace dpp_contract_detail {
+        template <typename DPP, typename... IOps>
+        FK_HOST_DEVICE_CNST void assertIOPackContract() {
+            using Check = IOPackConformance<DPP::IO_SPEC.inputIOps, DPP::IO_SPEC.outputIOps,
+                                            DPP::IO_SPEC.acceptsComputeIOps, IOps...>;
+            static_assert(Check::ENOUGH_IOPS,
+                "DPP IO contract violation: not enough IOps. The DPP consumes IO_SPEC.inputIOps Read/ReadBack IOps "
+                "and produces into IO_SPEC.outputIOps Write IOps.");
+            if constexpr (Check::ENOUGH_IOPS) {
+                static_assert(Check::INPUTS_ARE_READS,
+                    "DPP IO contract violation: the first IO_SPEC.inputIOps IOps must be complete Read or ReadBack "
+                    "IOps (the data going INTO the DPP).");
+                static_assert(Check::COMPUTE_CHAIN_OK,
+                    "DPP IO contract violation: this DPP does not accept compute IOps between its input (Read/ReadBack) "
+                    "and output (Write) IOps. Fuse them into the input IOp instead (readIOp.then(computeIOp...)).");
+                static_assert(Check::MIDDLE_ARE_COMPUTE,
+                    "DPP IO contract violation: the IOps between the inputs and the outputs must be compute "
+                    "(Unary/Binary/Ternary) or MidWrite IOps.");
+                static_assert(Check::OUTPUTS_ARE_WRITES,
+                    "DPP IO contract violation: the last IO_SPEC.outputIOps IOps must be Write IOps (the data coming "
+                    "OUT of the DPP).");
+            }
+        }
+
+        template <typename DPP, typename Seq>
+        FK_HOST_DEVICE_CNST void assertIOpSequenceContract() {
+            static_assert(IOpSequenceConformance<DPP, Seq>::Check::CONFORMS,
+                "DPP IO contract violation: an InstantiableOperationSequence does not conform to the DPP IO contract. "
+                "Each sequence must contain IO_SPEC.inputIOps complete Read/ReadBack IOps, then compute IOps (if "
+                "IO_SPEC.acceptsComputeIOps), then IO_SPEC.outputIOps Write IOps.");
+        }
+    } // namespace dpp_contract_detail
+
+    /**
+     * @brief assertDPPIOContract: hard (static_assert) check of a pack of build/exec
+     * arguments against the IO contract of DPP, with granular error messages.
+     */
+    template <typename DPP, typename... Args>
+    FK_HOST_DEVICE_CNST void assertDPPIOContract() {
+        static_assert(hasDPPIOSpec_v<DPP>,
+            "InstantiableDPP: the DPP does not declare its IO contract. "
+            "Add 'static constexpr DPPIOSpec IO_SPEC{ inputIOps, outputIOps, acceptsComputeIOps, argsAreIOpSequences };' "
+            "to the DPP struct.");
+        if constexpr (hasDPPIOSpec_v<DPP>) {
+            if constexpr (DPP::IO_SPEC.argsAreIOpSequences) {
+                static_assert(sizeof...(Args) > 0,
+                    "DPP IO contract violation: this DPP requires at least one InstantiableOperationSequence "
+                    "(see buildOperationSequence()).");
+                static_assert((isIOpSequence_v<Args> && ...),
+                    "DPP IO contract violation: this DPP consumes InstantiableOperationSequences "
+                    "(see buildOperationSequence()), not loose IOps.");
+                if constexpr (sizeof...(Args) > 0 && (isIOpSequence_v<Args> && ...)) {
+                    ((void)dpp_contract_detail::assertIOpSequenceContract<DPP, std::decay_t<Args>>(), ...);
+                }
+            } else {
+                static_assert((!isIOpSequence_v<Args> && ...),
+                    "DPP IO contract violation: this DPP consumes loose IOps, not InstantiableOperationSequences. "
+                    "Pass the IOps directly instead of wrapping them with buildOperationSequence().");
+                if constexpr ((!isIOpSequence_v<Args> && ...)) {
+                    dpp_contract_detail::assertIOPackContract<DPP, std::decay_t<Args>...>();
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief InstantiableDPP: a Data Parallel Pattern bundled with the runtime values
+     * it needs in order to be executed: the DPP details (runtime parameters not related
+     * to the data being processed) plus the IOps (or IOpSequences) that read, transform
+     * and write the data. Produced by DPP::build(iOps...). Execute it with
+     * fk::execute(stream, instantiableDPP) (see executors.h / fused_kernel.h).
+     */
+    template <typename DPPType, typename DetailsType, typename... IOps>
+    struct InstantiableDPP {
+        using DPP = DPPType;
+        using Details = DetailsType;
+        static constexpr ParArch PAR_ARCH = DPPType::PAR_ARCH;
+        Details details;
+        Tuple<IOps...> iOps;
+    };
+
+    // isInstantiableDPP trait
+    template <typename T>
+    struct IsInstantiableDPP : std::false_type {};
+    template <typename DPP, typename Details, typename... IOps>
+    struct IsInstantiableDPP<InstantiableDPP<DPP, Details, IOps...>> : std::true_type {};
+    template <typename T>
+    constexpr bool isInstantiableDPP_v = IsInstantiableDPP<std::decay_t<T>>::value;
+
+    namespace dpp_contract_detail {
+        // Fuses the ReadBack stack (Backwards Vertical Fusion) of an IOpSequence,
+        // returning a new IOpSequence in canonical (fused) form.
+        template <typename... IOps>
+        FK_HOST_CNST auto fuseBackIOpSequence(const InstantiableOperationSequence<IOps...>& iOpSequence) {
+            return buildOperationSequence_tup(
+                apply([](const auto&... iOps) {
+                    return BackFuser::fuse_back(iOps...);
+                }, iOpSequence.iOps));
+        }
+
+        template <typename DPP, typename... Args>
+        FK_HOST_CNST auto buildInstantiableDPPFromCanonical(const Args&... args) {
+            assertDPPIOContract<DPP, Args...>();
+            if constexpr (dppIOContractSatisfied<DPP, Args...>()) {
+                const auto details = DPP::build_details(args...);
+                using Details = std::decay_t<decltype(details)>;
+                return InstantiableDPP<DPP, Details, Args...>{ details, { args... } };
+            } else {
+                // The static_asserts above already failed: return a dummy to avoid error cascades.
+                return NullType{};
+            }
+        }
+    } // namespace dpp_contract_detail
+
+    /**
+     * @brief buildInstantiableDPP: generic implementation of DPP::build(iOps...).
+     * Brings the IOps to canonical form (fusing ReadBack stacks via Backwards Vertical
+     * Fusion), enforces the DPP IO contract at compile time, builds the DPP details and
+     * returns the resulting InstantiableDPP value.
+     */
+    template <typename DPP, typename... Args>
+    FK_HOST_CNST auto buildInstantiableDPP(const Args&... args) {
+        constexpr bool ARGS_ARE_SEQUENCES = (sizeof...(Args) > 0) && (isIOpSequence_v<Args> && ...);
+        if constexpr (ARGS_ARE_SEQUENCES) {
+            return dpp_contract_detail::buildInstantiableDPPFromCanonical<DPP>(
+                dpp_contract_detail::fuseBackIOpSequence(args)...);
+        } else {
+            const auto fusedIOps = BackFuser::fuse_back(args...);
+            return apply([](const auto&... fused) {
+                return dpp_contract_detail::buildInstantiableDPPFromCanonical<DPP>(fused...);
+            }, fusedIOps);
+        }
+    }
+
+} // namespace fk
+
+#endif // FK_INSTANTIABLE_DPP_H

--- a/tests/examples/inlining_and_LDL_STL.h
+++ b/tests/examples/inlining_and_LDL_STL.h
@@ -190,8 +190,11 @@ struct InstantiableSimpleTransformDPPReference {
     static constexpr ParArch PAR_ARCH = ParArch::GPU_NVIDIA;
 };
 
+// Local prototype that predates (and is superseded by) fk::InstantiableDPP
+// (core/execution_model/instantiable_dpp.h). Renamed to LocalInstantiableDPP to
+// avoid ambiguity with the fk:: one (this TU does `using namespace fk`).
 template <typename DPP_, typename... Operations>
-struct InstantiableDPP {
+struct LocalInstantiableDPP {
     using DPP = DPP_;
     using OperationsTuple = Tuple<Operations...>;
     OperationsTuple ops;
@@ -200,12 +203,12 @@ struct InstantiableDPP {
 struct SimpleTransformDPPReferenceBuilder {
     template <typename... IOps>
     FK_HOST_FUSE auto build(const IOps&... iops) {
-        return InstantiableDPP<SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>, IOps...>{make_tuple(iops...)};
+        return LocalInstantiableDPP<SimpleTransformDPPReferenceFoldExpr<ParArch::GPU_NVIDIA>, IOps...>{make_tuple(iops...)};
     }
 };
 
 template <typename IDPP>
-__global__ void launchInstantiableDPP_Kernel(const __grid_constant__ IDPP idpp) {
+__global__ void launchLocalInstantiableDPP_Kernel(const __grid_constant__ IDPP idpp) {
     apply_d([](auto &&...args) { return std::decay_t<IDPP>::DPP::exec(std::forward<decltype(args)>(args)...); },
               idpp.ops);
 }
@@ -333,7 +336,7 @@ struct Executor<InstantiableSimpleTransformDPPReference> {
         const dim3 block{ctx_block.x, ctx_block.y, 1};
         const dim3 grid{static_cast<uint>(ceil(activeThreads.x / static_cast<float>(block.x))),
                         static_cast<uint>(ceil(activeThreads.y / static_cast<float>(block.y))), activeThreads.z};
-        launchInstantiableDPP_Kernel<<<grid, block, 0, stream>>>(idpp);
+        launchLocalInstantiableDPP_Kernel<<<grid, block, 0, stream>>>(idpp);
         gpuErrchk(cudaGetLastError());
     }
 

--- a/utests/algorithm/reductions/utest_row_reduce_dpp.h
+++ b/utests/algorithm/reductions/utest_row_reduce_dpp.h
@@ -1,0 +1,175 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Tests RowReduceDPP: a DPP defined purely through the InstantiableDPP protocol
+// (IO_SPEC + build_details + exec + getLaunchConfig), with both CPU and GPU
+// implementations, executed through the generic fk::execute path. It proves that a
+// new conforming DPP needs no Executor specialization and no dedicated __global__
+// kernel. This test compiles and runs on both backends.
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/algorithms/reductions/row_reduce.h>
+#include <fused_kernel/fused_kernel.h>
+#include <iostream>
+#include <stdexcept>
+
+using namespace fk;
+
+// ============================================================================
+// Compile-time IO contract checks (DPPIOSpec)
+// ============================================================================
+namespace row_reduce_contract_checks {
+    constexpr RawPtr<ND::_2D, int> dummyInput{ nullptr, { 32, 8, 0 } };
+    constexpr RawPtr<ND::_1D, int> dummyOutput{ nullptr, { 8, 0 } };
+    constexpr auto readIOp = PerThreadRead<ND::_2D, int>::build({ dummyInput });
+    constexpr auto mulIOp = Mul<int>::build(2);
+    constexpr auto writeIOp = PerThreadWrite<ND::_1D, int>::build({ dummyOutput });
+
+    using ReadT = std::decay_t<decltype(readIOp)>;
+    using MulT = std::decay_t<decltype(mulIOp)>;
+    using WriteT = std::decay_t<decltype(writeIOp)>;
+    using RowSum = RowReduceDPP<Add<int>>;
+
+    static_assert(hasDPPIOSpec_v<RowSum>, "RowReduceDPP must declare its IO contract (IO_SPEC)");
+    static_assert(dppIOContractSatisfied<RowSum, ReadT, WriteT>(), "read + write must conform");
+    // RowReduceDPP does NOT accept a compute IOp chain: per-element preprocessing has
+    // to be fused into the input IOp (readIOp.then(...)) instead.
+    static_assert(!dppIOContractSatisfied<RowSum, ReadT, MulT, WriteT>(),
+                  "read + compute + write must NOT conform");
+    static_assert(!dppIOContractSatisfied<RowSum, ReadT>(), "missing Write must not conform");
+    static_assert(!dppIOContractSatisfied<RowSum, MulT, WriteT>(), "missing Read must not conform");
+
+    // Compile-fail documentation (the repo has no compile-fail test infra). If
+    // uncommented, this line must fail to compile with the quoted message:
+    //
+    // constexpr auto bad = RowSum::build(readIOp, mulIOp, writeIOp);
+    //   error: static assertion failed: DPP IO contract violation: this DPP does not accept compute
+    //   IOps between its input (Read/ReadBack) and output (Write) IOps. Fuse them into the input
+    //   IOp instead (readIOp.then(computeIOp...)).
+} // namespace row_reduce_contract_checks
+
+template <int WIDTH, int HEIGHT>
+bool testRowSum(Stream& stream) {
+    Ptr2D<int> input(WIDTH, HEIGHT);
+    Ptr1D<int> output(HEIGHT);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            input.at(x, y) = (x + y) % 7 + 1;
+        }
+    }
+    input.upload(stream);
+
+    const auto iDPP = RowReduceDPP<Add<int>>::build(PerThreadRead<ND::_2D, int>::build(input),
+                                                    PerThreadWrite<ND::_1D, int>::build(output));
+    static_assert(isInstantiableDPP_v<decltype(iDPP)>, "build() must return an InstantiableDPP");
+    execute(stream, iDPP);
+
+    output.download(stream);
+    stream.sync();
+
+    bool correct{ true };
+    for (int y = 0; y < HEIGHT; ++y) {
+        int expected = 0;
+        for (int x = 0; x < WIDTH; ++x) {
+            expected += (x + y) % 7 + 1;
+        }
+        if (output.at(Point{ y }) != expected) {
+            std::cout << "testRowSum<" << WIDTH << ", " << HEIGHT << "> mismatch at row " << y
+                      << ": got " << output.at(Point{ y }) << ", expected " << expected << std::endl;
+            correct = false;
+        }
+    }
+    return correct;
+}
+
+bool testRowReduceRejects3DInput() {
+    // RowReduceDPP reduces 2D inputs only: both backends fix the Point z coordinate
+    // to 0, so a batched/3D input would silently reduce only plane z == 0. build()
+    // must fail loudly instead of accepting it.
+    constexpr int WIDTH = 16;
+    constexpr int HEIGHT = 8;
+    constexpr int PLANES = 2;
+
+    Tensor<int> input(WIDTH, HEIGHT, PLANES);
+    Ptr1D<int> output(HEIGHT);
+
+    try {
+        const auto iDPP = RowReduceDPP<Add<int>>::build(TensorRead<int>::build(input),
+                                                        PerThreadWrite<ND::_1D, int>::build(output));
+        (void)iDPP;
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    std::cout << "testRowReduceRejects3DInput: build() did not reject a 3D (batched) input" << std::endl;
+    return false;
+}
+
+bool testRowSumFusedPrologue(Stream& stream) {
+    // Per-element preprocessing is fused into the input Read IOp: the compute chain
+    // runs in-register at load time, on every element, before the reduction.
+    constexpr int WIDTH = 129;
+    constexpr int HEIGHT = 9;
+
+    Ptr2D<int> input(WIDTH, HEIGHT);
+    Ptr1D<int> output(HEIGHT);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            input.at(x, y) = x % 5;
+        }
+    }
+    input.upload(stream);
+
+    const auto fusedReadIOp = PerThreadRead<ND::_2D, int>::build(input).then(Mul<int>::build(3));
+    const auto iDPP = RowReduceDPP<Add<int>>::build(fusedReadIOp, PerThreadWrite<ND::_1D, int>::build(output));
+    execute(stream, iDPP);
+
+    output.download(stream);
+    stream.sync();
+
+    bool correct{ true };
+    for (int y = 0; y < HEIGHT; ++y) {
+        int expected = 0;
+        for (int x = 0; x < WIDTH; ++x) {
+            expected += (x % 5) * 3;
+        }
+        if (output.at(Point{ y }) != expected) {
+            std::cout << "testRowSumFusedPrologue mismatch at row " << y << ": got "
+                      << output.at(Point{ y }) << ", expected " << expected << std::endl;
+            correct = false;
+        }
+    }
+    return correct;
+}
+
+int launch() {
+    Stream stream;
+
+    // Integer ReduceOp on purpose: the reduction order is backend-dependent (sequential
+    // left fold on CPU, strided per-lane accumulation + tree reduction on GPU), so the
+    // ReduceOp must be associative and commutative, and floating-point results may
+    // differ between backends by rounding (reassociation).
+    bool correct{ true };
+    correct &= testRowSum<7, 5>(stream);     // narrower than one block
+    correct &= testRowSum<256, 13>(stream);  // exactly one block wide (default BLOCK_SIZE)
+    correct &= testRowSum<300, 17>(stream);  // wider than one block: strided accumulation
+    correct &= testRowReduceRejects3DInput();
+    correct &= testRowSumFusedPrologue(stream);
+
+    return correct ? 0 : -1;
+}

--- a/utests/core/execution_model/utest_instantiable_divergent_dpp.h
+++ b/utests/core/execution_model/utest_instantiable_divergent_dpp.h
@@ -1,0 +1,117 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Tests DivergentBatchTransformDPP through the InstantiableDPP path:
+// DPP::build(iOpSequences...) + fk::execute(stream, instantiableDPP), checking the
+// per-sequence IO contract and comparing results against the legacy Executor path.
+// The Divergent Horizontal Fusion DPP is GPU-only (its CPU backend is not implemented).
+
+#define __ONLY_CU__
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/basic_ops/arithmetic.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/fused_kernel.h>
+#include <iostream>
+
+using namespace fk;
+
+struct PlaneSelector {
+    FK_HOST_DEVICE_FUSE uint at(const uint& index) { return index == 0 ? 0u : 1u; }
+};
+
+int launch() {
+    Stream stream;
+
+    constexpr int WIDTH = 64;
+    constexpr int HEIGHT = 32;
+
+    Ptr2D<float> imgA(WIDTH, HEIGHT);
+    Ptr2D<float> imgB(WIDTH, HEIGHT);
+    Tensor<float> outputNew(WIDTH, HEIGHT, 2);
+    Tensor<float> outputLegacy(WIDTH, HEIGHT, 2);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            imgA.at(x, y) = static_cast<float>(x + y);
+            imgB.at(x, y) = static_cast<float>(x * y);
+        }
+    }
+    imgA.upload(stream);
+    imgB.upload(stream);
+
+    using DivergentDPP = DivergentBatchTransformDPP<ParArch::GPU_NVIDIA, PlaneSelector>;
+
+    // Contract: the divergent DPP consumes IOpSequences (one per divergent branch),
+    // each holding 1 Read/ReadBack IOp, an optional compute chain, and 1 Write IOp.
+    {
+        using ReadT = decltype(PerThreadRead<ND::_2D, float>::build(imgA));
+        using MulT = decltype(Mul<float>::build(2.f));
+        using WriteT = decltype(TensorWrite<float>::build(outputNew));
+        using SeqT = InstantiableOperationSequence<ReadT, MulT, WriteT>;
+        using BadSeqT = InstantiableOperationSequence<MulT, WriteT>;
+        static_assert(DivergentDPP::IO_SPEC.argsAreIOpSequences, "Divergent DPP consumes IOpSequences");
+        static_assert(dppIOContractSatisfied<DivergentDPP, SeqT, SeqT>(), "conforming sequences must pass");
+        static_assert(!dppIOContractSatisfied<DivergentDPP, SeqT, BadSeqT>(), "a sequence without a Read must fail");
+        static_assert(!dppIOContractSatisfied<DivergentDPP>(), "at least one sequence is required");
+        static_assert(!dppIOContractSatisfied<DivergentDPP, ReadT, WriteT>(),
+                      "loose IOps must fail: the divergent DPP consumes IOpSequences");
+        // Compile-fail documentation: if uncommented, must fail with the quoted message:
+        // DivergentDPP::build(PerThreadRead<ND::_2D, float>::build(imgA), Mul<float>::build(2.f),
+        //                     TensorWrite<float>::build(outputNew));
+        //   error: static assertion failed: DPP IO contract violation: this DPP consumes
+        //   InstantiableOperationSequences (see buildOperationSequence()), not loose IOps.
+    }
+
+    const auto seq1New = buildOperationSequence(PerThreadRead<ND::_2D, float>::build(imgA),
+                                                Mul<float>::build(2.0f),
+                                                TensorWrite<float>::build(outputNew));
+    const auto seq2New = buildOperationSequence(PerThreadRead<ND::_2D, float>::build(imgB),
+                                                Add<float>::build(100.0f),
+                                                TensorWrite<float>::build(outputNew));
+
+    const auto iDPP = DivergentDPP::build(seq1New, seq2New);
+    static_assert(isInstantiableDPP_v<decltype(iDPP)>, "build() must return an InstantiableDPP");
+    execute(stream, iDPP);
+
+    const auto seq1Legacy = buildOperationSequence(PerThreadRead<ND::_2D, float>::build(imgA),
+                                                   Mul<float>::build(2.0f),
+                                                   TensorWrite<float>::build(outputLegacy));
+    const auto seq2Legacy = buildOperationSequence(PerThreadRead<ND::_2D, float>::build(imgB),
+                                                   Add<float>::build(100.0f),
+                                                   TensorWrite<float>::build(outputLegacy));
+    Executor<DivergentDPP>::executeOperations(stream, seq1Legacy, seq2Legacy);
+
+    outputNew.download(stream);
+    outputLegacy.download(stream);
+    stream.sync();
+
+    bool correct{ true };
+    for (int z = 0; z < 2; ++z) {
+        for (int y = 0; y < HEIGHT; ++y) {
+            for (int x = 0; x < WIDTH; ++x) {
+                const float expected = z == 0 ? imgA.at(x, y) * 2.f : imgB.at(x, y) + 100.f;
+                const float newVal = outputNew.at(Point{ x, y, z });
+                const float legacyVal = outputLegacy.at(Point{ x, y, z });
+                if (newVal != expected || newVal != legacyVal) {
+                    std::cout << "Divergent mismatch at (" << x << ", " << y << ", " << z << "): new = "
+                              << newVal << ", legacy = " << legacyVal << ", expected = " << expected << std::endl;
+                    correct = false;
+                }
+            }
+        }
+    }
+
+    return correct ? 0 : -1;
+}

--- a/utests/core/execution_model/utest_instantiable_dpp.h
+++ b/utests/core/execution_model/utest_instantiable_dpp.h
@@ -1,0 +1,254 @@
+/* Copyright 2026 Oscar Amoros Huguet, Johnny Nunez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+// Tests for the InstantiableDPP model: DPP::build(iOps...) -> InstantiableDPP value,
+// the compile-time DPP IO contract (DPPIOSpec / dppIOContractSatisfied) and the
+// generic execution entry point fk::execute(stream, instantiableDPP), which must
+// produce the same results as the legacy Executor path on both backends.
+
+#include <tests/main.h>
+
+#include <fused_kernel/algorithms/algorithms.h>
+#include <fused_kernel/algorithms/basic_ops/memory_operations.h>
+#include <fused_kernel/fused_kernel.h>
+#include <iostream>
+
+using namespace fk;
+
+// ============================================================================
+// Compile-time IO contract checks (DPPIOSpec)
+// ============================================================================
+namespace instantiable_dpp_contract_checks {
+    constexpr RawPtr<ND::_2D, float> dummyInput{ nullptr, { 64, 64, 0 } };
+    constexpr RawPtr<ND::_2D, float> dummyOutput{ nullptr, { 64, 64, 0 } };
+    constexpr auto readIOp = PerThreadRead<ND::_2D, float>::build({ dummyInput });
+    constexpr auto mulIOp = Mul<float>::build(2.f);
+    constexpr auto writeIOp = PerThreadWrite<ND::_2D, float>::build({ dummyOutput });
+
+    using ReadT = std::decay_t<decltype(readIOp)>;
+    using MulT = std::decay_t<decltype(mulIOp)>;
+    using WriteT = std::decay_t<decltype(writeIOp)>;
+    using TDPP = TransformDPP<>;
+
+    // TransformDPP declares its IO API: 1 Read/ReadBack in, optional compute chain, 1 Write out
+    static_assert(hasDPPIOSpec_v<TDPP>, "TransformDPP must declare its IO contract (IO_SPEC)");
+    static_assert(TDPP::IO_SPEC.inputIOps == 1 && TDPP::IO_SPEC.outputIOps == 1 &&
+                  TDPP::IO_SPEC.acceptsComputeIOps && !TDPP::IO_SPEC.argsAreIOpSequences,
+                  "Unexpected TransformDPP IO_SPEC");
+
+    // Conforming packs
+    static_assert(dppIOContractSatisfied<TDPP, ReadT, WriteT>(), "read + write must conform");
+    static_assert(dppIOContractSatisfied<TDPP, ReadT, MulT, WriteT>(), "read + compute + write must conform");
+    static_assert(dppIOContractSatisfied<TDPP, ReadT, MulT, MulT, WriteT>(), "compute chains must conform");
+
+    // Non-conforming packs (these are the same checks that make DPP::build() fail
+    // to compile, reported through static_asserts with explicit messages)
+    static_assert(!dppIOContractSatisfied<TDPP>(), "empty pack must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, ReadT>(), "missing Write must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, MulT, WriteT>(), "missing Read must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, ReadT, MulT>(), "compute in Write position must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, WriteT, ReadT>(), "swapped Read/Write must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, ReadT, WriteT, MulT>(), "compute after Write must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, ReadT, ReadT, WriteT>(), "Read in compute position must not conform");
+    // TransformDPP consumes loose IOps: IOpSequences must not conform (the inverse of
+    // passing loose IOps to DivergentBatchTransformDPP, see utest_instantiable_divergent_dpp.h)
+    using SeqT = InstantiableOperationSequence<ReadT, MulT, WriteT>;
+    static_assert(!dppIOContractSatisfied<TDPP, SeqT>(), "an IOpSequence must not conform");
+    static_assert(!dppIOContractSatisfied<TDPP, SeqT, SeqT>(), "IOpSequences must not conform");
+
+    // Compile-fail documentation (the repo has no compile-fail test infra). Each of the
+    // following lines, if uncommented, must fail to compile with the quoted message:
+    //
+    // TransformDPP<>::build(mulIOp, writeIOp);
+    //   error: static assertion failed: DPP IO contract violation: the first IO_SPEC.inputIOps IOps
+    //   must be complete Read or ReadBack IOps (the data going INTO the DPP).
+    //
+    // TransformDPP<>::build(buildOperationSequence(readIOp, mulIOp, writeIOp));
+    //   error: static assertion failed: DPP IO contract violation: this DPP consumes loose IOps,
+    //   not InstantiableOperationSequences. Pass the IOps directly instead of wrapping them with
+    //   buildOperationSequence().
+    //
+    // TransformDPP<>::build(readIOp, mulIOp);
+    //   error: static assertion failed: DPP IO contract violation: the last IO_SPEC.outputIOps IOps
+    //   must be Write IOps (the data coming OUT of the DPP).
+    //
+    // TransformDPP<>::build(readIOp);
+    //   error: static assertion failed: DPP IO contract violation: not enough IOps. [...]
+    //
+    // fk::execute(stream, InstantiableDPP<TransformDPP<>, TransformDPPDetails<false, ReadT>, ReadT>{});
+    //   error: static assertion failed: fk::execute: the InstantiableDPP does not conform to the
+    //   IO contract (IO_SPEC) of its DPP.
+} // namespace instantiable_dpp_contract_checks
+
+bool testTransformBuildAndExecute(Stream& stream) {
+    constexpr int WIDTH = 67;
+    constexpr int HEIGHT = 43;
+
+    Ptr2D<float> input(WIDTH, HEIGHT);
+    Ptr2D<float> outputNew(WIDTH, HEIGHT);
+    Ptr2D<float> outputLegacy(WIDTH, HEIGHT);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            input.at(x, y) = static_cast<float>(x * 100 + y);
+        }
+    }
+    input.upload(stream);
+
+    const auto readIOp = PerThreadRead<ND::_2D, float>::build(input);
+    const auto mulIOp = Mul<float>::build(3.f);
+    const auto writeNew = PerThreadWrite<ND::_2D, float>::build(outputNew);
+    const auto writeLegacy = PerThreadWrite<ND::_2D, float>::build(outputLegacy);
+
+    // New path: DPPs are instantiable values, like Operations
+    const auto iDPP = TransformDPP<>::build(readIOp, mulIOp, writeNew);
+    static_assert(isInstantiableDPP_v<decltype(iDPP)>, "build() must return an InstantiableDPP");
+    execute(stream, iDPP);
+
+    // Legacy path, unchanged
+    executeOperations<TransformDPP<>>(stream, readIOp, mulIOp, writeLegacy);
+
+    outputNew.download(stream);
+    outputLegacy.download(stream);
+    stream.sync();
+
+    bool correct{ true };
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            const float expected = static_cast<float>(x * 100 + y) * 3.f;
+            if (outputNew.at(x, y) != expected || outputNew.at(x, y) != outputLegacy.at(x, y)) {
+                std::cout << "testTransformBuildAndExecute mismatch at (" << x << ", " << y << "): new = "
+                          << outputNew.at(x, y) << ", legacy = " << outputLegacy.at(x, y)
+                          << ", expected = " << expected << std::endl;
+                correct = false;
+            }
+        }
+    }
+    return correct;
+}
+
+bool testTransformReadBackStack(Stream& stream) {
+    // build() fuses the ReadBack stack (Backwards Vertical Fusion) into canonical form
+    // before checking the IO contract, exactly like the legacy Executor path does.
+    Ptr2D<float2> input(320, 240);
+    Ptr2D<float2> outputNew(16, 16);
+    Ptr2D<float2> outputLegacy(16, 16);
+
+    for (int y = 0; y < 240; ++y) {
+        for (int x = 0; x < 320; ++x) {
+            input.at(x, y) = make_<float2>(static_cast<float>(x), static_cast<float>(y));
+        }
+    }
+    input.upload(stream);
+
+    const auto readIOp = PerThreadRead<ND::_2D, float2>::build(input);
+    const auto cropIOp = Crop<>::build(Rect(32, 64, 64, 64));
+    const auto resizeIOp = Resize<InterpolationType::INTER_LINEAR>::build(Size(16, 16));
+    const auto mulIOp = Mul<float2>::build(make_<float2>(3.f, 5.f));
+
+    const auto iDPP = TransformDPP<>::build(readIOp, cropIOp, resizeIOp, mulIOp,
+                                            PerThreadWrite<ND::_2D, float2>::build(outputNew));
+    execute(stream, iDPP);
+
+    executeOperations<TransformDPP<>>(stream, readIOp, cropIOp, resizeIOp, mulIOp,
+                                      PerThreadWrite<ND::_2D, float2>::build(outputLegacy));
+
+    outputNew.download(stream);
+    outputLegacy.download(stream);
+    stream.sync();
+
+    bool correct{ true };
+    for (int y = 0; y < 16; ++y) {
+        for (int x = 0; x < 16; ++x) {
+            if (outputNew.at(x, y) != outputLegacy.at(x, y)) {
+                std::cout << "testTransformReadBackStack mismatch at (" << x << ", " << y << "): new = ("
+                          << outputNew.at(x, y).x << ", " << outputNew.at(x, y).y << "), legacy = ("
+                          << outputLegacy.at(x, y).x << ", " << outputLegacy.at(x, y).y << ")" << std::endl;
+                correct = false;
+            }
+        }
+    }
+    return correct;
+}
+
+template <int WIDTH>
+bool testTransformThreadFusion(Stream& stream) {
+    // Instantiated with a width divisible by the thread fusion factor AND with a
+    // non-divisible one, so BOTH threadDivisible dispatches of the InstantiableDPP
+    // path (the grid-uniform runtime branch of the front exec) run and are compared
+    // against the legacy executeOperations path.
+    constexpr int HEIGHT = 17;
+
+    Ptr2D<float> input(WIDTH, HEIGHT);
+    Ptr2D<float> outputNew(WIDTH, HEIGHT);
+    Ptr2D<float> outputLegacy(WIDTH, HEIGHT);
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            input.at(x, y) = static_cast<float>(x + y);
+        }
+    }
+    input.upload(stream);
+
+    using TFDPP = TransformDPP<defaultParArch, TF::ENABLED>;
+
+    const auto readIOp = PerThreadRead<ND::_2D, float>::build(input);
+    const auto addIOp = Add<float>::build(10.f);
+
+    const auto iDPP = TFDPP::build(readIOp, addIOp, PerThreadWrite<ND::_2D, float>::build(outputNew));
+
+    using DetailsT = typename std::decay_t<decltype(iDPP)>::Details;
+    static_assert(DetailsT::TFI::ENABLED, "thread fusion must be enabled for this IOp pack");
+    static_assert(DetailsT::TFI::elems_per_thread > 1,
+                  "elems_per_thread must be > 1 for the divisibility dispatch to be exercised");
+    const bool expectedDivisible = (WIDTH % static_cast<int>(DetailsT::TFI::elems_per_thread)) == 0;
+    bool correct{ iDPP.details.threadDivisible == expectedDivisible };
+    if (!correct) {
+        std::cout << "testTransformThreadFusion<" << WIDTH << ">: threadDivisible = "
+                  << iDPP.details.threadDivisible << ", expected " << expectedDivisible << std::endl;
+    }
+
+    execute(stream, iDPP);
+
+    executeOperations<TFDPP>(stream, readIOp, addIOp, PerThreadWrite<ND::_2D, float>::build(outputLegacy));
+
+    outputNew.download(stream);
+    outputLegacy.download(stream);
+    stream.sync();
+
+    for (int y = 0; y < HEIGHT; ++y) {
+        for (int x = 0; x < WIDTH; ++x) {
+            const float expected = static_cast<float>(x + y) + 10.f;
+            if (outputNew.at(x, y) != expected || outputNew.at(x, y) != outputLegacy.at(x, y)) {
+                std::cout << "testTransformThreadFusion<" << WIDTH << "> mismatch at (" << x << ", " << y
+                          << "): new = " << outputNew.at(x, y) << ", legacy = " << outputLegacy.at(x, y)
+                          << ", expected = " << expected << std::endl;
+                correct = false;
+            }
+        }
+    }
+    return correct;
+}
+
+int launch() {
+    Stream stream;
+
+    bool correct{ true };
+    correct &= testTransformBuildAndExecute(stream);
+    correct &= testTransformReadBackStack(stream);
+    correct &= testTransformThreadFusion<1023>(stream); // not divisible by the TF factor
+    correct &= testTransformThreadFusion<1024>(stream); // divisible: grid-uniform fast branch
+
+    return correct ? 0 : -1;
+}


### PR DESCRIPTION
## Motivation

Operations have a clear instantiable model: a stateless Operation struct plus `Op::build(params)` producing an IOp (`Operation` type + runtime `OperationData`). DPPs did not: each DPP exposed a bespoke static `exec` signature, required a hand-written `Executor<DPP>` specialization in `executors.h` (or a raw `__global__` launcher), and its IO expectations ("the number of input Read/ReadBack, compute, and output Write Operations it requires") existed only as prose in the DPP-authoring skill. This PR closes that gap: DPPs become instantiable values with a formally declared, compile-time-enforced IO API, executed through one generic path.

## What changed

### InstantiableDPP (`core/execution_model/instantiable_dpp.h`)
- `DPP::build(iOps...)` now produces an `InstantiableDPP<DPP, Details, IOps...>` (DPP type + runtime details + the IOps), mirroring the IOp design: types define the kernel, `build()` values are runtime parameters.
- `buildInstantiableDPP<DPP>(...)` implements `build()` generically: it brings the IOps to canonical form (fusing ReadBack stacks via Backwards Vertical Fusion), enforces the IO contract, and calls `DPP::build_details`.

### Compile-time IO contract (`DPPIOSpec`)
Every DPP declares what goes in and what comes out:
```cpp
static constexpr DPPIOSpec IO_SPEC{ inputIOps, outputIOps, acceptsComputeIOps, argsAreIOpSequences };
```
- `TransformDPP`: `{1, 1, true, false}` — 1 Read/ReadBack in, optional compute chain, 1 Write out.
- `DivergentBatchTransformDPP` (GPU): `{1, 1, true, true}` — N IOpSequences, contract applied per sequence.
- `RowReduceDPP`: `{1, 1, false, false}` — no compute chain (fuse preprocessing into the read IOp).

Building or executing a non-conforming pack fails with granular `static_assert` messages ("DPP IO contract violation: the first IO_SPEC.inputIOps IOps must be complete Read or ReadBack IOps...", etc.), each firing as a single clean error. Mixing up the two argument styles is diagnosed explicitly in both directions: passing loose IOps to a sequence-consuming DPP and passing an `InstantiableOperationSequence` to a loose-IOps DPP each name the actual mistake instead of a misleading count/kind failure. The soft check `dppIOContractSatisfied<DPP, IOps...>()` is usable in tests/SFINAE.

### One generic execution path (`fk::execute`)
`fk::execute(stream, instantiableDPP)` replaces per-DPP executors for conforming DPPs: on CPU it calls `DPP::exec(details, iOps...)` (the DPP implements the loop); on GPU it launches the single generic `launchInstantiableDPP_Kernel` trampoline with the grid/block returned by the DPP's `getLaunchConfig()`. The block-size heuristics moved from `executors.h` to `executor_details/launch_config.h` (`DPPLaunchConfig`, `defaultDPPLaunchConfig`) so DPPs can declare launch configuration; `executors.h` re-includes them, so no existing name moves.

**A new conforming DPP needs no `Executor` specialization and no dedicated `__global__` kernel.**

### Retrofits
- `TransformDPP` is the reference retrofit (`IO_SPEC`, `build`, `getLaunchConfig`, front-level `exec` dispatch; when thread fusion is enabled, thread-divisibility is selected by a grid-uniform branch in the new path).
- `DivergentBatchTransformDPP` (GPU) retrofitted with per-sequence contracts; its CPU backend remains unimplemented as before.
- `executeOperations<TransformDPP<...>>(stream, iOps...)` and all existing `Executor` specializations are unchanged; utests assert result equality between the new and legacy paths.

### New example DPP: `RowReduceDPP` (`algorithms/reductions/row_reduce.h`)
Row-wise reduction (`RowReduceDPP<Add<int>>::build(readIOp, writeIOp)`) written purely against the new protocol with both backends: sequential CPU loop, and a GPU cooperative kernel (one block per row, strided accumulation + shared-memory tree reduction, no identity element required). Prologue fusion (`readIOp.then(...)`) works as with any Read IOp. Two semantic requirements the type system cannot check are documented and enforced where possible:
- The combination order is backend-dependent, so the ReduceOp must be associative and commutative (documented in the header and the DPP skill; floating-point results may differ between backends by rounding due to reassociation).
- Inputs are 2D-only: `build()` throws `std::invalid_argument` for batched/3D inputs (both backends fix the Point z coordinate to 0, so accepting them would silently reduce only plane z == 0).

### Tests
- `utest_instantiable_dpp` (CPU+GPU): build/execute vs legacy for plain, ReadBack-stack (Crop+Resize) and TF::ENABLED cases — the thread-fusion test runs both a non-divisible (1023) and a divisible (1024) width, asserting the runtime `threadDivisible` selection so both dispatches of the grid-uniform branch are exercised; 12 compile-time contract checks (including IOpSequences-to-TransformDPP rejection); commented compile-fail documentation (no compile-fail infra exists).
- `utest_instantiable_divergent_dpp` (GPU): divergent build/execute vs legacy with numeric verification and per-sequence contract checks.
- `utest_row_reduce_dpp` (CPU+GPU): widths below/equal/above BLOCK_SIZE, fused-prologue verification, and rejection of a 3D (batched Tensor) input.
- `tests/examples/inlining_and_LDL_STL.h`: its local prototype `InstantiableDPP`/`launchInstantiableDPP_Kernel` renamed to `Local*` to avoid ambiguity with the new `fk::` names under its `using namespace fk`.

### Docs
`fkl-implementing-data-parallel-patterns/SKILL.md` rewritten around the InstantiableDPP protocol (protocol table, contract semantics, `RowReduceDPP` as the authoring reference including its documented semantic requirements, updated checklist).

## Testing
Full CMake Release build (all targets) and complete ctest suite pass locally: 74/74 tests, including all pre-existing tests, on both `_cpp` and `_cu` backends (CUDA 13.0, aarch64). An additional clang++ (host, C++20) smoke build of the new headers compiles and runs clean, and the documented contract compile-failures were verified to fire as single clean errors with the quoted messages (g++ `-fsyntax-only`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)