### PR TITLE
Require CUDA 13.3+: drop pre-13.3 cxp polyfills and standardize on cuda::std

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,12 +21,12 @@ The library has CPU and CUDA backends. HIP support is architecturally possible b
 FusedKernelLibrary/
 ├── .clang-format                 # LLVM-based style, 4-space indent, 120-char column limit
 ├── .github/workflows/            # CI: cmake-linux-amd64.yml, cmake-linux-arm64.yml, cmake-windows-amd64.yml
-├── CMakeLists.txt                # Root build (v0.2.0, requires CMake >= 3.28, C++20, and CUDA)
+├── CMakeLists.txt                # Root build (v0.2.0, requires CMake >= 3.28, C++20, and CUDA >= 13.3)
 ├── cmake/                        # CMake helpers: arch flags, CUDA init, test discovery, generators
 │   ├── archflags.cmake           # CPU SIMD flags (AVX2 default on MSVC x64, native on Unix)
 │   ├── cmake_init.cmake          # Global CMake settings
 │   ├── cuda_init.cmake           # CUDA language enablement and NVCC path (Ninja/Windows workaround)
-│   ├── libs/cuda/archs.cmake     # CUDA arch selection/filtering (requires compute_70+ for CUDA < 13)
+│   ├── libs/cuda/archs.cmake     # CUDA arch selection
 │   └── tests/                    # Test discovery and stub generation
 │       ├── discover_tests.cmake
 │       └── add_generated_test.cmake
@@ -52,7 +52,7 @@ FusedKernelLibrary/
 ### Requirements
 - **CMake** >= 3.28
 - **C++ compiler** with C++20 support
-- **CUDA** (required): requires NVCC. **Only nvcc is supported as the CUDA compiler**; clang-as-CUDA-compiler is not supported despite `CLANG_HOST_DEVICE` macro existing.
+- **CUDA** (required): requires NVCC from CUDA 13.3 or newer. **Only nvcc is supported as the CUDA compiler**; clang-as-CUDA-compiler is not supported despite `CLANG_HOST_DEVICE` macro existing.
 - **MSVC**: Visual Studio 2022 or Visual Studio 2026 (MSVC_VERSION >= 1930) required;
 
 ### Configure and Build (typical)
@@ -78,9 +78,8 @@ cmake --build build --config Release
 | `ARCH_FLAGS` | `AVX2`/`native` | CPU SIMD flags (MSVC: AVX/AVX2/AVX512; Unix: native/haswell/…) |
 
 ### CUDA Architecture Notes
-- **CUDA < 13**: Architectures below `compute_70` (Volta) are filtered out automatically. A GPU with compute < 70 will trigger an error.
-- **`native` with CUDA < 13**: `nvidia-smi --query-gpu=compute_cap` is executed at CMake configure time to detect the local GPU.
-- **CUDA >= 13**: All architectures allowed.
+- `CUDA_ARCH` is passed verbatim to the `CUDA_ARCHITECTURES` target property; no arch filtering is performed.
+- The minimum supported CUDA Toolkit is 13.3 (enforced at CMake configure time and via `#error` in `core/utils/utils.h`).
 
 ### Windows-Specific Notes
 - CI uses self-hosted runners with LLVM 21.1.0 at `D:/clang+llvm-21.1.0-x86_64-pc-windows-msvc/bin/`.
@@ -233,7 +232,7 @@ All three workflow files trigger on **pull requests to `main`** (push triggers a
 ### Windows (cmake-windows-amd64.yml)
 - **Host compilers**: `cl` (MSVC), `clang-cl`
 - **MSVC versions**: 14.44, 14.51 (via `-vcvars_ver`)
-- **CUDA**: 13.0, 13.3 (NVCC at `%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v<version>\bin\nvcc.exe`)
+- **CUDA**: 13.3 (NVCC at `%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v<version>\bin\nvcc.exe`)
 - **LLVM**: `D:/clang+llvm-21.1.0-x86_64-pc-windows-msvc/bin/` (added to PATH)
 - **Generator**: Ninja
 - **Workaround**: After CMake configure, `rules.ninja` may contain an empty NVCC path that is patched with PowerShell string replacement.

--- a/.github/skills/fkl-build-and-test/SKILL.md
+++ b/.github/skills/fkl-build-and-test/SKILL.md
@@ -9,7 +9,7 @@ running or adding tests, or debugging a compile failure in the test tree on any 
 # Building and testing FKL
 
 ## Build Options & Requirements
-- Requires CMake >= 3.28, a C++20 host compiler, and CUDA.
+- Requires CMake >= 3.28, a C++20 host compiler, and CUDA 13.3 or newer.
 - **Only nvcc is supported as the CUDA compiler**; clang-as-CUDA-compiler is not supported despite the
   `CLANG_HOST_DEVICE` macro.
 - Options: `ENABLE_CUDA` (default ON if found), `ENABLE_CPU` (ON), `ENABLE_BENCHMARK` (OFF).
@@ -27,7 +27,7 @@ cmake -G "Ninja" -B ../build -DCMAKE_BUILD_TYPE=Release -S .
 cmake --build ../build --config Release
 ```
 
-- Requires CMake >= 3.28, a C++ host compiler, and CUDA.
+- Requires CMake >= 3.28, a C++ host compiler, and CUDA 13.3 or newer.
 - Options: `ENABLE_CUDA` (default ON if found), `ENABLE_CPU` (ON),
   `ENABLE_BENCHMARK` (OFF) for the benchmark targets.
 - Binaries land in `../build` — one executable per test unit,

--- a/.github/skills/fkl-implementing-data-parallel-patterns/SKILL.md
+++ b/.github/skills/fkl-implementing-data-parallel-patterns/SKILL.md
@@ -170,4 +170,4 @@ apply([](const auto&... iOps) { return BackFuser::fuse_back(iOps...); }, tup);
 - [ ] `FK_STATIC_STRUCT`
 - [ ] CPU exec() is `FK_HOST_FUSE`; GPU exec() is `FK_DEVICE_FUSE`
 - [ ] utest instantiating every public alias/build path
-- [ ] compiles warning-clean on nvcc AND clang (CUDA 12.x and 13.x)
+- [ ] compiles warning-clean on nvcc AND clang (CUDA 13.3+)

--- a/.github/skills/fkl-implementing-operations/SKILL.md
+++ b/.github/skills/fkl-implementing-operations/SKILL.md
@@ -131,4 +131,4 @@ void testMyOp() {
 - [ ] both build() overloads for IncompleteReadBack ops
 - [ ] values in params, types in templates
 - [ ] utest instantiating every public alias/build path
-- [ ] compiles warning-clean on nvcc AND clang (CUDA 12.x and 13.x)
+- [ ] compiles warning-clean on nvcc AND clang (CUDA 13.3+)

--- a/.github/workflows/cmake-windows-amd64.yml
+++ b/.github/workflows/cmake-windows-amd64.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - host_compiler: "cl"
             msvc_env_version: "14.44"
-            cuda_version: "13.0"
+            cuda_version: "13.3"
 
           - host_compiler: "cl"
             msvc_env_version: "14.51"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Deep per-topic docs live in `.github/skills/*/SKILL.md` (implementing operations
 
 ## Build and test commands
 
-Requires CMake >= 3.28, a C++20 host compiler, and CUDA (nvcc). Project policy and CI treat CUDA as required, but CMake degrades gracefully: without nvcc it configures CPU-only and generates only `*_cpp` targets.
+Requires CMake >= 3.28, a C++20 host compiler, and CUDA >= 13.3 (nvcc). Project policy and CI treat CUDA as required, but CMake degrades gracefully: without nvcc it configures CPU-only and generates only `*_cpp` targets (an nvcc older than 13.3 is rejected with a FATAL_ERROR at configure time and a `#error` in `core/utils/utils.h`; `-DFK_ALLOW_OLDER_CUDA=ON` bypasses both for newer header-only CCCL >= 3.3 on an older toolkit).
 
 ```bash
 cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release -S .   # configure
@@ -29,7 +29,7 @@ ctest -R '_cpp$'                                 # CPU-backend tests only (no GP
 
 Key CMake options: `ENABLE_CPU` (ON), `ENABLE_CUDA` (ON if nvcc found), `BUILD_TEST` (ON), `BUILD_UTEST` (ON), `ENABLE_BENCHMARK` (OFF), `CUDA_ARCH` ("native", passed verbatim to `CUDA_ARCHITECTURES` — no arch filtering exists), `ARCH_FLAGS` (CPU SIMD), `ENABLE_NVTX`, `ENABLE_DEBUG`, `TEMPLATE_DEPTH` (1000).
 
-There is no lint/format gate. Format manually with `clang-format -i` using the repo-root `.clang-format` (LLVM base, 4-space indent, 120-char lines, `PointerAlignment: Right`). The merge gate is the full ctest suite building and passing across CI's compiler matrix (no `-Werror` anywhere, though the skills' PR checklists ask for warning-clean nvcc and clang builds). CI runs only on PRs to `main` (self-hosted runners): Linux amd64/arm64 with g++-13 and clang++-21 + CUDA 13.3; Windows with cl 14.44 + CUDA 13.0, cl 14.51 + CUDA 13.3, and clang-cl 14.51 + CUDA 13.3.
+There is no lint/format gate. Format manually with `clang-format -i` using the repo-root `.clang-format` (LLVM base, 4-space indent, 120-char lines, `PointerAlignment: Right`). The merge gate is the full ctest suite building and passing across CI's compiler matrix (no `-Werror` anywhere, though the skills' PR checklists ask for warning-clean nvcc and clang builds). CI runs only on PRs to `main` (self-hosted runners): Linux amd64/arm64 with g++-13 and clang++-21 + CUDA 13.3; Windows with cl 14.44 + CUDA 13.3, cl 14.51 + CUDA 13.3, and clang-cl 14.51 + CUDA 13.3.
 
 ## Test infrastructure (no framework — no GTest/Catch2)
 
@@ -85,7 +85,6 @@ Pattern (see `Mul` in `algorithms/basic_ops/arithmetic.h`, `Crop` in `algorithms
 ## Stale documentation — do not trust these claims
 
 - `CLANG_HOST_DEVICE` does not exist; `core/utils/compiler_macros.h` defines only `_MSC_VER_EXISTS` (docs referencing it are stale).
-- No CUDA arch filtering / `nvidia-smi` detection / compute_70 minimum exists in cmake — `CUDA_ARCH` is passed verbatim (copilot-instructions claim is stale).
 - `ENABLE_CPU` is never auto-disabled for old MSVC.
 - The README example includes `<fused_kernel/core/execution_model/memory_operations.h>` — the real path is `include/fused_kernel/algorithms/basic_ops/memory_operations.h`.
 - `attention/` is absent from all skills, README, and copilot-instructions.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ With this strategy, they don't need to share any of their code. They just need t
 
 This is an Apache 2.0 OpenSource project, currently with no funding. The 3 main contributors work on the project on their spare time. In the case of the main author, he can work on solving bugs or adding features during his work hours on Grup Mediapro S.L.U. The code added during that time will include Copyright Grup Mediapro S.L.U.
 
+The minimum supported CUDA Toolkit version is 13.3: FKL delegates to libcu++ (CCCL >= 3.3) functionality, such as `<cuda/std/algorithm>`, that first shipped with it. CPU-only builds (`-DENABLE_CUDA=OFF` or no nvcc installed) do not require CUDA at all.
+
 As per Apache 2.0 we provide no guaratees, or free support. Nevertheless, the software has some testing on the following OS and compiler versions:
 - Ubuntu 24.04 g++ 13 + CUDA 13.3 or clang21 + CUDA 13.3 for both amd64 and arm64 systems.
-- Windows 11 Visual Studio 2022 + CUDA 13.0 or Visual Studio 2026 + CUDA 13.3 or clang-cl (VS2026) + CUDA 13.3 on amd64 systems.
+- Windows 11 Visual Studio 2022 + CUDA 13.3 or Visual Studio 2026 + CUDA 13.3 or clang-cl (VS2026) + CUDA 13.3 on amd64 systems.

--- a/cmake/libs/cuda/cuda.cmake
+++ b/cmake/libs/cuda/cuda.cmake
@@ -12,6 +12,24 @@ endfunction()
 
 find_package(CUDAToolkit REQUIRED)
 
+# FKL relies on libcu++ features (e.g. <cuda/std/algorithm>) that first shipped with CUDA 13.3.
+# FK_ALLOW_OLDER_CUDA covers the CCCL-supported configuration of newer header-only CCCL (>= 3.3)
+# on an older toolkit: it skips this check and defines FK_ALLOW_OLDER_CUDA so the matching
+# #error in include/fused_kernel/core/utils/utils.h is bypassed as well.
+option(FK_ALLOW_OLDER_CUDA "Allow CUDA toolkits older than 13.3 (requires header-only CCCL >= 3.3 on the include path)" OFF)
+if (CUDAToolkit_VERSION VERSION_LESS "13.3")
+    if (${FK_ALLOW_OLDER_CUDA})
+        message(WARNING
+            "CUDA ${CUDAToolkit_VERSION} is older than the required 13.3; continuing because FK_ALLOW_OLDER_CUDA is ON. "
+            "A newer header-only CCCL (>= 3.3, providing <cuda/std/algorithm>) must come first in the include path.")
+        add_compile_definitions(FK_ALLOW_OLDER_CUDA)
+    else()
+        message(FATAL_ERROR
+            "FusedKernelLibrary requires CUDA 13.3 or newer, but CUDA ${CUDAToolkit_VERSION} was found. "
+            "Please upgrade your CUDA Toolkit, or configure with -DENABLE_CUDA=OFF for a CPU-only build.")
+    endif()
+endif()
+
 # extra cuda_libraries only detected after project() this is needed for compatibility with old local builds that only
 # have cuda in normal location instead of custom location
  

--- a/include/fused_kernel/core/constexpr_libs/constexpr_cmath.h
+++ b/include/fused_kernel/core/constexpr_libs/constexpr_cmath.h
@@ -24,39 +24,22 @@
 #include <limits>
 
 #ifdef __CUDACC__
+#include <cuda/std/algorithm> // Requires CUDA 13.3+ (libcu++/CCCL >= 3.3); enforced in core/utils/utils.h
 #include <cuda/std/bit>
 #include <cuda/std/utility>
-
-// Conditionally include the algorithm header if compiling on CUDA 13.3+
-#if __has_include(<cuda/std/algorithm>)
-#include <cuda/std/algorithm>
-#endif
 
 namespace cxp {
 using cuda::std::bit_cast;
 namespace base {
+using cuda::std::clamp;
 using cuda::std::cmp_equal;
 using cuda::std::cmp_greater;
 using cuda::std::cmp_greater_equal;
 using cuda::std::cmp_less;
 using cuda::std::cmp_less_equal;
 using cuda::std::cmp_not_equal;
-
-// If the header exists, alias the cuda::std versions
-#if __has_include(<cuda/std/algorithm>)
-using cuda::std::clamp;
 using cuda::std::max;
 using cuda::std::min;
-#else
-// Polyfill for CUDA < 13.3 where <cuda/std/algorithm> is missing
-template <typename T> constexpr __host__ __device__ const T &max(const T &a, const T &b) { return (a < b) ? b : a; }
-
-template <typename T> constexpr __host__ __device__ const T &min(const T &a, const T &b) { return (b < a) ? b : a; }
-
-template <typename T> constexpr __host__ __device__ const T &clamp(const T &v, const T &lo, const T &hi) {
-    return (v < lo) ? lo : ((hi < v) ? hi : v);
-}
-#endif
 } // namespace base
 } // namespace cxp
 #else
@@ -95,6 +78,7 @@ namespace cxp {
         return Exec<BaseFunc>::exec(vals...);          \
     }
 
+    // Hand-rolled: std::isnan is constexpr only since C++23 (P0533) and the CPU backend compiles as plain C++20.
     struct isnan {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -106,6 +90,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: std::isinf is constexpr only since C++23 (P0533) and the CPU backend compiles as plain C++20.
     struct isinf {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -117,6 +102,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: no std equivalent.
     struct is_even {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -141,6 +127,7 @@ namespace cxp {
     };
 
     // safe cmp_equal all types, including floating point
+    // Hand-rolled: std::cmp_equal and friends only accept integral types, the *_u variants also take floating point.
     struct cmp_equal_u {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -283,6 +270,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: neither C++20 std::round nor cuda::std::round (libcu++/CCCL 3.3) is constexpr.
     struct round {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -301,6 +289,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: neither C++20 std::floor nor cuda::std::floor (libcu++/CCCL 3.3) is constexpr.
     struct floor {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -330,6 +319,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: neither C++20 std::nearbyint nor cuda::std::nearbyint (libcu++/CCCL 3.3) is constexpr.
     struct nearbyint {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -409,6 +399,9 @@ namespace cxp {
         }
     };
 
+    // Hand-rolled: cuda::std::fmaxf drops the IEEE-754 signed-zero ordering when constant-evaluated
+    // (fmax(-0.f, +0.f) yields -0.f) and host libm differs from the device instruction on signed zeros,
+    // breaking the compile-time/runtime and CPU/GPU bit-identity this library guarantees.
     struct fmaxf {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -456,6 +449,7 @@ namespace cxp {
         }
     };
 
+    // Hand-rolled: same signed-zero bit-identity rationale as fmaxf.
     struct fminf {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -487,6 +481,7 @@ namespace cxp {
         FK_HOST_DEVICE_FUSE float f(const float &s) { return s; }
     };
 
+    // Hand-rolled: same signed-zero bit-identity rationale as fmaxf.
     struct fmax {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -516,6 +511,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: same signed-zero bit-identity rationale as fmaxf.
     struct fmin {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -546,6 +542,7 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: std::abs is constexpr only since C++23 and has no overloads for unsigned types.
     struct abs {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -594,6 +591,7 @@ namespace cxp {
         }
     };
 
+    // Hand-rolled: neither C++20 std::ldexp nor cuda::std::ldexpf (libcu++/CCCL 3.3) is constexpr.
     struct ldexpf {
         struct BaseFunc {
             using InstanceType = fk::BinaryType;
@@ -651,6 +649,8 @@ namespace cxp {
         CXP_F_FUNC
     };
 
+    // Hand-rolled: std::exp is constexpr only since C++26 (P1383) and cuda::std::expf (libcu++/CCCL 3.3)
+    // is not constexpr; also keeps CPU/GPU results bit-identical, which libm vs libdevice does not.
     struct expf {
         struct BaseFunc {
             using InstanceType = fk::UnaryType;
@@ -710,10 +710,7 @@ namespace cxp {
                 return base::clamp(val, minV, maxV);
             }
         };
-        template <typename... Types>
-        static constexpr inline auto f(const Types &...vals) {
-            return Exec<BaseFunc>::exec(vals...);
-        }
+        CXP_F_FUNC
     };
 
 #undef CXP_F_FUNC

--- a/include/fused_kernel/core/utils/utils.h
+++ b/include/fused_kernel/core/utils/utils.h
@@ -17,6 +17,16 @@
 
 #include <fused_kernel/core/utils/compiler_macros.h>
 
+// FKL requires the CUDA 13.3+ toolchain: its libcu++ (CCCL >= 3.3) is the first to ship
+// <cuda/std/algorithm>, which the cxp:: layer delegates to. Newer CCCL headers on an older
+// toolkit (a configuration CCCL supports) can bypass this check by defining FK_ALLOW_OLDER_CUDA
+// (in-tree builds: configure with -DFK_ALLOW_OLDER_CUDA=ON, which also skips the CMake gate).
+#if defined(__CUDACC_VER_MAJOR__) && !defined(FK_ALLOW_OLDER_CUDA)
+#if (__CUDACC_VER_MAJOR__ < 13) || ((__CUDACC_VER_MAJOR__ == 13) && (__CUDACC_VER_MINOR__ < 3))
+#error "FusedKernelLibrary requires CUDA 13.3 or newer"
+#endif
+#endif // defined(__CUDACC_VER_MAJOR__) && !defined(FK_ALLOW_OLDER_CUDA)
+
 #if !defined(NVRTC_COMPILER)
 #include <string>
 #include <stdexcept>


### PR DESCRIPTION
## Motivation

`cxp` (core/constexpr_libs/constexpr_cmath.h) carried a conditional polyfill for `min`/`max`/`clamp` because `<cuda/std/algorithm>` only ships with CUDA 13.3+ (libcu++/CCCL >= 3.3). Keeping two implementations of the same functions behind `__has_include` costs maintainability and means the polyfilled configuration is not what CI tests (Linux CI is already on CUDA 13.3). This PR makes CUDA 13.3 the explicit minimum, deletes the polyfills, and documents — per remaining hand-rolled `cxp` function — exactly why it cannot delegate to `std::`/`cuda::std::` yet.

## Changes

- **constexpr_cmath.h**: `#include <cuda/std/algorithm>` unconditionally under nvcc; `cuda::std::min/max/clamp` aliased directly next to the existing `bit_cast`/`cmp_*` aliases; polyfill removed. `cxp::clamp::f` now uses the `CXP_F_FUNC` macro like every other `cxp` entry point, so it is `__host__ __device__ constexpr` (it was accidentally host-only under nvcc: calling it from device code failed with "calling a constexpr __host__ function from a __global__ function").
- **Version enforcement**: `core/utils/utils.h` (the root include) emits `#error "FusedKernelLibrary requires CUDA 13.3 or newer"` for nvcc/NVRTC older than 13.3, so users get a clear diagnostic instead of a missing-header error. `cmake/libs/cuda/cuda.cmake` adds the same check at configure time with a friendly message (CPU-only builds via `-DENABLE_CUDA=OFF` are unaffected).
- **Escape hatch**: `FK_ALLOW_OLDER_CUDA` supports the CCCL-documented configuration of newer header-only CCCL (>= 3.3) on an older toolkit. It is both a preprocessor define (for direct nvcc/NVRTC use) and a CMake option: `-DFK_ALLOW_OLDER_CUDA=ON` downgrades the configure-time FATAL_ERROR to a warning and defines the macro for all targets so the `#error` is bypassed consistently.
- **CI**: the Windows `cl 14.44 + CUDA 13.0` matrix entry moves to CUDA 13.3; everything else is unchanged.
- **Docs**: README, CLAUDE.md, copilot-instructions and the build/PR-checklist skills now state the 13.3 minimum and the escape hatch; stale CUDA < 13 arch-filtering claims removed from copilot-instructions (and the CLAUDE.md stale-docs bullet that pointed at them).

## Why the remaining hand-rolled functions stay (verified against libcu++/CCCL 3.3)

Each function now carries a one-line comment in the header:

- `round`/`floor`/`nearbyint`, `expf`, `ldexpf`: not constexpr in libcu++ 3.3 (`_CCCL_API inline`) nor in C++20 `std::` (P0533 is C++23, `exp` is C++26/P1383).
- `fmaxf`/`fminf`/`fmax`/`fmin`: `cuda::std::fmax` is constexpr, but its constant-evaluated fallback (`x < y ? y : x`) drops the IEEE-754 signed-zero ordering — `fmax(-0.0, +0.0)` yields `-0.0` — and host libm differs from the device instruction on signed zeros. The utest static_asserts require `+0.0`, and CPU/GPU bit-identity is a library invariant.
- `isnan`/`isinf`/`abs`: constexpr in libcu++, but the CPU backend compiles as plain C++20 where `std::isnan`/`std::isinf`/`std::abs` are not constexpr until C++23 (`std::abs` also lacks unsigned overloads).
- `cmp_*_u`: `std::cmp_*` only accept integral types; the `_u` variants also handle floating point.

## Testing

- Full `_cpp` utest suite with g++-13 and clang++-18 (Linux arm64): green (one unrelated pre-existing `basic_test_cpp` segfault with g++-13 on this machine reproduces on unmodified `main`).
- `utest_constexpr_cmath_cu` built through the project's own CMake with `-DFK_ALLOW_OLDER_CUDA=ON` against the CUDA 13.3 libcu++ (CCCL v3.3.4 headers) and run on an sm_121 GPU: all tests pass, including all compile-time static_asserts through the new unconditional `cuda::std` aliases.
- Negative tests: nvcc < 13.3 fails with the explicit `#error` (and compiles once `FK_ALLOW_OLDER_CUDA` is defined with CCCL >= 3.3 headers first in the include path); CMake configure with an older toolkit fails with the friendly version message by default and proceeds with a warning under `-DFK_ALLOW_OLDER_CUDA=ON`; `-DENABLE_CUDA=OFF` configures and builds unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)